### PR TITLE
fix(frontend/Dockerfile): enhanced permissions for nginx.conf substitution

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -57,7 +57,7 @@ ENV JSFOLDER=/usr/share/nginx/html/assets/*.js
 USER root
 
 COPY ./nginx.conf /etc/nginx/nginx.conf
-RUN chmod 117 /etc/nginx/nginx.conf
+RUN chmod 777 /etc/nginx/nginx.conf
 COPY ./start-nginx.sh /usr/bin/start-nginx.sh
 RUN apk --no-cache add moreutils
 


### PR DESCRIPTION
## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

When checking the #255 the nginx.conf substitution for rate limitting had problems due to permissions.

Tested together with @f-zimmer. Problem did not occure anymore but we wanted to make sure it works with 777 rights instead of 117.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
