### PR TITLE
Fix: typo in customer backend properties

### DIFF
--- a/local/tractus-x-edc/config/customer/puris-backend.properties
+++ b/local/tractus-x-edc/config/customer/puris-backend.properties
@@ -9,7 +9,7 @@ puris.statusrequest.apiassetid=statusrequest-api-asset
 puris.response.serverendpoint=http://customer-backend:8081/catena/item-stock/response
 puris.response.apiassetid=response-api-asset
 puris.frameworkagreement.use=true
-puris.frameworkagreement.crednetial=FrameworkAgreement.traceability
+puris.frameworkagreement.credential=FrameworkAgreement.traceability
 puris.api.key=${CUSTOMER_BACKEND_API_KEY}
 puris.dtr.url=http://dtr-customer:4243
 


### PR DESCRIPTION
- fixed typo ("crednetials" vs "credentials")

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
