### PR TITLE
ci: configure trivy scans

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -19,26 +19,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-name: "Trivy"
+name: "Run Trivy scan and upload SARIF"
 
 on:
-  push:
-    branches: [ "main" ]
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.txt'
-  pull_request:
-    branches: [ "main" ]
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.txt'
-  schedule:
-    - cron: "0 0 * * *"
   workflow_dispatch:
-  # Trigger manually
+  schedule:
+    - cron: "0 0 * * *" # Once a day
 
 jobs:
-  analyze:
+  analyze-frontend:
+    name: Analyze frontend
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -46,21 +36,39 @@ jobs:
       security-events: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@master
+      # Pull image from Docker Hub and run Trivy vulnerability scanner
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.14.0
         with:
-          scan-type: "config"
-          exit-code: "1"
-          hide-progress: false
+          image-ref: "tractusx/app-puris-frontend:main"
           format: "sarif"
-          output: "trivy-results1.sarif"
-          severity: "CRITICAL,HIGH"
+          output: "trivy-results-1.sarif"
+          vuln-type: "os,library"
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
-        if: always()
         with:
-          sarif_file: "trivy-results1.sarif"
+          sarif_file: "trivy-results-1.sarif"
+
+  analyze-backend:
+    name: Analyze backend
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      # Pull image from Docker Hub and run Trivy vulnerability scanner
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.14.0
+        with:
+          image-ref: "tractusx/app-puris-backend:main"
+          format: "sarif"
+          output: "trivy-results-2.sarif"
+          vuln-type: "os,library"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: "trivy-results-2.sarif"


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

https://github.com/eclipse-tractusx/sig-security/issues/25

Setup trivy scans.
You don't need the trivy config scan - kics does this job.
I configured for you the trivy container scans for your frontend and backend.
In future, please add the `latest` tag to your published images and configure the `latest` tag in the trivy workflow config.