### PR TITLE
Fix: missing statusrequest url

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/util/EdcRequestBodyBuilder.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/util/EdcRequestBodyBuilder.java
@@ -90,7 +90,11 @@ public class EdcRequestBodyBuilder {
         propertiesObject.put("description", apiMethod.DESCRIPTION);
 
         var dataAddress = MAPPER.createObjectNode();
-        String url = apiMethod == DT_ApiMethodEnum.REQUEST ? variablesService.getRequestServerEndpoint() : variablesService.getResponseServerEndpoint();
+        String url = switch (apiMethod) {
+            case REQUEST -> variablesService.getRequestServerEndpoint();
+            case RESPONSE -> variablesService.getResponseServerEndpoint();
+            case STATUS_REQUEST -> variablesService.getStatusRequestServerEndpoint();
+        };
         dataAddress.put("baseUrl", url);
         dataAddress.put("type", "HttpData");
         dataAddress.put("proxyPath", "true");


### PR DESCRIPTION
- The method that creates request bodies for the puris api assets didn't properly set the URL for the status request api asset


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
