### PR TITLE
fix: helm test upgrade action

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -117,7 +117,7 @@ jobs:
             -   name: Run helm upgrade
                 run: |
                     helm repo add bitnami https://charts.bitnami.com/bitnami
-                    helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/
+                    helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
                     helm install puris tractusx-dev/puris --version ${{ github.event.inputs.upgrade_from || '1.0.0' }}
                     helm dependency update charts/puris
                     helm upgrade puris charts/puris


### PR DESCRIPTION
Fix the 404 issue of the upgrade action at helm test workflow:

<img width="1157" alt="image" src="https://github.com/eclipse-tractusx/puris/assets/7613143/af417b26-83ef-4616-94b6-94934c81af87">
