### PR TITLE
ci(frontend/Dockerfile): change from stable-alpine to alpine for nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ The project is made of a backend and a frontend. Look into the respective folder
 information about prerequirements and getting started guides.
 
 ## License
+
 The project is licensed under the [Apache License Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).
 For details on the licensing terms, see the `LICENSE` file.
 
 ## Notice for Docker Image
+
 This application provides container images for demonstration purposes.
 
 Eclipse Tractus-X product(s) installed within the image:
@@ -25,15 +27,20 @@ Eclipse Tractus-X product(s) installed within the image:
 - Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/puris/blob/main/LICENSE)
 
 **Used Base Image [Frontend]**
-- `node:lts-alpine`
-- DockerHub: https://hub.docker.com/_/node/
-- GitHub project: https://github.com/nodejs/docker-node
+
+`nginxinc/nginx-unprivileged:alpine`
+
+- DockerHub: https://hub.docker.com/r/nginxinc/nginx-unprivileged
+- GitHub project: https://github.com/nginxinc/docker-nginx-unprivileged
 
 **Used Base Image [Backend]**
-- `maven:3.8.7-eclipse-temurin-17`
-- DockerHub: https://hub.docker.com/_/maven/
-- GitHub project: https://github.com/carlossg/docker-maven
+`eclipse-temurin:17-jre-alpine`
 
-As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+- DockerHub: https://hub.docker.com/_/eclipse-temurin
+- GitHub project: https://github.com/adoptium/containers
 
-As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.
+As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc
+from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies
+with any relevant licenses for all software contained within.

--- a/backend/README.md
+++ b/backend/README.md
@@ -4,12 +4,13 @@
 </div>
 
 ## Table of Contents
+
 - [Prerequirements](#prerequirements)
 - [Getting Started](#getting-started)
 - [License](#license)
 
-
 ## Prerequirements
+
 The following things are needed to start PURIS:
 
 - A Java Runtime Environment + Maven or an equivalent Docker setup
@@ -21,10 +22,12 @@ The following things are needed to start PURIS:
 See the [installation instructions](INSTALL.md) for information on how to start the application.
 
 ## License
+
 The project is licensed under the [Apache License Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).
 For details on the licensing terms, see the `LICENSE` file.
 
 ## Notice for Docker Image
+
 This application provides container images for demonstration purposes.
 
 Eclipse Tractus-X product(s) installed within the image:
@@ -34,12 +37,14 @@ Eclipse Tractus-X product(s) installed within the image:
 - Dockerfile Backend: https://github.com/eclipse-tractusx/puris/blob/main/backend/Dockerfile
 - Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/puris/blob/main/backend/LICENSE)
 
-
 **Used Base Image [Backend]**
-- `maven:3.8.7-eclipse-temurin-17`
-- DockerHub: https://hub.docker.com/_/maven/
-- GitHub project: https://github.com/carlossg/docker-maven
+`eclipse-temurin:17-jre-alpine`
 
-As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+- DockerHub: https://hub.docker.com/_/eclipse-temurin
+- GitHub project: https://github.com/adoptium/containers
 
-As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.
+As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc
+from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies
+with any relevant licenses for all software contained within.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
 #
-# Copyright (c) 2022,2023 Volkswagen AG
-# Copyright (c) 2022,2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
-# Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2022-2024 Volkswagen AG
+# Copyright (c) 2022-2024 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
+# Copyright (c) 2022-2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -47,7 +47,7 @@ COPY NOTICE.md /app/dist/NOTICE.md
 COPY DEPENDENCIES /app/dist/DEPENDENCIES
 
 # uses 101 restricted user
-FROM nginxinc/nginx-unprivileged:stable-alpine
+FROM nginxinc/nginx-unprivileged:alpine
 #FROM nginx:stable-alpine
 
 # commly it would be .../html/js/.*js, but due to the project structure the JS files are in .../html/assets

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -64,6 +64,8 @@ RUN apk --no-cache add moreutils
 # use non-root user
 USER 101
 
+HEALTHCHECK --interval=30s --timeout=3s  CMD wget -O /dev/null http://localhost:8080 || exit 1
+
 WORKDIR /usr/share/nginx/html
 COPY --from=build /app/dist .
 ENTRYPOINT [ "start-nginx.sh" ]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -4,12 +4,13 @@
 </div>
 
 ## Table of Contents
+
 - [Prerequirements](#prerequirements)
 - [Getting Started](#getting-started)
 - [License](#license)
 
-
 ## Prerequirements
+
 The following things are needed to start PURIS:
 
 - `npm` or an equivalent Docker setup
@@ -20,10 +21,12 @@ The following things are needed to start PURIS:
 See the [installation instructions](INSTALL.md) for information on how to start the application.
 
 ## License
+
 The project is licensed under the [Apache License Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).
 For details on the licensing terms, see the `LICENSE` file.
 
 ## Notice for Docker Image
+
 This application provides container images for demonstration purposes.
 
 Eclipse Tractus-X product(s) installed within the image:
@@ -34,10 +37,18 @@ Eclipse Tractus-X product(s) installed within the image:
 - Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/puris/blob/main/frontend/LICENSE)
 
 **Used Base Image [Frontend]**
-- `node:lts-alpine`
+`node:lts-alpine`
+
 - DockerHub: https://hub.docker.com/_/node/
 - GitHub project: https://github.com/nodejs/docker-node
 
-As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+`nginxinc/nginx-unprivileged:alpine`
 
-As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.
+- DockerHub: https://hub.docker.com/r/nginxinc/nginx-unprivileged
+- GitHub project: https://github.com/nginxinc/docker-nginx-unprivileged
+
+As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc
+from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies
+with any relevant licenses for all software contained within.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -37,11 +37,6 @@ Eclipse Tractus-X product(s) installed within the image:
 - Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/puris/blob/main/frontend/LICENSE)
 
 **Used Base Image [Frontend]**
-`node:lts-alpine`
-
-- DockerHub: https://hub.docker.com/_/node/
-- GitHub project: https://github.com/nodejs/docker-node
-
 `nginxinc/nginx-unprivileged:alpine`
 
 - DockerHub: https://hub.docker.com/r/nginxinc/nginx-unprivileged


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Move from stable-alpine to common alpine image as stated in TRG 4.06. Also updated docker notice.

Added Healthcheck for Frontend Dockerfile

Updated Docker Notices / Readmes

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
