### PR TITLE
Feat: add route to partner controller endpoint to receive site and address information of the own application

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/MaterialController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/MaterialController.java
@@ -56,7 +56,6 @@ public class MaterialController {
         @ApiResponse(responseCode = "409", description = "Material with the given ownMaterialNumber already exists."),
         @ApiResponse(responseCode = "500", description = "Internal Server error.")
     })
-    @CrossOrigin
     public ResponseEntity<?> createMaterial(@RequestBody MaterialEntityDto materialDto) {
         if (materialDto.getOwnMaterialNumber() == null || materialDto.getOwnMaterialNumber().isEmpty()) {
             // Cannot create material without ownMaterialNumber
@@ -88,7 +87,6 @@ public class MaterialController {
         @ApiResponse(responseCode = "404", description = "No existing Material Entity found, no update was performed."),
         @ApiResponse(responseCode = "500", description = "Internal Server Error.")
     })
-    @CrossOrigin
     public ResponseEntity<?> updateMaterial(@RequestBody MaterialEntityDto materialDto) {
         if (materialDto.getOwnMaterialNumber() == null || materialDto.getOwnMaterialNumber().isEmpty()) {
             // Cannot update material without ownMaterialNumber
@@ -120,7 +118,6 @@ public class MaterialController {
         @ApiResponse(responseCode = "400", description = "Invalid parameter"),
         @ApiResponse(responseCode = "404", description = "Requested Material was not found.")
     })
-    @CrossOrigin
     public ResponseEntity<MaterialEntityDto> getMaterial(@Parameter(name = "ownMaterialNumber",
         description = "The Material Number that is used in your own company to identify the Material.",
         example = "MNR-7307-AU340474.002") @RequestParam String ownMaterialNumber) {
@@ -138,7 +135,6 @@ public class MaterialController {
 
     @GetMapping("/all")
     @Operation(description = "Returns a list of all Materials and Products.")
-    @CrossOrigin
     public ResponseEntity<List<MaterialEntityDto>> listMaterials() {
         return new ResponseEntity<>(materialService.findAll().
             stream().map(x -> modelMapper.map(x, MaterialEntityDto.class)).collect(Collectors.toList()),

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartnerController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartnerController.java
@@ -35,10 +35,12 @@ import org.eclipse.tractusx.puris.backend.masterdata.logic.service.PartnerServic
 import org.modelmapper.Conditions;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -202,10 +204,17 @@ public class PartnerController {
     @GetMapping("/ownSites")
     @Operation(description = "Returns all sites of the puris partner using the puris system.")
     public ResponseEntity<List<SiteDto>> getOwnSites() {
+        Partner ownPartnerEntity = partnerService.getOwnPartnerEntity();
+
+        if (ownPartnerEntity == null || ownPartnerEntity.getSites() == null ||
+                ownPartnerEntity.getSites().isEmpty()) {
+            return new ResponseEntity<>(new ArrayList<>(), HttpStatus.OK);
+        }
+
         return new ResponseEntity<>(partnerService.getOwnPartnerEntity().
             getSites().
             stream().map(site -> modelMapper.map(site, SiteDto.class)).collect(Collectors.toList()),
-            HttpStatusCode.valueOf(200));
+            HttpStatus.OK);
     }
 
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartnerController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartnerController.java
@@ -61,7 +61,6 @@ public class PartnerController {
         @ApiResponse(responseCode = "400", description = "Request body was malformed, didn't meet the minimum constraints or wrongfully contained a UUID."),
         @ApiResponse(responseCode = "409", description = "The BPNL specified in the request body is already assigned. ")
     })
-    @CrossOrigin
     public ResponseEntity<?> createPartner(@RequestBody PartnerDto partnerDto) {
         modelMapper.getConfiguration().setPropertyCondition(Conditions.isNotNull());
         // Any given UUID is wrong by default since we're creating a new Partner entity
@@ -92,7 +91,6 @@ public class PartnerController {
     }
 
     @PutMapping("putAddress")
-    @CrossOrigin
     @Operation(description = "Updates an existing Partner by adding a new Address. If that Partner already has " +
         "an Address with the BPNA given in the request body, that existing Address will be overwritten. ")
     @ApiResponses(value = {
@@ -138,7 +136,6 @@ public class PartnerController {
         @ApiResponse(responseCode = "404", description = "Partner not found."),
         @ApiResponse(responseCode = "500", description = "Internal Server Error.")
     })
-    @CrossOrigin
     public ResponseEntity<?> addSite(
         @Parameter(description = "The unique BPNL that was assigned to that Partner.",
             example = "BPNL2222222222RR") @RequestParam() String partnerBpnl,
@@ -168,8 +165,6 @@ public class PartnerController {
         return new ResponseEntity<>(HttpStatusCode.valueOf(200));
     }
 
-
-    @CrossOrigin
     @GetMapping
     @Operation(description = "Returns the requested PartnerDto.")
     @ApiResponses(value = {
@@ -196,12 +191,20 @@ public class PartnerController {
         }
     }
 
-    @CrossOrigin
     @GetMapping("/all")
     @Operation(description = "Returns a list of all Partners. ")
     public ResponseEntity<List<PartnerDto>> listPartners() {
         return new ResponseEntity<>(partnerService.findAll().
             stream().map(partner -> modelMapper.map(partner, PartnerDto.class)).collect(Collectors.toList()),
+            HttpStatusCode.valueOf(200));
+    }
+
+    @GetMapping("/ownSites")
+    @Operation(description = "Returns all sites of the puris partner using the puris system.")
+    public ResponseEntity<List<SiteDto>> getOwnSites() {
+        return new ResponseEntity<>(partnerService.getOwnPartnerEntity().
+            getSites().
+            stream().map(site -> modelMapper.map(site, SiteDto.class)).collect(Collectors.toList()),
             HttpStatusCode.valueOf(200));
     }
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/controller/StockViewController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/controller/StockViewController.java
@@ -95,7 +95,6 @@ public class StockViewController {
     @GetMapping("materials")
     @ResponseBody
     @Operation(description = "Returns a list of all materials (excluding products)")
-    @CrossOrigin
     public List<FrontendMaterialDto> getMaterials() {
         return materialService.findAllMaterials()
             .stream()
@@ -112,7 +111,6 @@ public class StockViewController {
                 "  \"BPNL1234567890ZZ\": \"MNR-8101-ID146955.001\"," +
                 "  \"BPNL4444444444XX\": \"MNR-7307-AU340474.002\"}")})),
         @ApiResponse(responseCode = "400", description = "Invalid parameter")})
-    @CrossOrigin
     public ResponseEntity<Map<String, String>> getMaterialNumbers(@RequestParam String ownMaterialNumber) {
         if (!materialPattern.matcher(ownMaterialNumber).matches()) {
             return new ResponseEntity<>(HttpStatusCode.valueOf(400));
@@ -123,7 +121,6 @@ public class StockViewController {
     @GetMapping("products")
     @ResponseBody
     @Operation(description = "Returns a list of all products (excluding materials)")
-    @CrossOrigin
     public List<FrontendMaterialDto> getProducts() {
         return materialService.findAllProducts()
             .stream()
@@ -131,7 +128,7 @@ public class StockViewController {
             .collect(Collectors.toList());
     }
 
-    @CrossOrigin
+
     @GetMapping("product-stocks")
     @ResponseBody
     @Operation(description = "Returns a list of all product-stocks")
@@ -141,7 +138,6 @@ public class StockViewController {
             .collect(Collectors.toList());
     }
 
-    @CrossOrigin
     @PostMapping("product-stocks")
     @ResponseBody
     @Operation(description = "Creates a new product-stock")
@@ -160,7 +156,6 @@ public class StockViewController {
         return convertToDto(createdProductStock);
     }
 
-    @CrossOrigin
     @PutMapping("product-stocks")
     @ResponseBody
     @Operation(description = "Updates an existing product-stock")
@@ -195,7 +190,6 @@ public class StockViewController {
         return productStock;
     }
 
-    @CrossOrigin
     @GetMapping("material-stocks")
     @ResponseBody
     @Operation(description = "Returns a list of all material-stocks")
@@ -207,7 +201,6 @@ public class StockViewController {
         return allMaterialStocks;
     }
 
-    @CrossOrigin
     @PostMapping("material-stocks")
     @ResponseBody
     @Operation(description = "Creates a new material-stock")
@@ -221,7 +214,6 @@ public class StockViewController {
         return convertToDto(createdMaterialStock);
     }
 
-    @CrossOrigin
     @PutMapping("material-stocks")
     @ResponseBody
     @Operation(description = "Updates an existing material-stock")
@@ -253,7 +245,6 @@ public class StockViewController {
         return stock;
     }
 
-    @CrossOrigin
     @GetMapping("partner-product-stocks")
     @Operation(description = "Returns a list of all partner-product-stocks that refer to the given material number")
     @ApiResponses(value = {
@@ -288,7 +279,6 @@ public class StockViewController {
         @ApiResponse(responseCode = "200", description = "OK"),
         @ApiResponse(responseCode = "400", description = "Invalid parameter")
     })
-    @CrossOrigin
     public ResponseEntity<List<PartnerDto>> getCustomerPartnersOrderingMaterial(@RequestParam String ownMaterialNumber) {
         if(!materialPattern.matcher(ownMaterialNumber).matches()) {
             return new ResponseEntity<>(HttpStatusCode.valueOf(400));
@@ -308,7 +298,6 @@ public class StockViewController {
         @ApiResponse(responseCode = "200", description = "OK"),
         @ApiResponse(responseCode = "400", description = "Invalid parameter")
     })
-    @CrossOrigin
     public ResponseEntity<List<PartnerDto>> triggerPartnerProductStockUpdateForMaterial(@RequestParam String ownMaterialNumber) {
         if(!materialPattern.matcher(ownMaterialNumber).matches()) {
             return new ResponseEntity<>(HttpStatusCode.valueOf(400));


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
We introduced site information with PR #27 and increased validations in the past time. We've not yet been adding those capabilities to the frontend (see issue #112). 

Removed CrossOrigin annotations in controller, as I seem to have missed them in the TLS PR (#117).

This PR prepares the frontend to get the remaining data (own sites and addresses) to create dropdowns in the frontend.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
