### PR TITLE
feat(SecurityConfig): configure Swagger API-Key usage globally

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/security/SecurityConfig.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/security/SecurityConfig.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023, 2024 Volkswagen AG
- * Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023-2024 Volkswagen AG
+ * Copyright (c) 2023-2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -20,6 +20,12 @@
 package org.eclipse.tractusx.puris.backend.common.security;
 
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeIn;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import jakarta.servlet.DispatcherType;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -43,7 +49,11 @@ import java.util.List;
 @EnableWebSecurity
 @AllArgsConstructor
 @Slf4j
+@SecurityScheme(type = SecuritySchemeType.APIKEY, name = SecurityConfig.API_KEY_HEADER_NAME, in = SecuritySchemeIn.HEADER)
+@OpenAPIDefinition(info = @Info(title = "PURIS FOSS Open API", version = "1.0.0"), security = {@SecurityRequirement(name = "X-API-KEY")})
 public class SecurityConfig {
+
+    public static final String API_KEY_HEADER_NAME = "X-API-KEY";
 
     private final ApiKeyAuthenticationFilter apiKeyAuthenticationFilter;
 
@@ -69,7 +79,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(
                 // any request in spring context
                 (authorizeHttpRequests) -> authorizeHttpRequests
-                    .requestMatchers("/stockView/**", "/partners/**",  "/materials/**", "/materialpartnerrelations/**", "/item-stock/**", "/edrendpoint/**", "/edc/**").authenticated()
+                    .requestMatchers("/stockView/**", "/partners/**", "/materials/**", "/materialpartnerrelations/**", "/item-stock/**", "/edrendpoint/**", "/edc/**").authenticated()
                     .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/health/**").permitAll()
                     .dispatcherTypeMatchers(DispatcherType.ERROR).permitAll()
             )

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/security/logic/ApiKeyAuthenticationFilter.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/security/logic/ApiKeyAuthenticationFilter.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Volkswagen AG
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023-2024 Volkswagen AG
+ * Copyright (c) 2023-2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -24,7 +24,9 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
+import org.eclipse.tractusx.puris.backend.common.security.SecurityConfig;
 import org.eclipse.tractusx.puris.backend.common.security.domain.ApiKeyAuthentication;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -39,18 +41,18 @@ import java.io.IOException;
 @AllArgsConstructor
 public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
 
-    public final String API_KEY_HEADER = "X-API-KEY";
     private final ApiKeyAuthenticationProvider apiKeyAuthenticationProvider;
-    @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        String headerKey = request.getHeader(API_KEY_HEADER);
 
-        if (headerKey != null){
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, @NotNull HttpServletResponse response, @NotNull FilterChain filterChain) throws ServletException, IOException {
+        String headerKey = request.getHeader(SecurityConfig.API_KEY_HEADER_NAME);
+
+        if (headerKey != null) {
             ApiKeyAuthentication apiKeyAuthentication = new ApiKeyAuthentication(headerKey, false);
             Authentication authenticatedObject = apiKeyAuthenticationProvider.authenticate(apiKeyAuthentication);
             SecurityContextHolder.getContext().setAuthentication(authenticatedObject);
         }
 
-        filterChain.doFilter(request,response);
+        filterChain.doFilter(request, response);
     }
 }


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
The Swagger UI was unusable because the API Key has not been configured to be used globally. Now it is.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
