### PR TITLE
ci: fix render puml to svg workflow

### DIFF
--- a/.github/workflows/render-puml-to-svg.yml
+++ b/.github/workflows/render-puml-to-svg.yml
@@ -31,7 +31,7 @@ on:
       - '**/*.puml'
 jobs:
   render-images:
-    uses: eclipse-tractusx/sig-infra/.github/workflows/reusable-generate-puml-svg.yml@main
+    uses: eclipse-tractusx/sig-infra/.github/workflows/reusable-generate-puml-svg.yaml@main
 
   store-images:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
Fixes a file extension mistake in the puml to svg workflow.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
