### PR TITLE
chore: extracted docker notice to separate files (TRG 4.06)

### DIFF
--- a/.github/workflows/build-image-backend.yml
+++ b/.github/workflows/build-image-backend.yml
@@ -24,70 +24,70 @@
 name: Build - Docker image Backend (SemVer)
 
 on:
-  push:
-    branches:
-      - main
-    # trigger events for SemVer like tags
-    tags:
-      - 'v*.*.*'
-      - 'v*.*.*-*'
-  pull_request:
-    branches:
-      - main
+    push:
+        branches:
+            - main
+        # trigger events for SemVer like tags
+        tags:
+            - 'v*.*.*'
+            - 'v*.*.*-*'
+    pull_request:
+        branches:
+            - main
 
 env:
-  IMAGE_NAMESPACE: "tractusx"
-  IMAGE_NAME: "app-puris-backend"
+    IMAGE_NAMESPACE: "tractusx"
+    IMAGE_NAME: "app-puris-backend"
 
 jobs:
-  docker:
-    if: github.repository_owner == 'eclipse-tractusx' # prevent running on forks
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
+    docker:
+        if: github.repository_owner == 'eclipse-tractusx' # prevent running on forks
+        runs-on: ubuntu-latest
+        permissions:
+            packages: write
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      # Create SemVer or ref tags dependent of trigger event
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0
-        with:
-          images: |
-            ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
-          tags: |
-            # set latest tag for main branch
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }},event=pr
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}
-            type=semver,pattern={{major}}.{{minor}}
+            # Create SemVer or ref tags dependent of trigger event
+            -   name: Docker meta
+                id: meta
+                uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0
+                with:
+                    images: |
+                        ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+                    tags: |
+                        # set latest tag for main branch
+                        type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }},event=pr
+                        type=ref,event=branch
+                        type=ref,event=pr
+                        type=semver,pattern={{version}}
+                        type=semver,pattern={{major}}
+                        type=semver,pattern={{major}}.{{minor}}
 
-      - name: DockerHub login
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3
-        with:
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+            -   name: DockerHub login
+                if: github.event_name != 'pull_request'
+                uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3
+                with:
+                    username: ${{ secrets.DOCKER_HUB_USER }}
+                    password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      - name: Build and push
-        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 #v5.1
-        with:
-          context: ./backend
-          file: ./backend/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+            -   name: Build and push
+                uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 #v5.1
+                with:
+                    context: ./backend
+                    file: ./backend/Dockerfile
+                    push: ${{ github.event_name != 'pull_request' }}
+                    tags: ${{ steps.meta.outputs.tags }}
+                    labels: ${{ steps.meta.outputs.labels }}
 
-      # https://github.com/peter-evans/dockerhub-description
-      - name: Update Docker Hub description
-        if: github.event_name != 'pull_request'
-        uses: peter-evans/dockerhub-description@dc67fad7001ef9e8e3c124cb7a64e16d0a63d864 #v3.4.2
-        with:
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-          repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
-          readme-filepath: ./backend/README.md
+            # https://github.com/peter-evans/dockerhub-description
+            -   name: Update Docker Hub description
+                if: github.event_name != 'pull_request'
+                uses: peter-evans/dockerhub-description@dc67fad7001ef9e8e3c124cb7a64e16d0a63d864 #v3.4.2
+                with:
+                    username: ${{ secrets.DOCKER_HUB_USER }}
+                    password: ${{ secrets.DOCKER_HUB_TOKEN }}
+                    repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+                    readme-filepath: ./backend/DOCKER_NOTICE.md

--- a/.github/workflows/build-image-frontend.yml
+++ b/.github/workflows/build-image-frontend.yml
@@ -24,70 +24,70 @@
 name: Build - Docker image Frontend (SemVer)
 
 on:
-  push:
-    branches:
-      - main
-    # trigger events for SemVer like tags
-    tags:
-      - 'v*.*.*'
-      - 'v*.*.*-*'
-  pull_request:
-    branches:
-      - main
+    push:
+        branches:
+            - main
+        # trigger events for SemVer like tags
+        tags:
+            - 'v*.*.*'
+            - 'v*.*.*-*'
+    pull_request:
+        branches:
+            - main
 
 env:
-  IMAGE_NAMESPACE: "tractusx"
-  IMAGE_NAME: "app-puris-frontend"
+    IMAGE_NAMESPACE: "tractusx"
+    IMAGE_NAME: "app-puris-frontend"
 
 jobs:
-  docker:
-    if: github.repository_owner == 'eclipse-tractusx' # prevent running on forks
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
+    docker:
+        if: github.repository_owner == 'eclipse-tractusx' # prevent running on forks
+        runs-on: ubuntu-latest
+        permissions:
+            packages: write
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      # Create SemVer or ref tags dependent of trigger event
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0
-        with:
-          images: |
-            ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
-          tags: |
-            # set latest tag for main branch
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }},event=pr
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}
-            type=semver,pattern={{major}}.{{minor}}
+            # Create SemVer or ref tags dependent of trigger event
+            -   name: Docker meta
+                id: meta
+                uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0
+                with:
+                    images: |
+                        ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+                    tags: |
+                        # set latest tag for main branch
+                        type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }},event=pr
+                        type=ref,event=branch
+                        type=ref,event=pr
+                        type=semver,pattern={{version}}
+                        type=semver,pattern={{major}}
+                        type=semver,pattern={{major}}.{{minor}}
 
-      - name: DockerHub login
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3
-        with:
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+            -   name: DockerHub login
+                if: github.event_name != 'pull_request'
+                uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3
+                with:
+                    username: ${{ secrets.DOCKER_HUB_USER }}
+                    password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      - name: Build and push
-        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 #v5.1
-        with:
-          context: ./frontend
-          file: ./frontend/Dockerfile
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+            -   name: Build and push
+                uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 #v5.1
+                with:
+                    context: ./frontend
+                    file: ./frontend/Dockerfile
+                    push: ${{ github.event_name != 'pull_request' }}
+                    tags: ${{ steps.meta.outputs.tags }}
+                    labels: ${{ steps.meta.outputs.labels }}
 
-      # https://github.com/peter-evans/dockerhub-description
-      - name: Update Docker Hub description
-        if: github.event_name != 'pull_request'
-        uses: peter-evans/dockerhub-description@dc67fad7001ef9e8e3c124cb7a64e16d0a63d864 #v3.4.2
-        with:
-          username: ${{ secrets.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
-          repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
-          readme-filepath: ./frontend/README.md
+            # https://github.com/peter-evans/dockerhub-description
+            -   name: Update Docker Hub description
+                if: github.event_name != 'pull_request'
+                uses: peter-evans/dockerhub-description@dc67fad7001ef9e8e3c124cb7a64e16d0a63d864 #v3.4.2
+                with:
+                    username: ${{ secrets.DOCKER_HUB_USER }}
+                    password: ${{ secrets.DOCKER_HUB_TOKEN }}
+                    repository: ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
+                    readme-filepath: ./frontend/DOCKER_NOTICE.md

--- a/README.md
+++ b/README.md
@@ -15,32 +15,7 @@ For details on the licensing terms, see the `LICENSE` file.
 
 ## Notice for Docker Image
 
-This application provides container images for demonstration purposes.
+Below you can find the information regarding Docker Notice for this frontend.
 
-Eclipse Tractus-X product(s) installed within the image:
-
-- GitHub: https://github.com/eclipse-tractusx/puris
-- Project home: https://projects.eclipse.org/projects/automotive.tractusx
-- Dockerfiles:
-    - Frontend: https://github.com/eclipse-tractusx/puris/blob/main/frontend/Dockerfile
-    - Backend: https://github.com/eclipse-tractusx/puris/blob/main/backend/Dockerfile
-- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/puris/blob/main/LICENSE)
-
-**Used Base Image [Frontend]**
-
-`nginxinc/nginx-unprivileged:alpine`
-
-- DockerHub: https://hub.docker.com/r/nginxinc/nginx-unprivileged
-- GitHub project: https://github.com/nginxinc/docker-nginx-unprivileged
-
-**Used Base Image [Backend]**
-`eclipse-temurin:17-jre-alpine`
-
-- DockerHub: https://hub.docker.com/_/eclipse-temurin
-- GitHub project: https://github.com/adoptium/containers
-
-As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc
-from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
-
-As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies
-with any relevant licenses for all software contained within.
+- [Frontend](./frontend/DOCKER_NOTICE.md)
+- [Backend](./backend/DOCKER_NOTICE.md)

--- a/backend/DOCKER_NOTICE.md
+++ b/backend/DOCKER_NOTICE.md
@@ -1,0 +1,20 @@
+This application provides container images for demonstration purposes.
+
+Eclipse Tractus-X product(s) installed within the image:
+
+- GitHub: https://github.com/eclipse-tractusx/puris
+- Project home: https://projects.eclipse.org/projects/automotive.tractusx
+- Dockerfile Backend: https://github.com/eclipse-tractusx/puris/blob/main/backend/Dockerfile
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/puris/blob/main/backend/LICENSE)
+
+**Used Base Image [Backend]**
+`eclipse-temurin:17-jre-alpine`
+
+- DockerHub: https://hub.docker.com/_/eclipse-temurin
+- GitHub project: https://github.com/adoptium/containers
+
+As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc
+from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies
+with any relevant licenses for all software contained within.

--- a/backend/README.md
+++ b/backend/README.md
@@ -28,23 +28,6 @@ For details on the licensing terms, see the `LICENSE` file.
 
 ## Notice for Docker Image
 
-This application provides container images for demonstration purposes.
+Below you can find the information regarding Docker Notice for this frontend.
 
-Eclipse Tractus-X product(s) installed within the image:
-
-- GitHub: https://github.com/eclipse-tractusx/puris
-- Project home: https://projects.eclipse.org/projects/automotive.tractusx
-- Dockerfile Backend: https://github.com/eclipse-tractusx/puris/blob/main/backend/Dockerfile
-- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/puris/blob/main/backend/LICENSE)
-
-**Used Base Image [Backend]**
-`eclipse-temurin:17-jre-alpine`
-
-- DockerHub: https://hub.docker.com/_/eclipse-temurin
-- GitHub project: https://github.com/adoptium/containers
-
-As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc
-from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
-
-As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies
-with any relevant licenses for all software contained within.
+[Backend](./DOCKER_NOTICE.md)

--- a/frontend/DOCKER_NOTICE.md
+++ b/frontend/DOCKER_NOTICE.md
@@ -1,0 +1,20 @@
+This application provides container images for demonstration purposes.
+
+Eclipse Tractus-X product(s) installed within the image:
+
+- GitHub: https://github.com/eclipse-tractusx/puris
+- Project home: https://projects.eclipse.org/projects/automotive.tractusx
+- Dockerfile Frontend: https://github.com/eclipse-tractusx/puris/blob/main/frontend/Dockerfile
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/puris/blob/main/frontend/LICENSE)
+
+**Used Base Image [Frontend]**
+`nginxinc/nginx-unprivileged:alpine`
+
+- DockerHub: https://hub.docker.com/r/nginxinc/nginx-unprivileged
+- GitHub project: https://github.com/nginxinc/docker-nginx-unprivileged
+
+As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc
+from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies
+with any relevant licenses for all software contained within.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -27,23 +27,6 @@ For details on the licensing terms, see the `LICENSE` file.
 
 ## Notice for Docker Image
 
-This application provides container images for demonstration purposes.
+Below you can find the information regarding Docker Notice for this frontend.
 
-Eclipse Tractus-X product(s) installed within the image:
-
-- GitHub: https://github.com/eclipse-tractusx/puris
-- Project home: https://projects.eclipse.org/projects/automotive.tractusx
-- Dockerfile Frontend: https://github.com/eclipse-tractusx/puris/blob/main/frontend/Dockerfile
-- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/puris/blob/main/frontend/LICENSE)
-
-**Used Base Image [Frontend]**
-`nginxinc/nginx-unprivileged:alpine`
-
-- DockerHub: https://hub.docker.com/r/nginxinc/nginx-unprivileged
-- GitHub project: https://github.com/nginxinc/docker-nginx-unprivileged
-
-As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc
-from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
-
-As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies
-with any relevant licenses for all software contained within.
+[Frontend](./DOCKER_NOTICE.md)


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

solves #264 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
