### PR TITLE
ci(docker): use semver tag without v prefix

### DIFF
--- a/.github/workflows/build-image-backend.yml
+++ b/.github/workflows/build-image-backend.yml
@@ -29,8 +29,8 @@ on:
             - main
         # trigger events for SemVer like tags
         tags:
-            - 'v*.*.*'
-            - 'v*.*.*-*'
+            - '*.*.*'
+            - '*.*.*-*'
     pull_request:
         branches:
             - main

--- a/.github/workflows/build-image-frontend.yml
+++ b/.github/workflows/build-image-frontend.yml
@@ -29,8 +29,8 @@ on:
             - main
         # trigger events for SemVer like tags
         tags:
-            - 'v*.*.*'
-            - 'v*.*.*-*'
+            - '*.*.*'
+            - '*.*.*-*'
     pull_request:
         branches:
             - main


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
Commonly release versions don't use the v prefix. Removed that from the publish workflow for docker.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
