### PR TITLE
Feat: updated miw to 0.4.0

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/ddtr/logic/util/DtrRequestBodyBuilder.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/ddtr/logic/util/DtrRequestBodyBuilder.java
@@ -89,7 +89,7 @@ public class DtrRequestBodyBuilder {
 
         var itemStockRequestSubmodelObject = createItemStockSubmodelObject();
         submodelDescriptorsArray.add(itemStockRequestSubmodelObject);
-        log.info("Created body for material " + material.getOwnMaterialNumber() + "\n" + body.toPrettyString());
+        log.debug("Created body for material " + material.getOwnMaterialNumber() + "\n" + body.toPrettyString());
         return body;
     }
 
@@ -131,7 +131,7 @@ public class DtrRequestBodyBuilder {
         var itemStockRequestSubmodelObject = createItemStockSubmodelObject();
         submodelDescriptorsArray.add(itemStockRequestSubmodelObject);
 
-        log.info("Created body for product " + material.getOwnMaterialNumber() + "\n" + body.toPrettyString());
+        log.debug("Created body for product " + material.getOwnMaterialNumber() + "\n" + body.toPrettyString());
         return body;
     }
 

--- a/local/docker-compose-infrastructure.yaml
+++ b/local/docker-compose-infrastructure.yaml
@@ -20,67 +20,67 @@
 version: "3"
 
 services:
-    miw:
-        image: tractusx/managed-identity-wallet:0.2.0
-        container_name: miw
-        env_file:
-            - ./miw/infrastructure.properties
-        ports:
-            - "127.0.0.1:8000:80"
-            - "127.0.0.1:8090:8090"
-        networks:
-            - miw-net
+  miw:
+    image: tractusx/managed-identity-wallet:0.4.0
+    container_name: miw
+    env_file:
+      - ./miw/infrastructure.properties
+    ports:
+      - "127.0.0.1:8000:80"
+      - "127.0.0.1:8090:8090"
+    networks:
+      - miw-net
 
-    postgres:
-        image: postgres:15.4-alpine
-        container_name: postgres-miw
-        environment:
-            POSTGRES_DB: edc
-            POSTGRES_USER: ${PG_USER}
-            POSTGRES_PASSWORD: ${PG_PW}
-        volumes:
-            # use docker-compose down --volumes to kill db volume
-            # only then, changes to the script are executed!
-            - ./postgres/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql
-        ports:
-            - "127.0.0.1:5432:5432"
-        networks:
-            - miw-net
+  postgres:
+    image: postgres:15.4-alpine
+    container_name: postgres-miw
+    environment:
+      POSTGRES_DB: edc
+      POSTGRES_USER: ${PG_USER}
+      POSTGRES_PASSWORD: ${PG_PW}
+    volumes:
+      # use docker-compose down --volumes to kill db volume
+      # only then, changes to the script are executed!
+      - ./postgres/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql
+    ports:
+      - "127.0.0.1:5432:5432"
+    networks:
+      - miw-net
 
-    keycloak:
-        image: quay.io/keycloak/keycloak:21.1
-        env_file:
-            - ./miw/infrastructure.properties
-        environment:
-            DB_SCHEMA: public
-        command:
-            - start-dev
-            - --import-realm
-        volumes:
-            - ./miw/keycloak-setup.json:/opt/keycloak/data/import/miw_test_realm.json
-        ports:
-            - "127.0.0.1:8080:8080"
-        depends_on:
-            - postgres
-        networks:
-            - miw-net
-    vault:
-        build: ./vault
-        container_name: vault
-        ports:
-            - "127.0.0.1:8200:8200"
-        environment:
-            # token id may not contain prefix
-            VAULT_DEV_ROOT_TOKEN_ID: ${VAULT_DEV_ROOT_TOKEN_ID}
-            VAULT_ADDR: http://vault:8200
-            VAULT_PUT_SECRETS_DIR: ${VAULT_SECRETS_DIR}
-            # ATTENTION: Non productive environment
-            SKIP_SETCAP: true
-            SKIP_CHOWN: true
-        volumes:
-            - ./vault/secrets:${VAULT_SECRETS_DIR}
-        networks:
-            - miw-net
+  keycloak:
+    image: quay.io/keycloak/keycloak:21.1
+    env_file:
+      - ./miw/infrastructure.properties
+    environment:
+      DB_SCHEMA: public
+    command:
+      - start-dev
+      - --import-realm
+    volumes:
+      - ./miw/keycloak-setup.json:/opt/keycloak/data/import/miw_test_realm.json
+    ports:
+      - "127.0.0.1:8080:8080"
+    depends_on:
+      - postgres
+    networks:
+      - miw-net
+  vault:
+    build: ./vault
+    container_name: vault
+    ports:
+      - "127.0.0.1:8200:8200"
+    environment:
+      # token id may not contain prefix
+      VAULT_DEV_ROOT_TOKEN_ID: ${VAULT_DEV_ROOT_TOKEN_ID}
+      VAULT_ADDR: http://vault:8200
+      VAULT_PUT_SECRETS_DIR: ${VAULT_SECRETS_DIR}
+      # ATTENTION: Non productive environment
+      SKIP_SETCAP: true
+      SKIP_CHOWN: true
+    volumes:
+      - ./vault/secrets:${VAULT_SECRETS_DIR}
+    networks:
+      - miw-net
 networks:
-    miw-net:
-        name: miw-net
+  miw-net:
+    name: miw-net


### PR DESCRIPTION
- updated MIW docker image in local deployment to 0.4.0, solving #186 
- adjusted logging output in DtrRequestBodyBuilder to "debug" level

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
