### PR TITLE
Feat/include measurementunits in stocks

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/DataInjectionCommandLineRunner.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/DataInjectionCommandLineRunner.java
@@ -35,6 +35,7 @@ import org.eclipse.tractusx.puris.backend.masterdata.logic.service.MaterialPartn
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.MaterialService;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.PartnerService;
 import org.eclipse.tractusx.puris.backend.stock.domain.model.*;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.measurement.MeasurementUnit;
 import org.eclipse.tractusx.puris.backend.stock.logic.adapter.ProductStockSammMapper;
 import org.eclipse.tractusx.puris.backend.stock.logic.dto.samm.ProductStockSammDto;
 import org.eclipse.tractusx.puris.backend.stock.logic.service.MaterialStockService;
@@ -196,6 +197,7 @@ public class DataInjectionCommandLineRunner implements CommandLineRunner {
         MaterialStock materialStockEntity = new MaterialStock(
             semiconductorMaterial,
             5,
+            MeasurementUnit.piece,
             "BPNS4444444444XX",
             new Date()
         );
@@ -208,6 +210,7 @@ public class DataInjectionCommandLineRunner implements CommandLineRunner {
         PartnerProductStock partnerProductStockEntity = new PartnerProductStock(
             semiconductorMaterial,
             10,
+            MeasurementUnit.piece,
             supplierPartner.getSites().stream().findFirst().get().getBpns(),
             new Date(),
             supplierPartner
@@ -250,6 +253,7 @@ public class DataInjectionCommandLineRunner implements CommandLineRunner {
         ProductStock productStockEntity = new ProductStock(
             semiconductorMaterial,
             20,
+            MeasurementUnit.piece,
             "BPNS1234567890ZZ",
             new Date(),
             customerPartner

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/MaterialStock.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/MaterialStock.java
@@ -29,6 +29,7 @@ import lombok.Setter;
 import lombok.ToString;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
 import org.eclipse.tractusx.puris.backend.stock.domain.model.datatype.DT_StockTypeEnum;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.measurement.MeasurementUnit;
 
 import java.util.Date;
 
@@ -45,9 +46,9 @@ import java.util.Date;
 @NoArgsConstructor
 public class MaterialStock extends Stock {
 
-    public MaterialStock(Material material, double quantity, String atSiteBpns,
+    public MaterialStock(Material material, double quantity, MeasurementUnit measurementUnit, String atSiteBpns,
                          Date lastUpdatedOn) {
-        super(material, quantity, atSiteBpns, lastUpdatedOn);
+        super(material, quantity, measurementUnit, atSiteBpns, lastUpdatedOn);
         super.setType(DT_StockTypeEnum.MATERIAL);
     }
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/PartnerProductStock.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/PartnerProductStock.java
@@ -30,6 +30,7 @@ import lombok.ToString;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
 import org.eclipse.tractusx.puris.backend.stock.domain.model.datatype.DT_StockTypeEnum;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.measurement.MeasurementUnit;
 
 import java.util.Date;
 
@@ -52,15 +53,15 @@ public class PartnerProductStock extends Stock {
     @NotNull
     private Partner supplierPartner;
 
-    public PartnerProductStock(Material material, double quantity, String atSiteBpns,
+    public PartnerProductStock(Material material, double quantity, MeasurementUnit measurementUnit, String atSiteBpns,
                                Date lastUpdatedOn, Partner supplierPartner) {
-        super(material, quantity, atSiteBpns, lastUpdatedOn);
+        super(material, quantity, measurementUnit, atSiteBpns, lastUpdatedOn);
         super.setType(DT_StockTypeEnum.PRODUCT);
         this.setSupplierPartner(supplierPartner);
     }
 
-    public PartnerProductStock(Material material, double quantity, String atSiteBpns, Date lastUpdatedOn) {
-        super(material, quantity, atSiteBpns, lastUpdatedOn);
+    public PartnerProductStock(Material material, double quantity, MeasurementUnit measurementUnit, String atSiteBpns, Date lastUpdatedOn) {
+        super(material, quantity, measurementUnit, atSiteBpns, lastUpdatedOn);
         super.setType(DT_StockTypeEnum.PRODUCT);
     }
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/ProductStock.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/ProductStock.java
@@ -29,6 +29,7 @@ import lombok.ToString;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
 import org.eclipse.tractusx.puris.backend.stock.domain.model.datatype.DT_StockTypeEnum;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.measurement.MeasurementUnit;
 
 import java.util.Date;
 
@@ -50,14 +51,14 @@ public class ProductStock extends Stock {
     @NotNull
     private Partner allocatedToCustomerPartner;
 
-    public ProductStock(Material material, double quantity, String atSiteBpns, Date lastUpdatedOn, Partner allocatedToCustomerPartner) {
-        super(material, quantity, atSiteBpns, lastUpdatedOn);
+    public ProductStock(Material material, double quantity, MeasurementUnit measurementUnit, String atSiteBpns, Date lastUpdatedOn, Partner allocatedToCustomerPartner) {
+        super(material, quantity, measurementUnit, atSiteBpns, lastUpdatedOn);
         super.setType(DT_StockTypeEnum.PRODUCT);
         this.setAllocatedToCustomerPartner(allocatedToCustomerPartner);
     }
 
-    public ProductStock(Material material, double quantity, String atSiteBpns, Date lastUpdatedOn) {
-        super(material, quantity, atSiteBpns, lastUpdatedOn);
+    public ProductStock(Material material, double quantity, MeasurementUnit measurementUnit, String atSiteBpns, Date lastUpdatedOn) {
+        super(material, quantity, measurementUnit, atSiteBpns, lastUpdatedOn);
         super.setType(DT_StockTypeEnum.PRODUCT);
     }
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/Stock.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/Stock.java
@@ -29,6 +29,7 @@ import lombok.Setter;
 import lombok.ToString;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
 import org.eclipse.tractusx.puris.backend.stock.domain.model.datatype.DT_StockTypeEnum;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.measurement.MeasurementUnit;
 
 import java.util.Date;
 import java.util.UUID;
@@ -60,6 +61,9 @@ public class Stock {
     private double quantity;
 
     @NotNull
+    private MeasurementUnit measurementUnit;
+
+    @NotNull
     private String atSiteBpns;
 
     @Enumerated(EnumType.STRING)
@@ -70,9 +74,10 @@ public class Stock {
     @NotNull
     private Date lastUpdatedOn;
 
-    public Stock(Material material, double quantity, String atSiteBpns, Date lastUpdatedOn) {
+    public Stock(Material material, double quantity, MeasurementUnit measurementUnit, String atSiteBpns, Date lastUpdatedOn) {
         this.material = material;
         this.quantity = quantity;
+        this.measurementUnit = measurementUnit;
         this.atSiteBpns = atSiteBpns;
         this.lastUpdatedOn = lastUpdatedOn;
     }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/measurement/MeasurementUnit.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/measurement/MeasurementUnit.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2023 Volkswagen AG
+ * Copyright (c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package org.eclipse.tractusx.puris.backend.stock.domain.model.measurement;
 
 public enum MeasurementUnit {

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/measurement/MeasurementUnit.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/measurement/MeasurementUnit.java
@@ -1,0 +1,34 @@
+package org.eclipse.tractusx.puris.backend.stock.domain.model.measurement;
+
+public enum MeasurementUnit {
+
+    gram,
+    kilogram,
+    tonneMetricTon,
+    tonUsOrShortTonUkorus,
+    ounceAvoirdupois,
+    pound,
+    centimetre,
+    metre,
+    kilometre,
+    inch,
+    foot,
+    yard,
+    squareCentimetre,
+    squareMetre,
+    squareInch,
+    squareFoot,
+    squareYard,
+    cubicCentimetre,
+    cubicMetre,
+    cubicInch,
+    millilitre,
+    litre,
+    hectolitre,
+    piece,
+    set,
+    pair,
+    page,
+    kilowattHour
+
+}

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/MaterialStockDto.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/MaterialStockDto.java
@@ -26,6 +26,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.dto.MaterialDto;
 import org.eclipse.tractusx.puris.backend.stock.domain.model.datatype.DT_StockTypeEnum;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.measurement.MeasurementUnit;
 
 import java.util.Date;
 
@@ -34,8 +35,8 @@ import java.util.Date;
 @AllArgsConstructor
 public class MaterialStockDto extends StockDto {
 
-    public MaterialStockDto(MaterialDto material, double quantity, String atSiteBpns) {
-        super(material, quantity, atSiteBpns, new Date());
+    public MaterialStockDto(MaterialDto material, double quantity, MeasurementUnit measurementUnit, String atSiteBpns) {
+        super(material, quantity, measurementUnit, atSiteBpns, new Date());
         this.setType(DT_StockTypeEnum.MATERIAL);
     }
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/PartnerProductStockDto.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/PartnerProductStockDto.java
@@ -27,6 +27,7 @@ import lombok.Setter;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.dto.MaterialDto;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.dto.PartnerDto;
 import org.eclipse.tractusx.puris.backend.stock.domain.model.datatype.DT_StockTypeEnum;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.measurement.MeasurementUnit;
 
 import java.util.Date;
 
@@ -37,14 +38,14 @@ public class PartnerProductStockDto extends StockDto {
 
     private PartnerDto supplierPartner;
 
-    public PartnerProductStockDto(MaterialDto material, double quantity, String atSiteBpns) {
-        super(material, quantity, atSiteBpns, new Date());
+    public PartnerProductStockDto(MaterialDto material, double quantity, MeasurementUnit measurementUnit, String atSiteBpns) {
+        super(material, quantity, measurementUnit, atSiteBpns, new Date());
         this.setType(DT_StockTypeEnum.PRODUCT);
     }
 
-    public PartnerProductStockDto(MaterialDto material, double quantity, String atSiteBpns,
+    public PartnerProductStockDto(MaterialDto material, double quantity, MeasurementUnit measurementUnit, String atSiteBpns,
                                   PartnerDto supplierPartner) {
-        super(material, quantity, atSiteBpns, new Date());
+        super(material, quantity, measurementUnit, atSiteBpns, new Date());
         this.setType(DT_StockTypeEnum.PRODUCT);
         this.supplierPartner = supplierPartner;
     }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/PartnerProductStockDto.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/PartnerProductStockDto.java
@@ -44,8 +44,8 @@ public class PartnerProductStockDto extends StockDto {
     }
 
     public PartnerProductStockDto(MaterialDto material, double quantity, MeasurementUnit measurementUnit, String atSiteBpns,
-                                  PartnerDto supplierPartner) {
-        super(material, quantity, measurementUnit, atSiteBpns, new Date());
+                                  PartnerDto supplierPartner, Date lastUpdatedOn) {
+        super(material, quantity, measurementUnit, atSiteBpns, lastUpdatedOn);
         this.setType(DT_StockTypeEnum.PRODUCT);
         this.supplierPartner = supplierPartner;
     }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/ProductStockDto.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/ProductStockDto.java
@@ -28,6 +28,7 @@ import lombok.ToString;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.dto.MaterialDto;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.dto.PartnerDto;
 import org.eclipse.tractusx.puris.backend.stock.domain.model.datatype.DT_StockTypeEnum;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.measurement.MeasurementUnit;
 
 import java.util.Date;
 
@@ -39,14 +40,14 @@ public class ProductStockDto extends StockDto {
 
     private PartnerDto allocatedToCustomerPartner;
 
-    public ProductStockDto(MaterialDto material, double quantity, String atSiteBpns) {
-        super(material, quantity, atSiteBpns, new Date());
+    public ProductStockDto(MaterialDto material, double quantity, MeasurementUnit measurementUnit, String atSiteBpns) {
+        super(material, quantity, measurementUnit, atSiteBpns, new Date());
         this.setType(DT_StockTypeEnum.PRODUCT);
     }
 
-    public ProductStockDto(MaterialDto material, double quantity, String atSiteBpns,
+    public ProductStockDto(MaterialDto material, double quantity, MeasurementUnit measurementUnit, String atSiteBpns,
                            PartnerDto allocatedToCustomerPartner) {
-        super(material, quantity, atSiteBpns, new Date());
+        super(material, quantity, measurementUnit, atSiteBpns, new Date());
         this.setType(DT_StockTypeEnum.PRODUCT);
         this.allocatedToCustomerPartner = allocatedToCustomerPartner;
     }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/StockDto.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/StockDto.java
@@ -28,6 +28,7 @@ import lombok.Setter;
 import lombok.ToString;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.dto.MaterialDto;
 import org.eclipse.tractusx.puris.backend.stock.domain.model.datatype.DT_StockTypeEnum;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.measurement.MeasurementUnit;
 
 import java.io.Serializable;
 import java.util.Date;
@@ -46,15 +47,18 @@ public abstract class StockDto implements Serializable {
 
     private double quantity;
 
+    private MeasurementUnit measurementUnit;
+
     private String atSiteBpns;
 
     private DT_StockTypeEnum type;
 
     private Date lastUpdatedOn;
 
-    public StockDto(MaterialDto material, double quantity, String atSiteBpns, Date lastUpdatedOn) {
+    public StockDto(MaterialDto material, double quantity, MeasurementUnit measurementUnit, String atSiteBpns, Date lastUpdatedOn) {
         this.material = material;
         this.quantity = quantity;
+        this.measurementUnit = measurementUnit;
         this.atSiteBpns = atSiteBpns;
         this.lastUpdatedOn = lastUpdatedOn;
     }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/samm/AllocatedStock.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/samm/AllocatedStock.java
@@ -48,9 +48,6 @@ public class AllocatedStock {
     @JsonCreator
     public AllocatedStock(@JsonProperty(value = "quantityOnAllocatedStock") Quantity quantityOnAllocatedStock,
                           @JsonProperty(value = "supplierStockLocationId") LocationId supplierStockLocationId) {
-        super(
-
-        );
         this.quantityOnAllocatedStock = quantityOnAllocatedStock;
         this.supplierStockLocationId = supplierStockLocationId;
     }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/samm/LocationId.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/samm/LocationId.java
@@ -45,9 +45,6 @@ public class LocationId {
     @JsonCreator
     public LocationId(@JsonProperty(value = "locationIdType") LocationIdTypeEnum locationIdType,
                       @JsonProperty(value = "locationId") String locationId) {
-        super(
-
-        );
         this.locationIdType = locationIdType;
         this.locationId = locationId;
     }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/samm/OrderPositionReference.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/samm/OrderPositionReference.java
@@ -47,9 +47,6 @@ public class OrderPositionReference {
     public OrderPositionReference(@JsonProperty(value = "supplierOrderId") Optional<String> supplierOrderId,
                                   @JsonProperty(value = "customerOrderId") String customerOrderId,
                                   @JsonProperty(value = "customerOrderPositionId") String customerOrderPositionId) {
-        super(
-
-        );
         this.supplierOrderId = supplierOrderId;
         this.customerOrderId = customerOrderId;
         this.customerOrderPositionId = customerOrderPositionId;

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/samm/Position.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/samm/Position.java
@@ -28,6 +28,7 @@ import lombok.ToString;
 
 import javax.xml.datatype.XMLGregorianCalendar;
 import java.util.Collection;
+import java.util.Date;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -40,7 +41,7 @@ public class Position {
     private Optional<OrderPositionReference> orderPositionReference;
 
     @NotNull
-    private XMLGregorianCalendar lastUpdatedOnDateTime;
+    private Date lastUpdatedOnDateTime;
 
     @NotNull
     private Collection<AllocatedStock> allocatedStocks;
@@ -48,7 +49,7 @@ public class Position {
     @JsonCreator
     public Position(
             @JsonProperty(value = "orderPositionReference") Optional<OrderPositionReference> orderPositionReference,
-            @JsonProperty(value = "lastUpdatedOnDateTime") XMLGregorianCalendar lastUpdatedOnDateTime,
+            @JsonProperty(value = "lastUpdatedOnDateTime") Date lastUpdatedOnDateTime,
             @JsonProperty(value = "allocatedStocks") Collection<AllocatedStock> allocatedStocks) {
         super(
 
@@ -72,7 +73,7 @@ public class Position {
      *
      * @return {@link #lastUpdatedOnDateTime}
      */
-    public XMLGregorianCalendar getLastUpdatedOnDateTime() {
+    public Date getLastUpdatedOnDateTime() {
         return this.lastUpdatedOnDateTime;
     }
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/samm/ProductStockSammDto.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/samm/ProductStockSammDto.java
@@ -62,9 +62,6 @@ public class ProductStockSammDto extends MessageContentDto {
                                @JsonProperty(value = "materialNumberCustomer") String materialNumberCustomer,
                                @JsonProperty(value = "materialNumberCatenaX") Optional<String> materialNumberCatenaX,
                                @JsonProperty(value = "materialNumberSupplier") Optional<String> materialNumberSupplier) {
-        super(
-
-        );
         this.positions = positions;
         this.materialNumberCustomer = materialNumberCustomer;
         this.materialNumberCatenaX = materialNumberCatenaX;

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/samm/Quantity.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/samm/Quantity.java
@@ -45,9 +45,6 @@ public class Quantity {
     @JsonCreator
     public Quantity(@JsonProperty(value = "quantityNumber") Double quantityNumber,
                     @JsonProperty(value = "measurementUnit") String measurementUnit) {
-        super(
-
-        );
         this.quantityNumber = quantityNumber;
         this.measurementUnit = measurementUnit;
     }

--- a/backend/src/main/resources/application-customer.properties
+++ b/backend/src/main/resources/application-customer.properties
@@ -16,11 +16,11 @@ spring.jpa.hibernate.ddl-auto=create
 server.servlet.context-path=${API_ROOTDIR:/catena}
 # EDC Config
 edc.controlplane.host=${EDC_CONTROLPLANE_HOST:192.168.49.2}
-edc.controlplane.data.port=${EDC_CONTROLPLANE_DATA_PORT:31944}
+edc.controlplane.data.port=${EDC_CONTROLPLANE_DATA_PORT:30216}
 edc.controlplane.key=${EDC_CONTROLPLANE_KEY:password}
 
 edc.applydataplaneworkaround=true
-edc.dataplane.public.port=30703
+edc.dataplane.public.port=31944
 minikube.ip=${MINIKUBE_IP:host.minikube.internal}
 # Jackson (JSON)
 #spring.jackson.default-property-inclusion=non_empty

--- a/backend/src/main/resources/application-supplier.properties
+++ b/backend/src/main/resources/application-supplier.properties
@@ -16,11 +16,11 @@ spring.jpa.hibernate.ddl-auto=create
 server.servlet.context-path=${API_ROOTDIR:/catena}
 # EDC Config
 edc.controlplane.host=${EDC_CONTROLPLANE_HOST:192.168.49.2}
-edc.controlplane.data.port=${EDC_CONTROLPLANE_DATA_PORT:32272}
+edc.controlplane.data.port=${EDC_CONTROLPLANE_DATA_PORT:31466}
 edc.controlplane.key=${EDC_CONTROLPLANE_KEY:password}
 
 edc.applydataplaneworkaround=true
-edc.dataplane.public.port=30784
+edc.dataplane.public.port=31102
 minikube.ip=${MINIKUBE_IP:host.minikube.internal}
 # Jackson (JSON)
 #spring.jackson.default-property-inclusion=non_empty


### PR DESCRIPTION


## Description
- included MeasurementUnits in Stock and its sub classes.
- productstocksammdto now using java.util.date instead of xmlgregorian


## Pre-review checks

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
