### PR TITLE
Fix/missing valid annotations

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/domain/model/Partner.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/domain/model/Partner.java
@@ -76,7 +76,9 @@ public class Partner {
      * Partner's BPNL.
      */
     private SortedSet<Address> addresses = new TreeSet<>();
+
     @OneToMany(cascade = CascadeType.ALL)
+    @Valid
     /**
      * Contains all Sites (BPNSs) that are assigned to this
      * Partner's BPNL. Each BPNS has one or more addresses (BPNAs).

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/dto/MaterialDto.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/dto/MaterialDto.java
@@ -46,7 +46,6 @@ public class MaterialDto implements Serializable {
      * <p>
      * Boolean because there could be companies (tradesmen company) that buy and sell the same material.
      */
-    @Pattern(regexp = PatternStore.NON_EMPTY_NON_VERTICAL_WHITESPACE_STRING)
     private boolean materialFlag;
 
     /**

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/dto/PartnerDto.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/dto/PartnerDto.java
@@ -21,6 +21,7 @@
  */
 package org.eclipse.tractusx.puris.backend.masterdata.logic.dto;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import lombok.*;
 import org.eclipse.tractusx.puris.backend.common.util.PatternStore;
@@ -45,7 +46,9 @@ public class PartnerDto implements Serializable {
     @Pattern(regexp = PatternStore.BPNL_STRING)
     private String bpnl;
 
+    @Valid
     private SortedSet<AddressDto> addresses = new TreeSet<>();
+    @Valid
     private SortedSet<SiteDto> sites = new TreeSet<>();
 
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/dto/SiteDto.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/dto/SiteDto.java
@@ -21,6 +21,7 @@
  */
 package org.eclipse.tractusx.puris.backend.masterdata.logic.dto;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import lombok.*;
 import org.eclipse.tractusx.puris.backend.common.util.PatternStore;
@@ -38,6 +39,7 @@ public class SiteDto implements Comparable<SiteDto> {
     private String bpns;
     @Pattern(regexp = PatternStore.NON_EMPTY_NON_VERTICAL_WHITESPACE_STRING)
     private String name;
+    @Valid
     private Set<AddressDto> addresses = new HashSet<>();
 
     @Override

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/ItemStockRequestMessageDto.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/ItemStockRequestMessageDto.java
@@ -20,6 +20,7 @@
 
 package org.eclipse.tractusx.puris.backend.stock.logic.dto;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
@@ -43,8 +44,10 @@ import java.util.UUID;
  */
 public class ItemStockRequestMessageDto {
     @NotNull
+    @Valid
     private HeaderDto header = new HeaderDto();
     @NotNull
+    @Valid
     private ContentDto content = new ContentDto();
 
     @Getter
@@ -76,6 +79,7 @@ public class ItemStockRequestMessageDto {
         @NotNull
         private DirectionCharacteristic direction;
         @NotNull
+        @Valid
         private List<RequestDto> itemStock = new ArrayList<>();
     }
     @Getter

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/ItemStockResponseDto.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/ItemStockResponseDto.java
@@ -20,6 +20,7 @@
 
 package org.eclipse.tractusx.puris.backend.stock.logic.dto;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
@@ -43,8 +44,10 @@ import java.util.UUID;
 public class ItemStockResponseDto {
 
     @NotNull
+    @Valid
     private HeaderDto header = new HeaderDto();
     @NotNull
+    @Valid
     private ContentDto content = new ContentDto();
 
     @Getter
@@ -75,6 +78,7 @@ public class ItemStockResponseDto {
     @Setter
     @ToString
     public static class ContentDto {
+        @Valid
         List<ItemStockSamm> itemStock = new ArrayList<>();
     }
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/ItemStockStatusRequestMessageDto.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/ItemStockStatusRequestMessageDto.java
@@ -20,6 +20,7 @@
 
 package org.eclipse.tractusx.puris.backend.stock.logic.dto;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
@@ -39,8 +40,10 @@ import java.util.UUID;
  */
 public class ItemStockStatusRequestMessageDto {
     @NotNull
+    @Valid
     private HeaderDto header = new HeaderDto();
     @NotNull
+    @Valid
     private Object content = new Object();
 
     @Getter

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/StockDto.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/StockDto.java
@@ -23,6 +23,7 @@ package org.eclipse.tractusx.puris.backend.stock.logic.dto;
 
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -46,6 +47,7 @@ public abstract class StockDto implements Serializable {
 
     private UUID uuid;
 
+    @Valid
     private MaterialDto material;
 
     private double quantity;

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/itemstocksamm/AllocatedStock.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/itemstocksamm/AllocatedStock.java
@@ -21,6 +21,7 @@ package org.eclipse.tractusx.puris.backend.stock.logic.dto.itemstocksamm;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
@@ -46,6 +47,7 @@ import java.util.Objects;
 public class AllocatedStock {
 
 	@NotNull
+    @Valid
 	private ItemQuantityEntity quantityOnAllocatedStock;
 
 	@NotNull

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/itemstocksamm/ItemStockSamm.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/itemstocksamm/ItemStockSamm.java
@@ -21,6 +21,7 @@ package org.eclipse.tractusx.puris.backend.stock.logic.dto.itemstocksamm;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
@@ -44,6 +45,7 @@ import java.util.Objects;
 public class ItemStockSamm {
 
     @NotNull
+    @Valid
     private List<Position> positions;
 
     @NotNull

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/itemstocksamm/Position.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/itemstocksamm/Position.java
@@ -21,6 +21,7 @@ package org.eclipse.tractusx.puris.backend.stock.logic.dto.itemstocksamm;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -50,6 +51,7 @@ public class Position {
 	private Date lastUpdatedOnDateTime;
 
 	@NotNull
+    @Valid
 	private List<AllocatedStock> allocatedStocks;
 
 	@JsonCreator

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/itemstocksamm/Position.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/dto/itemstocksamm/Position.java
@@ -45,6 +45,7 @@ import java.util.Objects;
 @NoArgsConstructor
 @ToString
 public class Position {
+    @Valid
 	private OrderPositionReference orderPositionReference;
 
     @NotNull

--- a/backend/src/test/java/org/eclipse/tractusx/puris/backend/masterdata/domain/model/PartnerTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/puris/backend/masterdata/domain/model/PartnerTest.java
@@ -46,7 +46,7 @@ public class PartnerTest {
     @Test
     public void test_invalidPartnerName() {
         Partner partner = new Partner("Invalid\nName", "https://www.example.com", "BPNL1234567890LE",
-            "BPNS123456780LE", "Site A", "BPNA1234567890LE", "123 Main St", "12345 New York", "USA");
+            "BPNS1234567890LE", "Site A", "BPNA1234567890LE", "123 Main St", "12345 New York", "USA");
 
         Set<ConstraintViolation<Partner>> violations = validator.validate(partner);
 


### PR DESCRIPTION
 I noticed that some of our dto and entity classes are missing an @Valid annotation. This annotation is necessary, because without it, the validator will not inspect the nested objects. 

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
