### PR TITLE
ci(frontend/Dockerfile): removed sponge from base image

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -23,9 +23,6 @@ FROM node:lts-alpine as build
 ARG NPM_BUILD_MODE=dockerbuild
 ENV JQ_VERSION=1.6
 
-# TODO curl results in problem with node during ```npm run ${NPM_BUILD_MODE}```
-#RUN apk --no-cache add curl
-#RUN curl https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 -o /tmp/jq-linux64
 RUN wget --no-check-certificate https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64 -O /tmp/jq-linux64
 RUN cp /tmp/jq-linux64 /usr/bin/jq
 RUN chmod +x /usr/bin/jq
@@ -59,7 +56,6 @@ USER root
 COPY ./nginx.conf /etc/nginx/nginx.conf
 RUN chmod 777 /etc/nginx/nginx.conf
 COPY ./start-nginx.sh /usr/bin/start-nginx.sh
-RUN apk --no-cache add moreutils
 
 # use non-root user
 USER 101

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,7 @@
 #
-# Copyright (c) 2022-2024 Volkswagen AG
-# Copyright (c) 2022-2024 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
-# Copyright (c) 2022-2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2022,2024 Volkswagen AG
+# Copyright (c) 2022,2024 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
+# Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/frontend/start-nginx.sh
+++ b/frontend/start-nginx.sh
@@ -9,16 +9,27 @@ echo "==============="
 
 for file in $JSFOLDER;
 do
-  echo -e "\r\n"
-  echo $file
+  echo "Substitute environment variables in $file"
 
-  # other command cuts off length of files. sponge has no file-size limitation.
-  #cat $file | envsubst $EXISTING_VARS | tee $file
-  #envsubst $EXISTING_VARS < $file | tee $file
-  envsubst $EXISTING_VARS < $file | sponge $file
+  tmp_file="$file.tmp"
+  echo "envsubstitute $file to $tmp_file"
+  envsubst $EXISTING_VARS < $file > $tmp_file
+
+  echo "replace file ($file) by tmp file ($tmp_file)"
+  rm $file
+  mv $tmp_file $file
+
   echo -e "\r\n"
 done
 
-envsubst $EXISTING_VARS < /etc/nginx/nginx.conf | sponge /etc/nginx/nginx.conf
+nginx_conf="/etc/nginx/nginx.conf"
+tmp_nginx_conf="$nginx_conf.tmp"
+
+echo "envsubstitute $nginx_conf to $tmp_file"
+envsubst $EXISTING_VARS < $nginx_conf > $tmp_nginx_conf
+
+echo "replace config ($nginx_conf) by tmp file ($tmp_nginx_conf)"
+rm $nginx_conf
+mv $tmp_nginx_conf $nginx_conf
 
 nginx -g 'daemon off;'

--- a/frontend/start-nginx.sh
+++ b/frontend/start-nginx.sh
@@ -1,3 +1,22 @@
+#
+# Copyright (c) 2023,2024 Volkswagen AG
+# Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 #!/usr/bin/env sh
 echo "Starting NGINX"
 export EXISTING_VARS=$(printenv | awk -F= '{print $1}' | sed 's/^/\$/g' | paste -sd,);


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Per [TRG 4.02](https://eclipse-tractusx.github.io/docs/release/trg-4/trg-4-02) no additional packages should be installed. @tomaszbarwicki provided workaround ideas that have been incorporated.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
