### PR TITLE
feat: added MaterialPartnerRelation and accompanying services

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/api/domain/model/Message.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/api/domain/model/Message.java
@@ -26,6 +26,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.ProductStockRequest;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.ProductStockResponse;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/api/domain/model/MessageHeader.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/api/domain/model/MessageHeader.java
@@ -27,6 +27,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import org.eclipse.tractusx.puris.backend.common.api.domain.model.datatype.DT_UseCaseEnum;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.ProductStockRequest;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.ProductStockResponse;
 
 import java.util.Date;
 import java.util.UUID;

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/api/domain/model/datatype/DT_RequestStateEnum.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/api/domain/model/datatype/DT_RequestStateEnum.java
@@ -20,8 +20,8 @@
  */
 package org.eclipse.tractusx.puris.backend.common.api.domain.model.datatype;
 
-import org.eclipse.tractusx.puris.backend.common.api.domain.model.ProductStockRequest;
-import org.eclipse.tractusx.puris.backend.common.api.domain.model.ProductStockResponse;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.ProductStockRequest;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.ProductStockResponse;
 
 /**
  * Enum to track the status of

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/domain/model/Material.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/domain/model/Material.java
@@ -21,11 +21,17 @@
  */
 package org.eclipse.tractusx.puris.backend.masterdata.domain.model;
 
-import jakarta.persistence.*;
-import lombok.*;
-import org.eclipse.tractusx.puris.backend.stock.domain.model.Stock;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
-import java.util.*;
+import java.util.Objects;
+import java.util.Set;
 
 @Entity
 @Table(name = "material")
@@ -34,36 +40,6 @@ import java.util.*;
 @ToString
 @NoArgsConstructor
 public class Material {
-
-    @Id
-    @GeneratedValue
-    private UUID uuid;
-
-    @ManyToMany(fetch = FetchType.EAGER)
-    @JoinTable(
-            name = "partner_supplies_product",
-            joinColumns = @JoinColumn(name = "material_uuid", referencedColumnName = "uuid"),
-            inverseJoinColumns = @JoinColumn(name = "partner_uuid", referencedColumnName = "uuid")
-    )
-    @ToString.Exclude
-    @Setter(AccessLevel.NONE)
-    private Set<Partner> suppliedByPartners = new HashSet<>();
-    ;;
-
-    @ManyToMany(targetEntity = Partner.class, fetch = FetchType.EAGER)
-    @JoinTable(
-            name = "partner_orders_product",
-            joinColumns = @JoinColumn(name = "material_uuid", referencedColumnName = "uuid"),
-            inverseJoinColumns = @JoinColumn(name = "partner_uuid", referencedColumnName = "uuid")
-    )
-    @ToString.Exclude
-    @Setter(AccessLevel.NONE)
-    private Set<Partner> orderedByPartners = new HashSet<>();
-
-    @OneToMany(mappedBy = "uuid")
-    @ToString.Exclude
-    @Setter(AccessLevel.NONE)
-    private List<Stock> materialOnStocks = new ArrayList<>();
 
     /**
      * If true, then the Material is a material (input for production / something I buy).
@@ -79,30 +55,27 @@ public class Material {
      */
     private boolean productFlag;
 
-    private String materialNumberCustomer;
-
-    private String materialNumberSupplier;
+    @Id
+    private String ownMaterialNumber;
 
     private String materialNumberCx;
 
     private String name;
 
-    public Material(boolean materialFlag, boolean productFlag, String materialNumberCustomer, String materialNumberSupplier, String materialNumberCx, String name) {
-        this.materialFlag = materialFlag;
-        this.productFlag = productFlag;
-        this.materialNumberCustomer = materialNumberCustomer;
-        this.materialNumberSupplier = materialNumberSupplier;
-        this.materialNumberCx = materialNumberCx;
-        this.name = name;
+    @OneToMany(mappedBy = "material")
+    Set<MaterialPartnerRelation> materialPartnerRelations;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Material)) return false;
+        Material material = (Material) o;
+        return Objects.equals(ownMaterialNumber, material.ownMaterialNumber);
     }
 
-    public void addPartnerToSuppliedByPartners(Partner supplierPartner) {
-        this.suppliedByPartners.add(supplierPartner);
-        supplierPartner.getSuppliesMaterials().add(this);
+    @Override
+    public int hashCode() {
+        return Objects.hash(ownMaterialNumber);
     }
 
-    public void addPartnerToOrderedByPartners(Partner customerPartner) {
-        this.orderedByPartners.add(customerPartner);
-        customerPartner.getOrdersProducts().add(this);
-    }
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/domain/model/MaterialPartnerRelation.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/domain/model/MaterialPartnerRelation.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2023 Volkswagen AG
+ * Copyright (c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.tractusx.puris.backend.masterdata.domain.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+public class MaterialPartnerRelation {
+
+    @EmbeddedId
+    Key key;
+
+    private String partnerMaterialNumber;
+    private boolean partnerSuppliesMaterial;
+    private boolean partnerBuysMaterial;
+
+    @ManyToOne
+    @MapsId("ownMaterialNumber")
+    @JoinColumn(name = "material_ownMaterialNumber")
+    Material material;
+
+    @ManyToOne
+    @MapsId("uuid")
+    @JoinColumn(name = "partner_uuid")
+    Partner partner;
+
+    public MaterialPartnerRelation() {
+        this.key = new Key();
+    }
+
+    public MaterialPartnerRelation(Material material, Partner partner, String partnerMaterialNumber, boolean partnerSupplies, boolean partnerBuys) {
+        this.material = material;
+        this.partner = partner;
+        this.key = new Key(material.getOwnMaterialNumber(), partner.getUuid());
+        this.partnerMaterialNumber = partnerMaterialNumber;
+        this.partnerSuppliesMaterial = partnerSupplies;
+        this.partnerBuysMaterial = partnerBuys;
+    }
+
+    @Override
+    public String toString() {
+        return "MaterialPartnerRelation{" +
+            "key=" + key +
+            ", partnerMaterialNumber='" + partnerMaterialNumber + '\'' +
+            ", partnerSuppliesMaterial=" + partnerSuppliesMaterial +
+            ", partnerBuysMaterial=" + partnerBuysMaterial +
+            ", material=" + material.getOwnMaterialNumber() +
+            ", partner=" + partner.getBpnl() +
+            '}';
+    }
+
+    @Embeddable
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @ToString
+    public static class Key implements Serializable {
+
+        @Column(name = "material_ownMaterialNumber")
+        private String ownMaterialNumber;
+
+        @Column(name = "partner_uuid")
+        private UUID partnerUuid;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Key)) return false;
+            Key key = (Key) o;
+            return Objects.equals(ownMaterialNumber, key.ownMaterialNumber) && Objects.equals(partnerUuid, key.partnerUuid);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(ownMaterialNumber, partnerUuid);
+        }
+    }
+}

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/domain/model/Partner.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/domain/model/Partner.java
@@ -22,7 +22,6 @@
 package org.eclipse.tractusx.puris.backend.masterdata.domain.model;
 
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.eclipse.tractusx.puris.backend.stock.domain.model.PartnerProductStock;
 import org.eclipse.tractusx.puris.backend.stock.domain.model.ProductStock;
@@ -41,38 +40,40 @@ public class Partner {
     @GeneratedValue
     private UUID uuid;
     private String name;
-    @NotNull
-    private boolean actsAsCustomerFlag;
-    @NotNull
-    private boolean actsAsSupplierFlag;
     private String edcUrl;
     private String bpnl;
     private String siteBpns;
 
-    @ManyToMany(mappedBy = "suppliedByPartners", fetch = FetchType.EAGER)
-    @Setter(AccessLevel.NONE)
-    private Set<Material> suppliesMaterials = new HashSet<>();
+    @OneToMany(mappedBy = "partner")
+    private Set<MaterialPartnerRelation> materialPartnerRelations;
 
-    @ManyToMany(mappedBy = "orderedByPartners", fetch = FetchType.EAGER)
-    @Setter(AccessLevel.NONE)
-    private Set<Material> ordersProducts = new HashSet<>();
-
-    @OneToMany(mappedBy = "uuid", fetch = FetchType.LAZY)
+    @OneToMany
     @ToString.Exclude
     @Setter(AccessLevel.NONE)
     private List<ProductStock> allocatedProductStocksForCustomer = new ArrayList<>();
 
-    @OneToMany(mappedBy = "uuid")
+    @OneToMany
     @ToString.Exclude
     @Setter(AccessLevel.NONE)
     private List<PartnerProductStock> partnerProductStocks = new ArrayList<>();
 
-    public Partner(String name, boolean actsAsCustomerFlag, boolean actsAsSupplierFlag, String edcUrl, String bpnl, String siteBpns) {
+    public Partner(String name, String edcUrl, String bpnl, String siteBpns) {
         this.name = name;
-        this.actsAsCustomerFlag = actsAsCustomerFlag;
-        this.actsAsSupplierFlag = actsAsSupplierFlag;
         this.edcUrl = edcUrl;
         this.bpnl = bpnl;
         this.siteBpns = siteBpns;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Partner)) return false;
+        Partner partner = (Partner) o;
+        return Objects.equals(uuid, partner.uuid);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uuid);
     }
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/domain/repository/MaterialPartnerRelationRepository.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/domain/repository/MaterialPartnerRelationRepository.java
@@ -21,18 +21,27 @@
  */
 package org.eclipse.tractusx.puris.backend.masterdata.domain.repository;
 
-import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.MaterialPartnerRelation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import java.util.List;
 import java.util.UUID;
 
 @Repository
-public interface PartnerRepository extends JpaRepository<Partner, UUID> {
+public interface MaterialPartnerRelationRepository extends JpaRepository<MaterialPartnerRelation, MaterialPartnerRelation.Key> {
 
-    Optional<Partner> findFirstByBpnl(String bpnl);
+    List<MaterialPartnerRelation> findAllByPartner_Uuid(UUID partnerUuid);
 
-    Optional<Partner> findFirstBySiteBpns(String siteBpns);
+    List<MaterialPartnerRelation> findAllByPartner_UuidAndPartnerSuppliesMaterialIsTrue(UUID partnerUuid);
 
+    List<MaterialPartnerRelation> findAllByPartner_UuidAndPartnerBuysMaterialIsTrue(UUID partnerUuid);
+
+    List<MaterialPartnerRelation> findAllByMaterial_OwnMaterialNumber(String ownMaterialNumber);
+
+    List<MaterialPartnerRelation> findAllByMaterial_OwnMaterialNumberAndPartnerSuppliesMaterialIsTrue(String ownMaterialNumber);
+
+    List<MaterialPartnerRelation> findAllByMaterial_OwnMaterialNumberAndPartnerBuysMaterialIsTrue(String ownMaterialNumber);
+
+    List<MaterialPartnerRelation> findAllByPartnerMaterialNumber(String partnerMaterialNumber);
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/domain/repository/MaterialRepository.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/domain/repository/MaterialRepository.java
@@ -26,21 +26,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.UUID;
 
 @Repository
-public interface MaterialRepository extends JpaRepository<Material, UUID> {
+public interface MaterialRepository extends JpaRepository<Material, String> {
 
     List<Material> findAllByMaterialFlagTrue();
 
     List<Material> findAllByProductFlagTrue();
 
-    public List<Material> findByMaterialNumberCustomer(String materialNumberCustomer);
-
     public List<Material> findByMaterialNumberCx(String materialNumberCx);
-
-    public List<Material> findByMaterialNumberCustomerAndMaterialFlagTrue(String materialNumberCustomer);
-
-    public List<Material> findByMaterialNumberCustomerAndProductFlagTrue(String materialNumberCustomer);
 
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/dto/MaterialDto.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/dto/MaterialDto.java
@@ -36,14 +36,6 @@ public class MaterialDto implements Serializable {
 
     private UUID uuid;
 
-    @Setter(AccessLevel.NONE)
-    private Set<PartnerDto> suppliedByPartners = new HashSet<>();
-
-    @Setter(AccessLevel.NONE)
-    private Set<PartnerDto> orderedByPartners = new HashSet<>();
-
-    @Setter(AccessLevel.NONE)
-    private List<StockDto> materialOnStocks = new ArrayList<>();
 
     /**
      * If true, then the Material is a material (input for production / something I buy).
@@ -77,14 +69,6 @@ public class MaterialDto implements Serializable {
         this.name = name;
     }
 
-    public void addSuppliedByPartner(PartnerDto supplierPartner) {
-        this.suppliedByPartners.add(supplierPartner);
-        supplierPartner.getSuppliesMaterials().add(this);
-    }
 
-    public void addOrderedByPartner(PartnerDto customerPartner) {
-        this.orderedByPartners.add(customerPartner);
-        customerPartner.getOrdersProducts().add(this);
-    }
 
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/dto/PartnerDto.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/dto/PartnerDto.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2023 Volkswagen AG
+ * Copyright (c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.eclipse.tractusx.puris.backend.masterdata.logic.dto;
 
 import jakarta.annotation.Nullable;
@@ -18,54 +39,8 @@ public class PartnerDto implements Serializable {
     private UUID uuid;
     private String name;
 
-    private boolean actsAsCustomerFlag;
-    private boolean actsAsSupplierFlag;
-
     private String edcUrl;
     private String bpnl;
     private String siteBpns;
-
-    @Nullable
-    @ToString.Exclude
-    @Setter(AccessLevel.NONE)
-    private Set<MaterialDto> suppliesMaterials = new HashSet<>();
-
-    @Nullable
-    @ToString.Exclude
-    @Setter(AccessLevel.NONE)
-    private Set<MaterialDto> ordersProducts = new HashSet<>();
-
-    @ToString.Exclude
-    @Setter(AccessLevel.NONE)
-    private List<ProductStockDto> allocatedProductStocksForCustomer = new ArrayList<>();
-
-    @ToString.Exclude
-    @Setter(AccessLevel.NONE)
-    private List<PartnerProductStockDto> partnerProductStocks = new ArrayList<>();
-
-    public PartnerDto(String name, boolean actsAsCustomerFlag, boolean actsAsSupplierFlag, String edcUrl, String bpnl, String siteBpns) {
-        super();
-        this.name = name;
-        this.actsAsCustomerFlag = actsAsCustomerFlag;
-        this.actsAsSupplierFlag = actsAsSupplierFlag;
-        this.edcUrl = edcUrl;
-        this.bpnl = bpnl;
-        this.siteBpns = siteBpns;
-    }
-
-    public void addSuppliedMaterial(MaterialDto suppliedMaterial) {
-        this.suppliesMaterials.add(suppliedMaterial);
-        suppliedMaterial.getSuppliedByPartners().add(this);
-    }
-
-    public void addOrderedProduct(MaterialDto orderedProduct) {
-        this.ordersProducts.add(orderedProduct);
-        orderedProduct.getOrderedByPartners().add(this);
-    }
-
-    public void addPartnerProductStock(PartnerProductStockDto partnerProductStockDto) {
-        this.partnerProductStocks.add(partnerProductStockDto);
-        partnerProductStockDto.setSupplierPartner(this);
-    }
 
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/MaterialPartnerRelationService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/MaterialPartnerRelationService.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2023 Volkswagen AG
+ * Copyright (c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.tractusx.puris.backend.masterdata.logic.service;
+
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.MaterialPartnerRelation;
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+
+public interface MaterialPartnerRelationService {
+    MaterialPartnerRelation create(MaterialPartnerRelation materialPartnerRelation);
+
+    MaterialPartnerRelation update(MaterialPartnerRelation materialPartnerRelation);
+
+    MaterialPartnerRelation find(Material material, Partner partner);
+
+    List<Material> findAllMaterialsThatPartnerSupplies(Partner partner);
+
+    List<Material> findAllProductsThatPartnerBuys(Partner partner);
+
+    List<MaterialPartnerRelation> findAll();
+
+    Map<String, String> getBPNL_To_MaterialNumberMap(String ownMaterialNumber);
+
+    MaterialPartnerRelation find(String ownMaterialNumber, UUID partnerUuid);
+
+    List<Partner> findAllSuppliersForOwnMaterialNumber(String ownMaterialNumber);
+
+    List<Partner> findAllCustomersForOwnMaterialNumber(String ownMaterialNumber);
+
+    List<Partner> findAllSuppliersForMaterial(Material material);
+
+    List<Material> findAllByPartnerMaterialNumber(String partnerMaterialNumber);
+
+    boolean partnerSuppliesMaterial(Material material, Partner partner);
+
+    boolean partnerOrdersProduct(Material material, Partner partner);
+}

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/MaterialPartnerRelationServiceImpl.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/MaterialPartnerRelationServiceImpl.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2023 Volkswagen AG
+ * Copyright (c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.tractusx.puris.backend.masterdata.logic.service;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.tractusx.puris.backend.common.api.logic.service.VariablesService;
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.MaterialPartnerRelation;
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
+import org.eclipse.tractusx.puris.backend.masterdata.domain.repository.MaterialPartnerRelationRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@AllArgsConstructor
+@Service
+@Slf4j
+public class MaterialPartnerRelationServiceImpl implements MaterialPartnerRelationService {
+
+    @Autowired
+    private MaterialPartnerRelationRepository mprRepository;
+
+    @Autowired
+    private VariablesService variablesService;
+
+
+    /**
+     * Stores the given relation to the database.
+     * @param materialPartnerRelation
+     * @return the stored relation or null, if the given relation was already in existence.
+     */
+    @Override
+    public MaterialPartnerRelation create(MaterialPartnerRelation materialPartnerRelation) {
+        flagConsistencyTest(materialPartnerRelation);
+        var searchResult = find(materialPartnerRelation.getMaterial(), materialPartnerRelation.getPartner());
+        if (searchResult == null) {
+            return mprRepository.save(materialPartnerRelation);
+        }
+        log.error("Could not create MaterialPartnerRelation, " + materialPartnerRelation.getKey() + " already exists");
+        return null;
+    }
+
+    /**
+     * Updates an existing MaterialPartnerRelation
+     * @param materialPartnerRelation
+     * @return the updated relation or null, if the given relation didn't exist before.
+     */
+    @Override
+    public MaterialPartnerRelation update(MaterialPartnerRelation materialPartnerRelation) {
+        flagConsistencyTest(materialPartnerRelation);
+        var foundEntity = mprRepository.findById(materialPartnerRelation.getKey());
+        if (foundEntity.isPresent()) {
+            return mprRepository.save(materialPartnerRelation);
+        }
+        log.error("Could not update MaterialPartnerRelation, " + materialPartnerRelation.getKey() + " didn't exist before");
+        return null;
+    }
+
+    private void flagConsistencyTest(MaterialPartnerRelation materialPartnerRelation) {
+        Material material = materialPartnerRelation.getMaterial();
+        boolean test = material.isMaterialFlag() && materialPartnerRelation.isPartnerSuppliesMaterial();
+        test = test || (material.isProductFlag() && materialPartnerRelation.isPartnerBuysMaterial());
+        if (!test) {
+            log.warn("Flags of " + materialPartnerRelation + " are not consistent with flags of " + material.getOwnMaterialNumber());
+        }
+    }
+
+    /**
+     * Find the MaterialPartnerRelation containing the material and the partner.
+     * @param material
+     * @param partner
+     * @return the relation, if it exists or else null;
+     */
+    @Override
+    public MaterialPartnerRelation find(Material material, Partner partner) {
+        return find(material.getOwnMaterialNumber(), partner.getUuid());
+    }
+
+    /**
+     * Returns a list of all materials that the given partner supplies to you.
+     * @param partner the partner
+     * @return a list of material entities
+     */
+    @Override
+    public List<Material> findAllMaterialsThatPartnerSupplies(Partner partner) {
+        return mprRepository
+            .findAllByPartner_UuidAndPartnerSuppliesMaterialIsTrue(partner.getUuid())
+            .stream()
+            .map(mpr -> mpr.getMaterial())
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns a list of all products that the given partner buys from you.
+     * @param partner the partner
+     * @return a list of product entities
+     */
+    @Override
+    public List<Material> findAllProductsThatPartnerBuys(Partner partner) {
+        return mprRepository
+            .findAllByPartner_UuidAndPartnerBuysMaterialIsTrue(partner.getUuid())
+            .stream()
+            .map(mpr -> mpr.getMaterial())
+            .collect(Collectors.toList());
+    }
+
+    /**
+     *
+     * @return a list of all existing MaterialPartnerRelations
+     */
+    @Override
+    public List<MaterialPartnerRelation> findAll() {
+        return mprRepository.findAll();
+    }
+
+    /**
+     * Generates a Map of key-value-pairs. Each key represents the BPNL of a
+     * partner (and yourself), each corresponding value is the materialNumber
+     * that the owner of the BPNL is using in his own house to define the given Material.
+     * @param ownMaterialNumber
+     * @return a Map with the content described above or an empty map if no entries with the given ownMaterialNumber could be found.
+     */
+    @Override
+    public Map<String, String> getBPNL_To_MaterialNumberMap(String ownMaterialNumber) {
+        var relationsList = mprRepository.findAllByMaterial_OwnMaterialNumber(ownMaterialNumber);
+        HashMap<String, String> output = new HashMap<>();
+        if (relationsList.isEmpty()) {
+            return output;
+        }
+        output.put(variablesService.getOwnBpnl(), ownMaterialNumber);
+        for (var relation : relationsList) {
+            output.put(relation.getPartner().getBpnl(), relation.getPartnerMaterialNumber());
+        }
+        return output;
+    }
+
+    /**
+     * Find the MaterialPartnerRelation containing the material with the given
+     * ownMaterialNumber and the uuid referencing a partner in your database.
+     * @param ownMaterialNumber
+     * @param partnerUuid
+     * @return the relation, if it exists or else null
+     */
+    @Override
+    public MaterialPartnerRelation find(String ownMaterialNumber, UUID partnerUuid) {
+        var searchResult = mprRepository.findById(new MaterialPartnerRelation.Key(ownMaterialNumber, partnerUuid));
+        if (searchResult.isPresent()) {
+            return searchResult.get();
+        }
+        return null;
+    }
+
+    /**Returns a list containing all Partners that are registered as suppliers for
+     * the material with the given ownMaterialNumber
+     *
+     * @param ownMaterialNumber
+     * @return a list of partners as described above
+     */
+    @Override
+    public List<Partner> findAllSuppliersForOwnMaterialNumber(String ownMaterialNumber) {
+        return  mprRepository.findAllByMaterial_OwnMaterialNumberAndPartnerSuppliesMaterialIsTrue(ownMaterialNumber)
+                .stream()
+                .map(mpr -> mpr.getPartner())
+                .collect(Collectors.toList());
+    }
+
+    /**Returns a list containing all Partners that are registered as customers for
+     * the material with the given ownMaterialNumber
+     *
+     * @param ownMaterialNumber
+     * @return a list of partners as described above
+     */
+    @Override
+    public List<Partner> findAllCustomersForOwnMaterialNumber(String ownMaterialNumber) {
+        return mprRepository.findAllByMaterial_OwnMaterialNumberAndPartnerBuysMaterialIsTrue(ownMaterialNumber)
+            .stream()
+            .map(mpr -> mpr.getPartner())
+            .collect(Collectors.toList());
+    }
+
+    /**Returns a list containing all Partners that are registered as suppliers for
+     * the material with the given material
+     *
+     * @param material
+     * @return a list of partners as described above
+     */
+    @Override
+    public List<Partner> findAllSuppliersForMaterial(Material material) {
+        return findAllSuppliersForOwnMaterialNumber(material.getOwnMaterialNumber());
+    }
+
+    /**Returns a list containing all Partners that are registered as customers for
+     * the material with the given material
+     *
+     * @param material
+     * @return a list of partners as described above
+     */
+    public List<Partner> findAllCustomersForMaterial(Material material) {
+        return findAllCustomersForOwnMaterialNumber(material.getOwnMaterialNumber());
+    }
+
+    /**
+     * Returns a list of all Materials, for which a MaterialPartnerRelation exists,
+     * where the partner is using the given partnerMaterialNumber.
+     * @param partnerMaterialNumber
+     * @return a list of Materials
+     */
+    @Override
+    public List<Material> findAllByPartnerMaterialNumber(String partnerMaterialNumber) {
+        return mprRepository.findAllByPartnerMaterialNumber(partnerMaterialNumber)
+            .stream()
+            .map(mpr -> mpr.getMaterial())
+            .collect(Collectors.toList());
+    }
+
+    /**
+     *
+     * @param material
+     * @param partner
+     * @return true, if the given partner is registered as supplier for the given material, else false
+     */
+    @Override
+    public boolean partnerSuppliesMaterial (Material material, Partner partner) {
+        if (material.isMaterialFlag()) {
+            MaterialPartnerRelation mpr = find(material, partner);
+            return mpr != null && mpr.isPartnerSuppliesMaterial();
+        }
+        return false;
+    }
+
+    /**
+     *
+     * @param material
+     * @param partner
+     * @return true, if the given partner is registered as customer for the given material, else false
+     */
+    @Override
+    public boolean partnerOrdersProduct(Material material, Partner partner) {
+        if (material.isProductFlag()) {
+            MaterialPartnerRelation mpr = find(material,partner);
+            return mpr != null && mpr.isPartnerBuysMaterial();
+        }
+        return false;
+    }
+
+}

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/MaterialService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/MaterialService.java
@@ -22,12 +22,9 @@
 package org.eclipse.tractusx.puris.backend.masterdata.logic.service;
 
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
-import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.UUID;
 
-@Service
 public interface MaterialService {
 
     Material create(Material material);
@@ -38,12 +35,16 @@ public interface MaterialService {
 
     List<Material> findAllProducts();
 
-    Material findByUuid(UUID materialUuid);
+
+
+//    Material findByUuid(UUID materialUuid);
+
+    Material findByOwnMaterialNumber(String ownMaterialNumber);
 
     Material findByMaterialNumberCx(String materialNumberCx);
 
-    Material findMaterialByMaterialNumberCustomer(String materialNumberCustomer);
-
-    Material findProductByMaterialNumberCustomer(String materialNumberCustomer);
+//    Material findMaterialByMaterialNumberCustomer(String materialNumberCustomer);
+//
+//    Material findProductByMaterialNumberCustomer(String materialNumberCustomer);
 
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/MaterialServiceImpl.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/MaterialServiceImpl.java
@@ -29,7 +29,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 @Service
 @Slf4j
@@ -40,17 +39,23 @@ public class MaterialServiceImpl implements MaterialService {
 
     @Override
     public Material create(Material material) {
-        return materialRepository.save(material);
+        var searchResult = materialRepository.findById(material.getOwnMaterialNumber());
+        if (searchResult.isEmpty()) {
+            return materialRepository.save(material);
+        }
+        log.error("Could not create material " + material.getOwnMaterialNumber() + " because it already exists");
+        return null;
     }
 
     @Override
     public Material update(Material material) {
         Optional<Material> existingMaterial =
-                materialRepository.findById(material.getUuid());
-
+                materialRepository.findById(material.getOwnMaterialNumber());
         if (existingMaterial.isPresent()) {
             return existingMaterial.get();
-        } else return null;
+        }
+        log.error("Could not update material " + material.getOwnMaterialNumber() + " because it didn't exist before");
+        return null;
     }
 
     @Override
@@ -64,13 +69,12 @@ public class MaterialServiceImpl implements MaterialService {
     }
 
     @Override
-    public Material findByUuid(UUID materialUuid) {
-        Optional<Material> foundMaterial = materialRepository.findById(materialUuid);
-
-        if (!foundMaterial.isPresent()) {
-            return null;
+    public Material findByOwnMaterialNumber(String ownMaterialNumber) {
+        var searchResult = materialRepository.findById(ownMaterialNumber);
+        if (searchResult.isPresent()) {
+            return searchResult.get();
         }
-        return foundMaterial.get();
+        return null;
     }
 
     @Override
@@ -86,34 +90,4 @@ public class MaterialServiceImpl implements MaterialService {
 
     }
 
-    @Override
-    public Material findMaterialByMaterialNumberCustomer(String materialNumberCustomer) {
-
-        List<Material> foundMaterial =
-                materialRepository.findByMaterialNumberCustomerAndMaterialFlagTrue(materialNumberCustomer);
-
-        if (foundMaterial.size() == 0) {
-            return null;
-        }
-        if (foundMaterial.size() > 1) {
-            log.warn("Found more than one result for materialNumberCx " + materialNumberCustomer);
-        }
-        return foundMaterial.get(0);
-    }
-
-    @Override
-    public Material findProductByMaterialNumberCustomer(String materialNumberCustomer) {
-
-        List<Material> foundProduct =
-                materialRepository.findByMaterialNumberCustomerAndProductFlagTrue(materialNumberCustomer);
-
-        if (foundProduct.size() == 0) {
-            return null;
-        }
-        if (foundProduct.size() > 1) {
-            log.warn("Found more than one result for materialNumberCx " + materialNumberCustomer);
-        }
-        return foundProduct.get(0);
-
-    }
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/PartnerService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/PartnerService.java
@@ -22,21 +22,19 @@
 package org.eclipse.tractusx.puris.backend.masterdata.logic.service;
 
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
-import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.UUID;
 
-@Service
 public interface PartnerService {
 
     Partner create(Partner partner);
 
     Partner findByUuid(UUID partnerUuid);
 
-    List<Partner> findAllCustomerPartnersForMaterialId(UUID materialUuid);
+    List<Partner> findAllCustomerPartnersForMaterialId(String ownMaterialNumber);
 
-    List<Partner> findAllSupplierPartnersForMaterialId(UUID materialUUID);
+    List<Partner> findAllSupplierPartnersForMaterialId(String ownMaterialNumber);
 
     Partner update(Partner partner);
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/PartnerProductStock.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/PartnerProductStock.java
@@ -21,13 +21,11 @@
  */
 package org.eclipse.tractusx.puris.backend.stock.domain.model;
 
-import jakarta.persistence.DiscriminatorValue;
-import jakarta.persistence.Entity;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
@@ -38,12 +36,13 @@ import java.util.Date;
 @Entity
 @DiscriminatorValue("PartnerProductStock")
 @Getter
+@Setter
 @ToString(callSuper = true)
 @NoArgsConstructor
 public class PartnerProductStock extends Stock {
 
-    @ManyToOne
-    @JoinColumn(name = "supplier_partner_uuid")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "partner_uuid")
     @NotNull
     private Partner supplierPartner;
 
@@ -59,8 +58,4 @@ public class PartnerProductStock extends Stock {
         super.setType(DT_StockTypeEnum.PRODUCT);
     }
 
-    public void setSupplierPartner(Partner supplierPartner) {
-        this.supplierPartner = supplierPartner;
-        supplierPartner.getPartnerProductStocks().add(this);
-    }
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/ProductStock.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/ProductStock.java
@@ -21,12 +21,10 @@
  */
 package org.eclipse.tractusx.puris.backend.stock.domain.model;
 
-import jakarta.persistence.DiscriminatorValue;
-import jakarta.persistence.Entity;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
@@ -36,11 +34,12 @@ import java.util.Date;
 
 @Entity
 @Getter
+@Setter
 @ToString(callSuper = true)
 @DiscriminatorValue("ProductStock")
 public class ProductStock extends Stock {
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "partner_uuid")
     @ToString.Exclude
     @NotNull
@@ -61,9 +60,4 @@ public class ProductStock extends Stock {
         super();
     }
 
-    public void setAllocatedToCustomerPartner(Partner allocatedToCustomerPartner) {
-        this.allocatedToCustomerPartner = allocatedToCustomerPartner;
-        allocatedToCustomerPartner.getAllocatedProductStocksForCustomer().size();
-        allocatedToCustomerPartner.getAllocatedProductStocksForCustomer().add(this);
-    }
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/ProductStockRequest.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/ProductStockRequest.java
@@ -18,22 +18,27 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.eclipse.tractusx.puris.backend.common.api.domain.model;
+package org.eclipse.tractusx.puris.backend.stock.domain.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.eclipse.tractusx.puris.backend.common.api.domain.model.MessageHeader;
+import org.eclipse.tractusx.puris.backend.common.api.domain.model.datatype.DT_RequestStateEnum;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
 /**
- * This Response represents the message received via a Response API.
+ * This Request represents the message received via a Request API.
  * <p>
- * This Response may not be confused with an HTTP response.
+ * This Request may not be confused with an HTTP request.
  * Both, the Response and the Request, are called (api) request.
  */
 @Entity
@@ -41,27 +46,45 @@ import java.util.UUID;
 @Setter
 @ToString
 @NoArgsConstructor
-public class ProductStockResponse {
+public class ProductStockRequest {
+
+    /**
+     * State of the request.
+     *
+     * @see DT_RequestStateEnum
+     */
+    @NotNull
+    @JsonIgnore
+    private DT_RequestStateEnum state;
 
     @Id
     @GeneratedValue
+    @JsonIgnore
     /**
      * Technical identifier for a Message.
      */
     private UUID uuid;
 
     /**
-     * Steering information {@link ProductStockResponse} api message.
+     * Steering information of a {@link ProductStockRequest} api message.
      */
     @Embedded
     private MessageHeader header;
 
-    /**
-     * List of actual content of the payload.
-     * <p>
-     * May contain also errors.
-     */
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<MessageContent> payload = new ArrayList<>();
+    private ContentWrapper content = new ContentWrapper();
+
+    @Embeddable
+    @Getter
+    @Setter
+    @ToString
+    public static class ContentWrapper {
+
+        /**
+         * List of actual content of the payload.
+         */
+        @ElementCollection
+        private List<ProductStockRequestForMaterial> productStock = new ArrayList<>();
+
+    }
 
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/ProductStockRequestForMaterial.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/ProductStockRequestForMaterial.java
@@ -41,7 +41,7 @@ import org.eclipse.tractusx.puris.backend.common.api.domain.model.MessageContent
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@ToString(callSuper = true)
+@ToString
 public class ProductStockRequestForMaterial {
 
     @NotNull

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/ProductStockResponse.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/ProductStockResponse.java
@@ -18,59 +18,64 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.eclipse.tractusx.puris.backend.common.api.domain.model;
+package org.eclipse.tractusx.puris.backend.stock.domain.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import org.eclipse.tractusx.puris.backend.common.api.domain.model.datatype.DT_RequestStateEnum;
-import org.eclipse.tractusx.puris.backend.stock.domain.model.ProductStockRequestForMaterial;
+import org.eclipse.tractusx.puris.backend.common.api.domain.model.MessageContent;
+import org.eclipse.tractusx.puris.backend.common.api.domain.model.MessageHeader;
+import org.eclipse.tractusx.puris.backend.stock.logic.dto.samm.ProductStockSammDto;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
 /**
- * This Request represents the message received via a Request API.
+ * This Response represents the message received via a Response API.
  * <p>
- * This Request may not be confused with an HTTP request.
+ * This Response may not be confused with an HTTP response.
  * Both, the Response and the Request, are called (api) request.
  */
-@Entity
+
 @Getter
 @Setter
 @ToString
 @NoArgsConstructor
-public class ProductStockRequest {
+public class ProductStockResponse {
+
+//    @Id
+//    @GeneratedValue
+//    @JsonIgnore
+//    /**
+//     * Technical identifier for a Message.
+//     */
+//    private UUID uuid;
 
     /**
-     * State of the request.
-     *
-     * @see DT_RequestStateEnum
-     */
-    @NotNull
-    private DT_RequestStateEnum state;
-
-    @Id
-    @GeneratedValue
-    /**
-     * Technical identifier for a Message.
-     */
-    private UUID uuid;
-
-    /**
-     * Steering information of a {@link ProductStockRequest} api message.
+     * Steering information {@link ProductStockResponse} api message.
      */
     @Embedded
     private MessageHeader header;
 
-    /**
-     * List of actual content of the payload.
-     */
-    @ElementCollection
-    private List<ProductStockRequestForMaterial> payload = new ArrayList<>();
+//    /**
+//     * List of actual content of the payload.
+//     * <p>
+//     * May contain also errors.
+//     */
+//    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<MessageContent> payload = new ArrayList<>();
+
+    private ContentWrapper content = new ContentWrapper();
+
+    @Getter
+    @Setter
+    @ToString
+    public static class ContentWrapper {
+        List<ProductStockSammDto> productStocks = new ArrayList<>();
+    }
 
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/Stock.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/Stock.java
@@ -47,7 +47,7 @@ public class Stock {
     private UUID uuid;
 
     @ManyToOne
-    @JoinColumn(name = "material_uuid")
+    @JoinColumn(name = "material_ownMaterialNumber")
     @NotNull
     private Material material;
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/repository/MaterialStockRepository.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/repository/MaterialStockRepository.java
@@ -44,6 +44,7 @@ public interface MaterialStockRepository extends JpaRepository<MaterialStock, UU
 
     List<MaterialStock> findAllByType(DT_StockTypeEnum stockType);
 
-    List<MaterialStock> findAllByMaterial_MaterialNumberCustomerAndType(String materialNumberCustomer, DT_StockTypeEnum stockType);
+//    List<MaterialStock> findAllByMaterial_MaterialNumberCustomerAndType(String materialNumberCustomer, DT_StockTypeEnum stockType);
+    List<MaterialStock> findAllByMaterial_OwnMaterialNumberAndType(String ownMaterialNumber, DT_StockTypeEnum stockType);
 
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/repository/PartnerProductStockRepository.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/repository/PartnerProductStockRepository.java
@@ -44,7 +44,13 @@ public interface PartnerProductStockRepository extends JpaRepository<PartnerProd
 
     List<PartnerProductStock> findAllByType(DT_StockTypeEnum stockType);
 
-    List<PartnerProductStock> findAllByMaterial_UuidAndType(UUID materialUuid, DT_StockTypeEnum stockType);
+//    List<PartnerProductStock> findAllByMaterial_UuidAndType(UUID materialUuid, DT_StockTypeEnum stockType);
 
-    List<PartnerProductStock> findAllByMaterial_UuidAndTypeAndSupplierPartner_Uuid(UUID materialUuid, DT_StockTypeEnum stockType, UUID supplierUuid);
+    List<PartnerProductStock> findAllByMaterial_OwnMaterialNumberAndType(String ownMaterialNumber, DT_StockTypeEnum stockType);
+
+//    List<PartnerProductStock> findAllByMaterial_UuidAndTypeAndSupplierPartner_Uuid(UUID materialUuid, DT_StockTypeEnum stockType, UUID supplierUuid);
+
+    List<PartnerProductStock> findAllByMaterial_OwnMaterialNumberAndTypeAndSupplierPartner_Uuid(String ownMaterialNumber, DT_StockTypeEnum stockType, UUID supplierUuid);
+
+    List<PartnerProductStock> findAllBySupplierPartner_Uuid(UUID uuid);
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/repository/ProductStockRepository.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/repository/ProductStockRepository.java
@@ -43,9 +43,11 @@ public interface ProductStockRepository extends JpaRepository<ProductStock, UUID
 
     List<ProductStock> findAllByTypeAndUuid(DT_StockTypeEnum stockType, UUID productStockUuid);
 
+    List<ProductStock> findAllByMaterial_OwnMaterialNumberAndType(String ownMaterialNumber, DT_StockTypeEnum stockType);
+
     List<ProductStock> findAllByType(DT_StockTypeEnum stockType);
 
-    List<ProductStock> findAllByMaterial_MaterialNumberCustomerAndType(String materialNumberCustomer, DT_StockTypeEnum stockType);
+//    List<ProductStock> findAllByMaterial_MaterialNumberCustomerAndType(String materialNumberCustomer, DT_StockTypeEnum stockType);
 
-    List<ProductStock> findAllByMaterial_MaterialNumberCustomerAndTypeAndAllocatedToCustomerPartner_Bpnl(String materialNumberCustomer, DT_StockTypeEnum stockType, String allocatedToPartnerBpnl);
+//    List<ProductStock> findAllByMaterial_MaterialNumberCustomerAndTypeAndAllocatedToCustomerPartner_Bpnl(String materialNumberCustomer, DT_StockTypeEnum stockType, String allocatedToPartnerBpnl);
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/repository/ProductStockRequestRepository.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/repository/ProductStockRequestRepository.java
@@ -18,24 +18,25 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.eclipse.tractusx.puris.backend.common.api.domain.repository;
+package org.eclipse.tractusx.puris.backend.stock.domain.repository;
 
-import org.eclipse.tractusx.puris.backend.common.api.domain.model.ProductStockResponse;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.ProductStockRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 /**
- * Repository to access Responses
+ * Repository to access Requests
  */
-@Repository
-public interface ProductStockResponseRepository extends JpaRepository<ProductStockResponse, UUID> {
+public interface ProductStockRequestRepository extends JpaRepository<ProductStockRequest, UUID> {
 
     /**
-     * find the request by the requestUuuid from the message's header
+     * find the request by the requestUuid from the message's header
      *
      * @param headerRequestUuid uuid set by the sending partner in the header
      * @return Request
      */
+    public Optional<ProductStockRequest> findFirstByHeader_RequestId(UUID headerRequestUuid);
+
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/repository/ProductStockResponseRepository.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/repository/ProductStockResponseRepository.java
@@ -18,25 +18,20 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.eclipse.tractusx.puris.backend.common.api.domain.repository;
+package org.eclipse.tractusx.puris.backend.stock.domain.repository;
 
-import org.eclipse.tractusx.puris.backend.common.api.domain.model.ProductStockRequest;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.ProductStockRequest;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.ProductStockResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
 import java.util.UUID;
 
 /**
- * Repository to access Requests
+ * Repository to access Responses
  */
-public interface ProductStockRequestRepository extends JpaRepository<ProductStockRequest, UUID> {
+@Repository
+public interface ProductStockResponseRepository extends JpaRepository<ProductStockRequest, UUID> {
 
-    /**
-     * find the request by the requestUuid from the message's header
-     *
-     * @param headerRequestUuid uuid set by the sending partner in the header
-     * @return Request
-     */
-    public Optional<ProductStockRequest> findFirstByHeader_RequestId(UUID headerRequestUuid);
 
 }


### PR DESCRIPTION
## Description
Currently the relationship of the material and partner were not correctly mapped according to m:n scenarios based on one material having e.g. multiple suppliers each with a different supplier number.

This commit handles the domain section (model + repositories) and the corresponding logic layer.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
