### PR TITLE
ci(veracode): prevent veracode GitHub action to run on forks

### DIFF
--- a/.github/workflows/veracode-backend.yml
+++ b/.github/workflows/veracode-backend.yml
@@ -33,6 +33,7 @@ on:
 
 jobs:
   analyze-backend:
+    if: github.repository_owner == 'eclipse-tractusx' # prevent running on forks
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/veracode-frontend.yml
+++ b/.github/workflows/veracode-frontend.yml
@@ -33,6 +33,7 @@ on:
 
 jobs:
   analyze-frontend:
+    if: github.repository_owner == 'eclipse-tractusx' # prevent running on forks
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This pull request updates the Veracode GitHub action to only run in the upstream `eclipse-tractusx/puris` repository, since it fails on forks due to missing secrets.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
