### PR TITLE
Feat/register parttype at edc

### DIFF
--- a/DEPENDENCIES_FRONTEND
+++ b/DEPENDENCIES_FRONTEND
@@ -283,7 +283,7 @@ npm/npmjs/@babel/highlight/7.23.4, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BS
 npm/npmjs/@babel/parser/7.23.6, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #10663
 npm/npmjs/@babel/plugin-transform-react-jsx-self/7.23.3, MIT, approved, clearlydefined
 npm/npmjs/@babel/plugin-transform-react-jsx-source/7.23.3, MIT, approved, clearlydefined
-npm/npmjs/@babel/runtime/7.24.0, MIT, approved, clearlydefined
+npm/npmjs/@babel/runtime/7.24.0, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #13900
 npm/npmjs/@babel/template/7.22.15, MIT, approved, #9017
 npm/npmjs/@babel/traverse/7.23.7, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #11520
 npm/npmjs/@babel/types/7.23.6, MIT AND (BSD-2-Clause AND ISC AND MIT) AND BSD-2-Clause AND BSD-3-Clause, approved, #11521

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/DataInjectionCommandLineRunner.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/DataInjectionCommandLineRunner.java
@@ -162,7 +162,7 @@ public class DataInjectionCommandLineRunner implements CommandLineRunner {
 
         MaterialPartnerRelation semiconductorPartnerRelation = new MaterialPartnerRelation(semiconductorMaterial,
             supplierPartner, semiconductorMatNbrSupplier, true, false);
-        semiconductorPartnerRelation.setPartnerCXNumber(semiconductorMatNbrCatenaX);
+//        semiconductorPartnerRelation.setPartnerCXNumber(semiconductorMatNbrCatenaX);
         mprService.create(semiconductorPartnerRelation);
         semiconductorPartnerRelation = mprService.find(semiconductorMaterial, supplierPartner);
         log.info("Found Relation: " + semiconductorPartnerRelation);
@@ -248,7 +248,7 @@ public class DataInjectionCommandLineRunner implements CommandLineRunner {
 
         MaterialPartnerRelation semiconductorPartnerRelation = new MaterialPartnerRelation(semiconductorMaterial,
             customerPartner, semiconductorMatNbrCustomer, false, true);
-        semiconductorPartnerRelation.setPartnerCXNumber(semiconductorMatNbrCatenaX);
+//        semiconductorPartnerRelation.setPartnerCXNumber(semiconductorMatNbrCatenaX);
         semiconductorPartnerRelation = mprService.create(semiconductorPartnerRelation);
 
         log.info("Created Relation " + semiconductorPartnerRelation);
@@ -411,7 +411,7 @@ public class DataInjectionCommandLineRunner implements CommandLineRunner {
     private Material getNewSemiconductorMaterialForCustomer() {
         Material material = new Material();
         material.setOwnMaterialNumber(semiconductorMatNbrCustomer);
-        material.setMaterialNumberCx(semiconductorMatNbrCatenaX);
+//        material.setMaterialNumberCx(semiconductorMatNbrCatenaX);
         material.setMaterialFlag(true);
         material.setName("Semiconductor");
         return material;

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/ddtr/logic/util/DtrRequestBodyBuilder.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/ddtr/logic/util/DtrRequestBodyBuilder.java
@@ -89,7 +89,7 @@ public class DtrRequestBodyBuilder {
 
         var itemStockRequestSubmodelObject = createItemStockSubmodelObject();
         submodelDescriptorsArray.add(itemStockRequestSubmodelObject);
-        log.info("Created body for material " + material.getOwnMaterialNumber() + "\n" + body.toPrettyString());
+        log.debug("Created body for material " + material.getOwnMaterialNumber() + "\n" + body.toPrettyString());
         return body;
     }
 
@@ -131,7 +131,7 @@ public class DtrRequestBodyBuilder {
         var itemStockRequestSubmodelObject = createItemStockSubmodelObject();
         submodelDescriptorsArray.add(itemStockRequestSubmodelObject);
 
-        log.info("Created body for product " + material.getOwnMaterialNumber() + "\n" + body.toPrettyString());
+        log.debug("Created body for product " + material.getOwnMaterialNumber() + "\n" + body.toPrettyString());
         return body;
     }
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
@@ -513,7 +513,9 @@ public class EdcAdapterService {
                 if (dctTypeObject != null) {
                     if (("https://w3id.org/catenax/taxonomy#Submodel").equals(dctTypeObject.get("@id").asText())) {
                         if ("3.0".equals(entry.get("https://w3id.org/catenax/ontology/common#version").asText())) {
-                            if ("urn:samm:io.catenax.part_type_information:1.0.0#PartTypeInformation".equals(entry.get("aas-semantics:semanticId.@id").asText())) {
+                            var semanticId = entry.get("aas-semantics:semanticId");
+                            String idString = semanticId.get("@id").asText();
+                            if ("urn:samm:io.catenax.part_type_information:1.0.0#PartTypeInformation".equals(idString)) {
                                 if (targetCatalogEntry == null) {
                                     if (variablesService.isUseFrameworkPolicy()) {
                                         if (testFrameworkAgreementConstraint(entry)) {

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
@@ -139,6 +139,8 @@ public class EdcAdapterService {
     public boolean createPolicyAndContractDefForPartner(Partner partner) {
         boolean result = createPolicyDefinitionForPartner(partner);
         result &= createDtrContractDefinitionForPartner(partner);
+        result &= registerPartTypeAssetForPartner(partner);
+        result &= createPartTypeInfoContractDefForPartner(partner);
         result &= createContractDefinitionForPartner(partner, DT_ApiMethodEnum.REQUEST);
         result &= createContractDefinitionForPartner(partner, DT_ApiMethodEnum.STATUS_REQUEST);
         return result & createContractDefinitionForPartner(partner, DT_ApiMethodEnum.RESPONSE);
@@ -182,6 +184,21 @@ public class EdcAdapterService {
             return true;
         } catch (Exception e) {
             log.error("Contract definition registration failed for partner " + partner.getBpnl() + " and DTR", e);
+            return false;
+        }
+    }
+
+    private boolean createPartTypeInfoContractDefForPartner(Partner partner) {
+        var body = edcRequestBodyBuilder.buildPartTypeInfoContractDefinitionForPartner(partner);
+        try (var response = sendPostRequest(body, List.of("v2", "contractdefinitions"))) {
+            if (!response.isSuccessful()) {
+                log.warn("Contract definition registration failed for partner " + partner.getBpnl() + " and PartTypeInfo asset");
+                return false;
+            }
+            log.info("Contract definition successful for PartTypeAsset and partner " + partner.getBpnl());
+            return true;
+        } catch (Exception e) {
+            log.error("Contract definition registration failed for partner " + partner.getBpnl() + " and PartTypeInfo asset", e);
             return false;
         }
     }
@@ -242,10 +259,29 @@ public class EdcAdapterService {
                 if (response.body() != null) {
                     log.warn("Response: \n" + response.body().string());
                 }
+                return false;
             }
             return true;
         } catch (Exception e) {
             log.error("Failed to register DTR Asset", e);
+            return false;
+        }
+    }
+
+    private boolean registerPartTypeAssetForPartner(Partner partner) {
+        var body = edcRequestBodyBuilder.buildPartTypeInfoRegistrationBody(partner);
+        try (var response = sendPostRequest(body, List.of("v3", "assets"))) {
+            if (!response.isSuccessful()) {
+                log.warn("Asset registration failed for PartTypeAsset and partner " + partner.getBpnl());
+                if (response.body() != null) {
+                    log.warn("Response: \n" + response.body().string());
+                }
+                return false;
+            }
+            log.info("Asset registration successful for PartTypeAsset and partner " + partner.getBpnl());
+            return true;
+        } catch (Exception e) {
+            log.error("Failed to register PartTypeAsset for partner " + partner.getBpnl());
             return false;
         }
     }
@@ -277,11 +313,12 @@ public class EdcAdapterService {
     /**
      * Retrieve the response to an unfiltered catalog request from the partner
      * with the given dspUrl
-     * @param dspUrl    The dspUrl of your partner
-     * @return          The response containing the full catalog, if successful
+     *
+     * @param dspUrl The dspUrl of your partner
+     * @return The response containing the full catalog, if successful
      */
     public Response getCatalogResponse(String dspUrl) throws IOException {
-         return sendPostRequest(edcRequestBodyBuilder.buildBasicCatalogRequestBody(dspUrl, null), List.of("v2", "catalog", "request"));
+        return sendPostRequest(edcRequestBodyBuilder.buildBasicCatalogRequestBody(dspUrl, null), List.of("v2", "catalog", "request"));
     }
 
     /**
@@ -429,6 +466,113 @@ public class EdcAdapterService {
         } catch (Exception e) {
             log.error("Failed to send Proxy Pull request to " + url, e);
             throw new RuntimeException(e);
+        }
+    }
+
+    public Response getProxyPullRequest(String url, String authKey, String authCode, String[] pathParams) {
+        HttpUrl.Builder urlBuilder = HttpUrl.parse(url).newBuilder();
+        for (var pathSegment : pathParams) {
+            urlBuilder.addPathSegment(pathSegment);
+        }
+        try {
+            var request = new Request.Builder()
+                .get()
+                .url(urlBuilder.build())
+                .header(authKey, authCode)
+                .build();
+            return CLIENT.newCall(request).execute();
+        } catch (Exception e) {
+            log.error("ProxyPull GET Request failed ", e);
+            return null;
+        }
+    }
+
+    /**
+     * Tries to negotiate for the PartTypeInfo-Api with the given partner
+     * and also tries to initiate the transfer of the edr token to the given endpoint.
+     * <p>
+     * It will return a String array of length 4. The authKey is stored under index 0, the
+     * authCode under index 1, the endpoint under index 2 and the contractId under index 3.
+     *
+     * @param partner   the partner
+     * @return A String array or null, if negotiation or transfer have failed or the authCode did not arrive
+     */
+    public String[] getContractForPartTypeInfoApi(Partner partner) {
+        try {
+            var responseNode = getCatalog(partner.getEdcUrl());
+            var catalogArray = responseNode.get("dcat:dataset");
+            // If there is exactly one asset, the catalogContent will be a JSON object.
+            // In all other cases catalogContent will be a JSON array.
+            // For the sake of uniformity we will embed a single object in an array.
+            if (catalogArray.isObject()) {
+                catalogArray = objectMapper.createArrayNode().add(catalogArray);
+            }
+            JsonNode targetCatalogEntry = null;
+            for (var entry : catalogArray) {
+                var dctTypeObject = entry.get("dct:type");
+                if (dctTypeObject != null) {
+                    if (("https://w3id.org/catenax/taxonomy#UniqueIdPushConnectToParentNotification").equals(dctTypeObject.get("@id").asText())) {
+                        if ("2.0".equals(entry.get("https://w3id.org/catenax/ontology/common#version").asText())) {
+                            if (targetCatalogEntry == null) {
+                                targetCatalogEntry = entry;
+                            } else {
+                                log.warn("Ambiguous catalog entries found! \n" + catalogArray.toPrettyString());
+                            }
+                        }
+                    }
+                }
+            }
+            if (targetCatalogEntry == null) {
+                log.error("Could not find api asset for PartTypeInformation at partner " + partner.getBpnl() + " 's catalog");
+                return null;
+            }
+            String assetApiId = targetCatalogEntry.get("@id").asText();
+            JsonNode negotiationResponse = initiateNegotiation(partner, targetCatalogEntry);
+            String negotiationId = negotiationResponse.get("@id").asText();
+            // Await confirmation of contract and contractId
+            String contractId = null;
+            for (int i = 0; i < 100; i++) {
+                Thread.sleep(100);
+                var responseObject = getNegotiationState(negotiationId);
+                if ("FINALIZED".equals(responseObject.get("edc:state").asText())) {
+                    contractId = responseObject.get("edc:contractAgreementId").asText();
+                    break;
+                }
+            }
+            if (contractId == null) {
+                var negotiationState = getNegotiationState(negotiationId);
+                log.warn("no contract id, last negotiation state: \n" + negotiationState.toPrettyString());
+                log.error("Failed to obtain " + assetApiId + " from " + partner.getEdcUrl());
+                return null;
+            }
+
+            // Initiate transfer of edr
+            var transferResp = initiateProxyPullTransfer(partner, contractId, assetApiId);
+            String transferId = transferResp.get("@id").asText();
+            for (int i = 0; i < 100; i++) {
+                Thread.sleep(100);
+                transferResp = getTransferState(transferId);
+                if ("STARTED".equals(transferResp.get("edc:state").asText())) {
+                    break;
+                }
+            }
+
+            // Await arrival of edr
+            for (int i = 0; i < 100; i++) {
+                Thread.sleep(100);
+                EDR_Dto edr_Dto = edrService.findByTransferId(transferId);
+                if (edr_Dto != null) {
+                    log.info("Successfully negotiated for " + assetApiId + " with " + partner.getEdcUrl());
+                    return new String[]{edr_Dto.authKey(), edr_Dto.authCode(), edr_Dto.endpoint(), contractId};
+                }
+            }
+            log.warn("did not receive authCode");
+            log.error("Failed to obtain " + assetApiId + " from " + partner.getEdcUrl());
+            return null;
+
+        } catch (Exception e) {
+            log.error("Failed to get contract for PartTypeInfo api from " + partner.getBpnl(), e);
+            return null;
         }
     }
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/util/EdcRequestBodyBuilder.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/util/EdcRequestBodyBuilder.java
@@ -365,7 +365,9 @@ public class EdcRequestBodyBuilder {
         propertiesObject.set("dct:type", dctTypeObject);
         dctTypeObject.put("@id", CX_TAXO_NAMESPACE + "Submodel");
         propertiesObject.put("cx-common:version", "3.0");
-        propertiesObject.put("aas-semantics:semanticId.@id", "urn:samm:io.catenax.part_type_information:1.0.0#PartTypeInformation");
+        var semanticIdObject = MAPPER.createObjectNode();
+        propertiesObject.set("aas-semantics:semanticId", semanticIdObject);
+        semanticIdObject.put("@id", "urn:samm:io.catenax.part_type_information:1.0.0#PartTypeInformation");
         var dataAddress = MAPPER.createObjectNode();
         String url = variablesService.getParttypeInformationServerendpoint();
         if (!url.endsWith("/")) {

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/util/EdcRequestBodyBuilder.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/util/EdcRequestBodyBuilder.java
@@ -212,6 +212,20 @@ public class EdcRequestBodyBuilder {
         return body;
     }
 
+    public JsonNode buildPartTypeInfoContractDefinitionForPartner(Partner partner) {
+        var body = getEdcContextObject();
+        body.put("@id", partner.getBpnl() +"_contractdefinition_for_PartTypeInfoAsset");
+        body.put("accessPolicyId", getBpnPolicyId(partner));
+        body.put("contractPolicyId", getBpnPolicyId(partner));
+        var assetsSelector = MAPPER.createObjectNode();
+        body.set("assetsSelector", assetsSelector);
+        assetsSelector.put("@type", "CriterionDto");
+        assetsSelector.put("operandLeft", EDC_NAMESPACE + "id");
+        assetsSelector.put("operator", "=");
+        assetsSelector.put("operandRight", getPartTypeInfoAssetId(partner));
+        return body;
+    }
+
     /**
      * This method helps to ensure that the buildContractDefinitionWithBpnRestrictedPolicy uses the
      * same policy-id as the one that is created with the buildContractDefinitionWithBpnRestrictedPolicy
@@ -338,8 +352,40 @@ public class EdcRequestBodyBuilder {
         return body;
     }
 
+    public JsonNode buildPartTypeInfoRegistrationBody(Partner partner) {
+        var body = getAssetRegistrationContext();
+        body.put("@id", getPartTypeInfoAssetId(partner));
+        var propertiesObject = MAPPER.createObjectNode();
+        body.set("properties", propertiesObject);
+        var dctTypeObject = MAPPER.createObjectNode();
+        propertiesObject.set("dct:type", dctTypeObject);
+        dctTypeObject.put("@id", "cx-taxo:UniqueIdPushConnectToParentNotification");
+        propertiesObject.put("cx-common:version", "2.0");
+        propertiesObject.put("asset:prop:type", "foo.bar.PartTypeProp");
+        var dataAddress = MAPPER.createObjectNode();
+        String url = variablesService.getParttypeInformationServerendpoint();
+        if (!url.endsWith("/")) {
+            url += "/";
+        }
+        url += partner.getBpnl();
+        dataAddress.put("@type", "DataAddress");
+        dataAddress.put("proxyPath", "true");
+        dataAddress.put("proxyQueryParams", "false");
+        dataAddress.put("proxyMethod", "false");
+        dataAddress.put("type", "HttpData");
+        dataAddress.put("baseUrl", url);
+        dataAddress.put("authKey", "x-api-key");
+        dataAddress.put("authCode", variablesService.getApiKey());
+        body.set("dataAddress", dataAddress);
+        return body;
+    }
+
     private String getDtrAssetId() {
         return "DigitalTwinRegistryId@" + variablesService.getOwnBpnl();
+    }
+
+    private String getPartTypeInfoAssetId(Partner partner) {
+        return "PartTypeInformationApi_" + partner.getBpnl();
     }
 
     private ObjectNode getAssetRegistrationContext() {

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/util/EdcRequestBodyBuilder.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/util/EdcRequestBodyBuilder.java
@@ -216,7 +216,11 @@ public class EdcRequestBodyBuilder {
         var body = getEdcContextObject();
         body.put("@id", partner.getBpnl() +"_contractdefinition_for_PartTypeInfoAsset");
         body.put("accessPolicyId", getBpnPolicyId(partner));
-        body.put("contractPolicyId", getBpnPolicyId(partner));
+        if(variablesService.isUseFrameworkPolicy()) {
+            body.put("contractPolicyId", FRAMEWORK_POLICY_ID);
+        } else {
+            body.put("contractPolicyId", getBpnPolicyId(partner));
+        }
         var assetsSelector = MAPPER.createObjectNode();
         body.set("assetsSelector", assetsSelector);
         assetsSelector.put("@type", "CriterionDto");
@@ -359,9 +363,9 @@ public class EdcRequestBodyBuilder {
         body.set("properties", propertiesObject);
         var dctTypeObject = MAPPER.createObjectNode();
         propertiesObject.set("dct:type", dctTypeObject);
-        dctTypeObject.put("@id", "cx-taxo:UniqueIdPushConnectToParentNotification");
-        propertiesObject.put("cx-common:version", "2.0");
-        propertiesObject.put("asset:prop:type", "foo.bar.PartTypeProp");
+        dctTypeObject.put("@id", CX_TAXO_NAMESPACE + "Submodel");
+        propertiesObject.put("cx-common:version", "3.0");
+        propertiesObject.put("aas-semantics:semanticId.@id", "urn:samm:io.catenax.part_type_information:1.0.0#PartTypeInformation");
         var dataAddress = MAPPER.createObjectNode();
         String url = variablesService.getParttypeInformationServerendpoint();
         if (!url.endsWith("/")) {

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/security/SecurityConfig.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/security/SecurityConfig.java
@@ -79,7 +79,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(
                 // any request in spring context
                 (authorizeHttpRequests) -> authorizeHttpRequests
-                    .requestMatchers("/stockView/**", "/partners/**", "/materials/**", "/materialpartnerrelations/**", "/item-stock/**", "/edrendpoint/**", "/edc/**", "/parttype/**").authenticated()
+                    .requestMatchers("/stockView/**", "/partners/**", "/materials/**", "/materialpartnerrelations/**", "/item-stock/**", "/edrendpoint/**", "/edc/**", "/parttypeinformation/**").authenticated()
                     .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/health/**").permitAll()
                     .dispatcherTypeMatchers(DispatcherType.ERROR).permitAll()
             )

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/security/SecurityConfig.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/security/SecurityConfig.java
@@ -79,7 +79,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(
                 // any request in spring context
                 (authorizeHttpRequests) -> authorizeHttpRequests
-                    .requestMatchers("/stockView/**", "/partners/**", "/materials/**", "/materialpartnerrelations/**", "/item-stock/**", "/edrendpoint/**", "/edc/**").authenticated()
+                    .requestMatchers("/stockView/**", "/partners/**", "/materials/**", "/materialpartnerrelations/**", "/item-stock/**", "/edrendpoint/**", "/edc/**", "/parttype/**").authenticated()
                     .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/health/**").permitAll()
                     .dispatcherTypeMatchers(DispatcherType.ERROR).permitAll()
             )

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/util/VariablesService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/util/VariablesService.java
@@ -119,7 +119,7 @@ public class VariablesService {
      */
     private String dtrUrl;
 
-    @Value("${puris.baseurl}" + "catena/parttype")
+    @Value("${puris.baseurl}" + "catena/parttypeinformation")
     private String parttypeInformationServerendpoint;
 
     @Value("${puris.generatematerialcatenaxid}")

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/util/VariablesService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/util/VariablesService.java
@@ -116,6 +116,9 @@ public class VariablesService {
      */
     private String dtrUrl;
 
+    @Value("${puris.parttypeinformation.serverendpoint}")
+    private String parttypeInformationServerendpoint;
+
     @Value("${puris.generatematerialcatenaxid}")
     /**
      * A flag that signals whether the MaterialService

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/util/VariablesService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/util/VariablesService.java
@@ -39,6 +39,8 @@ public class VariablesService {
      * The port used by this apps server application.
      */
     private String serverPort;
+    @Value("${puris.baseurl}")
+    private String purisBaseUrl;
     @Value("${puris.demonstrator.role}")
     /**
      * Must be set to "CUSTOMER" or "SUPPLIER" if
@@ -46,7 +48,8 @@ public class VariablesService {
      * defined in the DataInjectionCommandLineRunner
      */
     private String demoRole;
-    @Value("${puris.edr.endpoint}")
+
+    @Value("${puris.baseurl}" + "catena/edrendpoint")
     /**
      * The edrEndpoint to be used during consumer pull asset transfers.
      */
@@ -57,7 +60,7 @@ public class VariablesService {
      * in the context of a consumer pull is removed from memory
      */
     private long edrTokenDeletionTimer;
-    @Value("${puris.request.serverendpoint}")
+    @Value("${puris.baseurl}" + "catena/item-stock/request")
     /**
      * The url under which this application's request endpoint can
      * be reached by external machines.
@@ -69,7 +72,7 @@ public class VariablesService {
      * during asset creation.
      */
     private String requestApiAssetId;
-    @Value("${puris.response.serverendpoint}")
+    @Value("${puris.baseurl}" + "catena/item-stock/response")
     /**
      * The url under which this application's response endpoint can
      * be reached by external machines.
@@ -87,7 +90,7 @@ public class VariablesService {
      * during asset creation.
      */
     private String statusRequestApiAssetId;
-    @Value("${puris.statusrequest.serverendpoint}")
+    @Value("${puris.baseurl}" + "catena/item-stock/status")
     /**
      * The url under which this application's status-request endpoint
      * can be reached by external machines.
@@ -116,7 +119,7 @@ public class VariablesService {
      */
     private String dtrUrl;
 
-    @Value("${puris.parttypeinformation.serverendpoint}")
+    @Value("${puris.baseurl}" + "catena/parttype")
     private String parttypeInformationServerendpoint;
 
     @Value("${puris.generatematerialcatenaxid}")

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartTypeInformationController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartTypeInformationController.java
@@ -42,7 +42,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.regex.Pattern;
 
 @RestController
-@RequestMapping("parttype")
+@RequestMapping("parttypeinformation")
 @Slf4j
 public class PartTypeInformationController {
     static Pattern bpnlPattern = PatternStore.BPNL_PATTERN;
@@ -66,11 +66,13 @@ public class PartTypeInformationController {
         @ApiResponse(responseCode = "401", description = "Access forbidden. "),
         @ApiResponse(responseCode = "404", description = "Product not found for given parameters. ")
     })
-    @GetMapping("/{bpnl}/{materialnumber}")
+    @GetMapping("/{bpnl}/{materialnumber}/{representation}")
     public ResponseEntity<?> getMapping(@Parameter(description = "The BPNL of the requesting party") @PathVariable String bpnl,
                                         @Parameter(description = "The material number that the request receiving party uses for the material in question")
-                                        @PathVariable String materialnumber) {
-        if (!bpnlPattern.matcher(bpnl).matches() || !materialNumberPattern.matcher(materialnumber).matches()) {
+                                        @PathVariable String materialnumber,
+                                        @Parameter(description = "Must be set to '$value'") @PathVariable String representation) {
+        if (!bpnlPattern.matcher(bpnl).matches() || !materialNumberPattern.matcher(materialnumber).matches()
+            || !"$value".equals(representation)) {
             return ResponseEntity.badRequest().build();
         }
         Partner partner = partnerService.findByBpnl(bpnl);

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartTypeInformationController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartTypeInformationController.java
@@ -57,23 +57,27 @@ public class PartTypeInformationController {
     @Autowired
     private PartTypeInformationSammMapper sammMapper;
 
-    @Operation(description = "Ednpoint that delivers PartTypeInformation of own products to customer partners. " +
+    @Operation(description = "Endpoint that delivers PartTypeInformation of own products to customer partners. " +
         "'bpnl' must be set to the bpnl of the requesting party. 'materialnumber' must be set to the ownMaterialNumber of " +
         "the party, that receives the request")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Ok"),
         @ApiResponse(responseCode = "400", description = "Invalid request parameters. "),
         @ApiResponse(responseCode = "401", description = "Access forbidden. "),
-        @ApiResponse(responseCode = "404", description = "Product not found for given parameters. ")
+        @ApiResponse(responseCode = "404", description = "Product not found for given parameters. "),
+        @ApiResponse(responseCode = "501", description = "Unsupported representation requested. ")
     })
     @GetMapping("/{bpnl}/{materialnumber}/{representation}")
     public ResponseEntity<?> getMapping(@Parameter(description = "The BPNL of the requesting party") @PathVariable String bpnl,
                                         @Parameter(description = "The material number that the request receiving party uses for the material in question")
                                         @PathVariable String materialnumber,
                                         @Parameter(description = "Must be set to '$value'") @PathVariable String representation) {
-        if (!bpnlPattern.matcher(bpnl).matches() || !materialNumberPattern.matcher(materialnumber).matches()
-            || !"$value".equals(representation)) {
+        if (!bpnlPattern.matcher(bpnl).matches() || !materialNumberPattern.matcher(materialnumber).matches()) {
             return ResponseEntity.badRequest().build();
+        }
+
+        if (!"$value".equals(representation)) {
+            return ResponseEntity.status(501).build();
         }
         Partner partner = partnerService.findByBpnl(bpnl);
         if (partner == null) {

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartTypeInformationController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartTypeInformationController.java
@@ -21,6 +21,7 @@
 package org.eclipse.tractusx.puris.backend.masterdata.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.extern.slf4j.Slf4j;
@@ -66,7 +67,9 @@ public class PartTypeInformationController {
         @ApiResponse(responseCode = "404", description = "Product not found for given parameters. ")
     })
     @GetMapping("/{bpnl}/{materialnumber}")
-    public ResponseEntity<?> getMapping(@PathVariable String bpnl, @PathVariable String materialnumber) {
+    public ResponseEntity<?> getMapping(@Parameter(description = "The BPNL of the requesting party") @PathVariable String bpnl,
+                                        @Parameter(description = "The material number that the request receiving party uses for the material in question")
+                                        @PathVariable String materialnumber) {
         if (!bpnlPattern.matcher(bpnl).matches() || !materialNumberPattern.matcher(materialnumber).matches()) {
             return ResponseEntity.badRequest().build();
         }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartTypeInformationController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartTypeInformationController.java
@@ -1,0 +1,57 @@
+package org.eclipse.tractusx.puris.backend.masterdata.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.tractusx.puris.backend.common.util.PatternStore;
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
+import org.eclipse.tractusx.puris.backend.masterdata.logic.adapter.PartTypeInformationSammMapper;
+import org.eclipse.tractusx.puris.backend.masterdata.logic.service.MaterialPartnerRelationService;
+import org.eclipse.tractusx.puris.backend.masterdata.logic.service.MaterialService;
+import org.eclipse.tractusx.puris.backend.masterdata.logic.service.PartnerService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.regex.Pattern;
+
+@RestController
+@RequestMapping("parttype")
+@Slf4j
+public class PartTypeInformationController {
+    static Pattern bpnlPattern = PatternStore.BPNL_PATTERN;
+    static Pattern materialNumberPattern = PatternStore.NON_EMPTY_NON_VERTICAL_WHITESPACE_PATTERN;
+
+    @Autowired
+    private PartnerService partnerService;
+    @Autowired
+    private MaterialService materialService;
+    @Autowired
+    private MaterialPartnerRelationService mprService;
+    @Autowired
+    private PartTypeInformationSammMapper sammMapper;
+
+    @GetMapping("/{bpnl}/{materialnumber}")
+    public ResponseEntity<?> getMapping(@PathVariable String bpnl, @PathVariable String materialnumber) {
+        if (!bpnlPattern.matcher(bpnl).matches() || !materialNumberPattern.matcher(materialnumber).matches()) {
+            return ResponseEntity.badRequest().build();
+        }
+        Partner partner = partnerService.findByBpnl(bpnl);
+        if (partner == null) {
+            return ResponseEntity.status(401).build();
+        }
+        log.info(bpnl + " requests part type information on " + materialnumber);
+        Material material = materialService.findByOwnMaterialNumber(materialnumber);
+        if (material == null || !material.isProductFlag()) {
+            return ResponseEntity.status(404).build();
+        }
+        var mpr = mprService.find(material, partner);
+        if (mpr == null || !mpr.isPartnerBuysMaterial()) {
+            return ResponseEntity.status(404).build();
+        }
+        var samm = sammMapper.productToSamm(material);
+        return ResponseEntity.ok(samm);
+    }
+}

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartTypeInformationController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartTypeInformationController.java
@@ -1,5 +1,28 @@
+/*
+ * Copyright (c) 2024 Volkswagen AG
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package org.eclipse.tractusx.puris.backend.masterdata.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.tractusx.puris.backend.common.util.PatternStore;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
@@ -33,6 +56,15 @@ public class PartTypeInformationController {
     @Autowired
     private PartTypeInformationSammMapper sammMapper;
 
+    @Operation(description = "Ednpoint that delivers PartTypeInformation of own products to customer partners. " +
+        "'bpnl' must be set to the bpnl of the requesting party. 'materialnumber' must be set to the ownMaterialNumber of " +
+        "the party, that receives the request")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Ok"),
+        @ApiResponse(responseCode = "400", description = "Invalid request parameters. "),
+        @ApiResponse(responseCode = "401", description = "Access forbidden. "),
+        @ApiResponse(responseCode = "404", description = "Product not found for given parameters. ")
+    })
     @GetMapping("/{bpnl}/{materialnumber}")
     public ResponseEntity<?> getMapping(@PathVariable String bpnl, @PathVariable String materialnumber) {
         if (!bpnlPattern.matcher(bpnl).matches() || !materialNumberPattern.matcher(materialnumber).matches()) {

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/MaterialPartnerRelationServiceImpl.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/MaterialPartnerRelationServiceImpl.java
@@ -110,13 +110,13 @@ public class MaterialPartnerRelationServiceImpl implements MaterialPartnerRelati
                     " for " + materialPartnerRelation.getMaterial().getOwnMaterialNumber() + " failed");
                 return false;
             }
-            String[] data = edcAdapterService.getContractForPartTypeInfoApi(materialPartnerRelation.getPartner());
+            String[] data = edcAdapterService.getContractForPartTypeInfoSubmodel(materialPartnerRelation.getPartner());
             if (data != null) {
                 String authKey = data[0];
                 String authCode = data[1];
                 String endpoint = data[2];
                 var response = edcAdapterService.getProxyPullRequest(endpoint, authKey, authCode,
-                    new String[]{materialPartnerRelation.getPartnerMaterialNumber()});
+                    new String[]{materialPartnerRelation.getPartnerMaterialNumber(), "$value"});
                 if (response != null && response.isSuccessful()) {
                     var body = objectMapper.readTree(response.body().string());
                     var cxId = body.get("catenaXId").asText();

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/MaterialPartnerRelationServiceImpl.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/MaterialPartnerRelationServiceImpl.java
@@ -21,11 +21,14 @@
  */
 package org.eclipse.tractusx.puris.backend.masterdata.logic.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.tractusx.puris.backend.common.ddtr.logic.DigitalTwinMappingService;
 import org.eclipse.tractusx.puris.backend.common.ddtr.logic.DtrAdapterService;
+import org.eclipse.tractusx.puris.backend.common.edc.logic.service.EdcAdapterService;
+import org.eclipse.tractusx.puris.backend.common.util.PatternStore;
 import org.eclipse.tractusx.puris.backend.common.util.VariablesService;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.MaterialPartnerRelation;
@@ -61,7 +64,13 @@ public class MaterialPartnerRelationServiceImpl implements MaterialPartnerRelati
     private DtrAdapterService dtrAdapterService;
 
     @Autowired
+    private EdcAdapterService edcAdapterService;
+
+    @Autowired
     private ExecutorService executorService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     /**
      * Stores the given relation to the database.
@@ -76,10 +85,65 @@ public class MaterialPartnerRelationServiceImpl implements MaterialPartnerRelati
         if (searchResult == null) {
             dtmService.update(materialPartnerRelation);
             executorService.submit(new DtrRegistrationTask(materialPartnerRelation, "CREATE", 3));
+            if (materialPartnerRelation.getMaterial().isMaterialFlag() && materialPartnerRelation.isPartnerSuppliesMaterial()
+                && materialPartnerRelation.getPartnerCXNumber() == null) {
+                log.info("Attempting CX-Id fetch for Material " + materialPartnerRelation.getMaterial().getOwnMaterialNumber() +
+                    " from Supplier-Partner " + materialPartnerRelation.getPartner().getBpnl());
+                executorService.submit(new PartTypeInformationRetrievalTask(materialPartnerRelation, 3));
+            }
             return mprRepository.save(materialPartnerRelation);
         }
         log.error("Could not create MaterialPartnerRelation, " + materialPartnerRelation.getKey() + " already exists");
         return null;
+    }
+
+    @AllArgsConstructor
+    private class PartTypeInformationRetrievalTask implements Callable<Boolean> {
+        final MaterialPartnerRelation materialPartnerRelation;
+        int retries;
+
+        @Override
+        public Boolean call() throws Exception {
+            Thread.sleep(100);
+            if (retries < 0) {
+                log.warn("PartTypeInformation fetch from " + materialPartnerRelation.getPartner().getBpnl() +
+                    " for " + materialPartnerRelation.getMaterial().getOwnMaterialNumber() + " failed");
+                return false;
+            }
+            String[] data = edcAdapterService.getContractForPartTypeInfoApi(materialPartnerRelation.getPartner());
+            if (data != null) {
+                String authKey = data[0];
+                String authCode = data[1];
+                String endpoint = data[2];
+                var response = edcAdapterService.getProxyPullRequest(endpoint, authKey, authCode,
+                    new String[]{materialPartnerRelation.getPartnerMaterialNumber()});
+                if (response != null && response.isSuccessful()) {
+                    var body = objectMapper.readTree(response.body().string());
+                    var cxId = body.get("catenaXId").asText();
+                    if (cxId != null && PatternStore.URN_OR_UUID_PATTERN.matcher(cxId).matches()) {
+                        materialPartnerRelation.setPartnerCXNumber(cxId);
+                        var updatedMpr = mprRepository.save(materialPartnerRelation);
+                        if (updatedMpr != null) {
+                            log.info("Successfully inserted Partner CX Id for Partner " +
+                                materialPartnerRelation.getPartner().getBpnl() + " and Material "
+                                + materialPartnerRelation.getMaterial().getOwnMaterialNumber());
+                        }
+                    }
+                } else {
+                    log.warn("PartTypeInformation fetch from " + materialPartnerRelation.getPartner().getBpnl() +
+                        " for " + materialPartnerRelation.getMaterial().getOwnMaterialNumber() + " failed. Retries left: " + retries);
+                    retries--;
+                    return call();
+                }
+                return true;
+            } else {
+                log.warn("PartTypeInformation fetch from " + materialPartnerRelation.getPartner().getBpnl() +
+                    " for " + materialPartnerRelation.getMaterial().getOwnMaterialNumber() + " failed. Retries left: " + retries);
+                retries--;
+                return call();
+            }
+
+        }
     }
 
 
@@ -100,7 +164,7 @@ public class MaterialPartnerRelationServiceImpl implements MaterialPartnerRelati
             if (retries < 0) {
                 return false;
             }
-            if (materialPartnerRelation.getPartnerCXNumber() == null){
+            if (materialPartnerRelation.getPartnerCXNumber() == null) {
                 log.error("Missing partnerCX Number in " + materialPartnerRelation + "\nAborting DTR call");
                 return false;
             }
@@ -111,7 +175,7 @@ public class MaterialPartnerRelationServiceImpl implements MaterialPartnerRelati
                     if (materialPartnerRelation.getMaterial().isProductFlag()) {
                         var allCustomers =
                             mprRepository.findAllByMaterial_OwnMaterialNumberAndPartnerBuysMaterialIsTrue(
-                                materialPartnerRelation.getMaterial().getOwnMaterialNumber()).
+                                    materialPartnerRelation.getMaterial().getOwnMaterialNumber()).
                                 stream().filter(mpr -> mpr.getPartnerCXNumber() != null).toList();
                         boolean result = dtrAdapterService.updateProduct(materialPartnerRelation.getMaterial(), allCustomers);
                         if (result) {
@@ -164,7 +228,7 @@ public class MaterialPartnerRelationServiceImpl implements MaterialPartnerRelati
                 }
             }
             if (success) {
-               return true;
+                return true;
             } else {
                 retries--;
                 return call();
@@ -184,6 +248,12 @@ public class MaterialPartnerRelationServiceImpl implements MaterialPartnerRelati
         var foundEntity = mprRepository.findById(materialPartnerRelation.getKey());
         if (foundEntity.isPresent()) {
             dtmService.update(materialPartnerRelation);
+            if (materialPartnerRelation.getMaterial().isMaterialFlag() && materialPartnerRelation.isPartnerSuppliesMaterial()
+                && materialPartnerRelation.getPartnerCXNumber() == null) {
+                log.info("Attempting CX-Id fetch for Material " + materialPartnerRelation.getMaterial().getOwnMaterialNumber() +
+                    " from Supplier-Partner " + materialPartnerRelation.getPartner().getBpnl());
+                executorService.submit(new PartTypeInformationRetrievalTask(materialPartnerRelation, 3));
+            }
             if (!foundEntity.get().isPartnerSuppliesMaterial() && materialPartnerRelation.isPartnerSuppliesMaterial()) {
                 executorService.submit(new DtrRegistrationTask(materialPartnerRelation, "CREATE", 3));
             } else {

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,19 +1,18 @@
 # Server Config
 server.port=${SERVER_PORT:8081}
+
+# Requires a trailing "/"
+puris.baseurl=${PURIS_BASEURL:http://customer-backend:8081/}
+
 puris.demonstrator.role=${PURIS_DEMONSTRATOR_ROLE:customer}
-puris.edr.endpoint=${PURIS_EDR_ENDPOINT:http://customer-backend:8081/catena/edrendpoint}
 puris.edr.deletiontimer=${PURIS_EDR_DELETIONTIMER:2}
-puris.request.serverendpoint=${PURIS_REQUEST_SERVERENDPOINT:http://customer-backend:8081/catena/product-stock/request}
 puris.request.apiassetid=${PURIS_REQUEST_APIASSETID:request-api-asset}
-puris.response.serverendpoint=${PURIS_RESPONSE_SERVERENDPOINT:http://customer-backend:8081/catena/product-stock/response}
 puris.response.apiassetid=${PURIS_RESPONSE_APIASSETID:response-api-asset}
 puris.statusrequest.apiassetid=${PURIS_STATUSREQUEST_APIASSETID:statusrequest-api-asset}
-puris.statusrequest.serverendpoint=${PURIS_STATUSREQUEST_SERVERENDPOINT:http://customer-backend:8081/catena/item-stock/status}
 puris.frameworkagreement.use=${PURIS_FRAMEWORKAGREEMENT_USE:false}
 puris.frameworkagreement.credential=${PURIS_FRAMEWORKAGREEMENT_CREDENTIAL:FrameworkAgreement.traceability}
 puris.api.key=${PURIS_API_KEY:test}
 puris.dtr.url=${PURIS_DTR_URL:http://localhost:4243}
-puris.parttypeinformation.serverendpoint=${PURIS_PARTTYPEINFORMATION_SERVERENDPOINT:http://customer-backend:8081/catena/parttype}
 
 # Flag that decides whether the auto-generation feature of the puris backend is enabled.
 # Since all Material entities are required to have a CatenaX-Id, you must enter any pre-existing CatenaX-Id

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -13,6 +13,7 @@ puris.frameworkagreement.use=${PURIS_FRAMEWORKAGREEMENT_USE:false}
 puris.frameworkagreement.credential=${PURIS_FRAMEWORKAGREEMENT_CREDENTIAL:FrameworkAgreement.traceability}
 puris.api.key=${PURIS_API_KEY:test}
 puris.dtr.url=${PURIS_DTR_URL:http://localhost:4243}
+puris.parttypeinformation.serverendpoint=${PURIS_PARTTYPEINFORMATION_SERVERENDPOINT:http://customer-backend:8081/catena/parttype}
 
 # Flag that decides whether the auto-generation feature of the puris backend is enabled.
 # Since all Material entities are required to have a CatenaX-Id, you must enter any pre-existing CatenaX-Id

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -1,19 +1,15 @@
 # Server Config
 server.port=${SERVER_PORT:8081}
 puris.demonstrator.role=${PURIS_DEMONSTRATOR_ROLE:customer}
-puris.edr.endpoint=${PURIS_EDR_ENDPOINT:http://customer-backend:8081/catena/edrendpoint}
+puris.baseurl=${PURIS_BASEURL:http://customer-backend:8081/}
 puris.edr.deletiontimer=${PURIS_EDR_DELETIONTIMER:2}
-puris.request.serverendpoint=${PURIS_REQUEST_SERVERENDPOINT:http://customer-backend:8081/catena/item-stock/request}
 puris.request.apiassetid=${PURIS_REQUEST_APIASSETID:request-api-asset}
-puris.response.serverendpoint=${PURIS_RESPONSE_SERVERENDPOINT:http://customer-backend:8081/catena/item-stock/response}
 puris.response.apiassetid=${PURIS_RESPONSE_APIASSETID:response-api-asset}
 puris.statusrequest.apiassetid=${PURIS_STATUSREQUEST_APIASSETID:statusrequest-api-asset}
-puris.statusrequest.serverendpoint=${PURIS_STATUSREQUEST_SERVERENDPOINT:http://customer-backend:8081/catena/item-stock/status}
 puris.frameworkagreement.use=${PURIS_FRAMEWORKAGREEMENT_USE:false}
 puris.frameworkagreement.credential=${PURIS_FRAMEWORKAGREEMENT_CREDENTIAL:FrameworkAgreement.traceability}
 puris.api.key=${PURIS_API_KEY:test}
 puris.dtr.url=${PURIS_DTR_URL:http://localhost:4243}
-puris.parttypeinformation.serverendpoint=${PURIS_PARTTYPEINFORMATION_SERVERENDPOINT:http://customer-backend:8081/catena/parttype}
 puris.generatematerialcatenaxid=${PURIS_GENERATEMATERIALCATENAXID:true}
 
 # DB Configuration

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -13,6 +13,7 @@ puris.frameworkagreement.use=${PURIS_FRAMEWORKAGREEMENT_USE:false}
 puris.frameworkagreement.credential=${PURIS_FRAMEWORKAGREEMENT_CREDENTIAL:FrameworkAgreement.traceability}
 puris.api.key=${PURIS_API_KEY:test}
 puris.dtr.url=${PURIS_DTR_URL:http://localhost:4243}
+puris.parttypeinformation.serverendpoint=${PURIS_PARTTYPEINFORMATION_SERVERENDPOINT:http://customer-backend:8081/catena/parttype}
 puris.generatematerialcatenaxid=${PURIS_GENERATEMATERIALCATENAXID:true}
 
 # DB Configuration

--- a/charts/puris/Chart.yaml
+++ b/charts/puris/Chart.yaml
@@ -35,7 +35,7 @@ dependencies:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/puris/Chart.yaml
+++ b/charts/puris/Chart.yaml
@@ -35,7 +35,7 @@ dependencies:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2
+version: 2.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/puris/README.md
+++ b/charts/puris/README.md
@@ -1,6 +1,6 @@
 # puris
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A helm chart for Kubernetes deployment of PURIS
 
@@ -59,7 +59,7 @@ $ helm install puris --namespace puris --create-namespace .
 | backend.podSecurityContext | object | `{}` | Added security contexts for a pod |
 | backend.puris.api.key | string | `"test"` | The API key of the PURIS application |
 | backend.puris.api.rootDir | string | `"/catena"` | The root directory of the API |
-| backend.puris.baseurl | string | `"customer-backend:8081/"` | Base url of the PURIS backend (requires a trailing "/") |
+| backend.puris.baseurl | string | `"your-backend-host-address.com"` | Base url of the PURIS backend |
 | backend.puris.datasource.driverClassName | string | `"org.postgresql.Driver"` | Driver class name of the database |
 | backend.puris.datasource.password | string | `nil` | Password for the database user. Ignored if postgres.enabled is true. |
 | backend.puris.datasource.url | string | `"jdbc:postgresql://postgresql-name:5432/puris-database"` | URL of the database. Ignored if postgres.enabled is true. |

--- a/charts/puris/README.md
+++ b/charts/puris/README.md
@@ -59,6 +59,7 @@ $ helm install puris --namespace puris --create-namespace .
 | backend.podSecurityContext | object | `{}` | Added security contexts for a pod |
 | backend.puris.api.key | string | `"test"` | The API key of the PURIS application |
 | backend.puris.api.rootDir | string | `"/catena"` | The root directory of the API |
+| backend.puris.baseurl | string | `"customer-backend:8081/"` | Base url of the PURIS backend (requires a trailing "/") |
 | backend.puris.datasource.driverClassName | string | `"org.postgresql.Driver"` | Driver class name of the database |
 | backend.puris.datasource.password | string | `nil` | Password for the database user. Ignored if postgres.enabled is true. |
 | backend.puris.datasource.url | string | `"jdbc:postgresql://postgresql-name:5432/puris-database"` | URL of the database. Ignored if postgres.enabled is true. |
@@ -71,7 +72,6 @@ $ helm install puris --namespace puris --create-namespace .
 | backend.puris.edc.controlplane.protocol.url | string | `"https://your-edc-address:8184/api/v1/dsp"` | Url to the EDC controlplane protocol API of the edc |
 | backend.puris.edc.dataplane.public.url | string | `"https://your-data-plane:8285/api/public/"` | Url of one of your data plane's public api |
 | backend.puris.edr.deletiontimer | int | `2` | Number of minutes before received authentication data of a consumer pull is removed from memory |
-| backend.puris.edr.endpoint | string | `"your-backend-host-address.com"` | Endpoint for EDR |
 | backend.puris.existingSecret | string | `"secret-backend-puris"` | Secret for backend passwords. For more information look into 'backend-secrets.yaml' file. |
 | backend.puris.frameworkagreement.credential | string | `"FrameworkAgreement.traceability"` | The name of the framework agreement |
 | backend.puris.frameworkagreement.use | bool | `false` | Flag to determine whether to use a framework agreement in puris |
@@ -87,11 +87,8 @@ $ helm install puris --namespace puris --create-namespace .
 | backend.puris.own.streetnumber | string | `"Musterstraße 110A"` | Own street and number |
 | backend.puris.own.zipcodeandcity | string | `"12345 Musterhausen"` | Own zipcode and city |
 | backend.puris.request.apiassetid | string | `"request-api-asset"` | Asset ID for request API |
-| backend.puris.request.serverendpoint | string | `"your-backend-host-address.com"` | Endpoint of server for request |
 | backend.puris.response.apiassetid | string | `"response-api-asset"` | Asset ID for response API |
-| backend.puris.response.serverendpoint | string | `"your-backend-host-address.com"` | Endpoint of server for response |
 | backend.puris.statusrequest.apiassetid | string | `"statusrequest-api-asset"` | Asset ID for status-request API |
-| backend.puris.statusrequest.serverendpoint | string | `"your-backend-host-address.com"` | Endpoint of server for statusrequest |
 | backend.readinessProbe | object | `{"failureThreshold":3,"initialDelaySeconds":120,"periodSeconds":25,"successThreshold":1,"timeoutSeconds":1}` | Checks if the pod is fully ready to operate |
 | backend.readinessProbe.failureThreshold | int | `3` | Number of failures (threshold) for a readiness probe |
 | backend.readinessProbe.initialDelaySeconds | int | `120` | Delay in seconds after which an initial readiness probe is checked |

--- a/charts/puris/README.md
+++ b/charts/puris/README.md
@@ -1,6 +1,6 @@
 # puris
 
-![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A helm chart for Kubernetes deployment of PURIS
 

--- a/charts/puris/templates/backend-deployment.yaml
+++ b/charts/puris/templates/backend-deployment.yaml
@@ -125,36 +125,18 @@ spec:
                   key: "puris-api-key"
             - name: PURIS_DEMONSTRATOR_ROLE
               value: "{{ .Values.backend.puris.demonstrator.role }}"
+            - name: PURIS_BASEURL
+              {{- if and .Values.backend.ingress.enabled .Values.backend.ingress.tls }}
+              value: "https://{{ .Values.backend.puris.baseurl }}"
+                {{- else }}
+              value: "http://{{ .Values.backend.puris.baseurl }}"
+                {{- end}}
             - name: PURIS_EDR_DELETIONTIMER
               value: "{{ .Values.backend.puris.edr.deletiontimer }}"
-            - name: PURIS_EDR_ENDPOINT
-              {{- if and .Values.backend.ingress.enabled .Values.backend.ingress.tls }}
-              value: "https://{{ .Values.backend.puris.edr.endpoint }}{{ .Values.backend.puris.api.rootDir }}/edrendpoint"
-                {{- else }}
-              value: "http://{{ .Values.backend.puris.edr.endpoint }}{{ .Values.backend.puris.api.rootDir }}/edrendpoint"
-                {{- end }}
-            - name: PURIS_REQUEST_SERVERENDPOINT
-              {{- if and .Values.backend.ingress.enabled .Values.backend.ingress.tls }}
-              value: "https://{{ .Values.backend.puris.request.serverendpoint }}{{ .Values.backend.puris.api.rootDir }}/item-stock/request"
-                {{- else }}
-              value: "http://{{ .Values.backend.puris.request.serverendpoint }}{{ .Values.backend.puris.api.rootDir }}/item-stock/request"
-                {{- end}}
             - name: PURIS_REQUEST_APIASSETID
               value: "{{ .Values.backend.puris.request.apiassetid }}"
-            - name: PURIS_RESPONSE_SERVERENDPOINT
-              {{- if and .Values.backend.ingress.enabled .Values.backend.ingress.tls }}
-              value: "https://{{ .Values.backend.puris.response.serverendpoint }}{{ .Values.backend.puris.api.rootDir }}/item-stock/response"
-                {{- else }}
-              value: "http://{{ .Values.backend.puris.response.serverendpoint }}{{ .Values.backend.puris.api.rootDir }}/item-stock/response"
-                {{- end}}
             - name: PURIS_RESPONSE_APIASSETID
               value: "{{ .Values.backend.puris.response.apiassetid }}"
-            - name: PURIS_STATUSREQUEST_SERVERENDPOINT
-              {{- if and .Values.backend.ingress.enabled .Values.backend.ingress.tls }}
-              value: "https://{{ .Values.backend.puris.statusrequest.serverendpoint }}{{ .Values.backend.puris.api.rootDir }}/item-stock/status"
-                {{- else }}
-              value: "http://{{ .Values.backend.puris.statusrequest.serverendpoint }}{{ .Values.backend.puris.api.rootDir }}/item-stock/status"
-                {{- end}}
             - name: PURIS_STATUSREQUEST_APIASSETID
               value: "{{ .Values.backend.puris.statusrequest.apiassetid }}"
             - name: PURIS_FRAMEWORKAGREEMENT_USE

--- a/charts/puris/templates/backend-deployment.yaml
+++ b/charts/puris/templates/backend-deployment.yaml
@@ -126,10 +126,14 @@ spec:
             - name: PURIS_DEMONSTRATOR_ROLE
               value: "{{ .Values.backend.puris.demonstrator.role }}"
             - name: PURIS_BASEURL
-              {{- if and .Values.backend.ingress.enabled .Values.backend.ingress.tls }}
-              value: "https://{{ .Values.backend.puris.baseurl }}"
+                {{- $baseUrl := .Values.backend.puris.baseurl }}
+                {{- if not (tpl "(strings.HasSuffix \"$baseUrl\" \"/\")" .) }}
+                {{- $baseUrl = printf "%s/" $baseUrl }}
+                {{- end }}
+                {{- if and .Values.backend.ingress.enabled .Values.backend.ingress.tls }}
+              value: "https://{{ $baseUrl }}"
                 {{- else }}
-              value: "http://{{ .Values.backend.puris.baseurl }}"
+              value: "http://{{ $baseUrl }}"
                 {{- end}}
             - name: PURIS_EDR_DELETIONTIMER
               value: "{{ .Values.backend.puris.edr.deletiontimer }}"

--- a/charts/puris/values.yaml
+++ b/charts/puris/values.yaml
@@ -348,8 +348,8 @@ backend:
     timeoutSeconds: 1
 
   puris:
-    # -- Base url of the PURIS backend (requires a trailing "/")
-    baseurl: customer-backend:8081/
+    # -- Base url of the PURIS backend
+    baseurl: *domain
     # -- Secret for backend passwords. For more information look into 'backend-secrets.yaml' file.
     existingSecret: "secret-backend-puris"
     api:

--- a/charts/puris/values.yaml
+++ b/charts/puris/values.yaml
@@ -348,6 +348,8 @@ backend:
     timeoutSeconds: 1
 
   puris:
+    # -- Base url of the PURIS backend (requires a trailing "/")
+    baseurl: customer-backend:8081/
     # -- Secret for backend passwords. For more information look into 'backend-secrets.yaml' file.
     existingSecret: "secret-backend-puris"
     api:
@@ -410,18 +412,12 @@ backend:
           # -- Enables "Lazy load no trans" property to fetch of each lazy entity to open a temporary session and run inside a separate transaction
           enable_lazy_load_no_trans: true
     request:
-      # -- Endpoint of server for request
-      serverendpoint: *domain
       # -- Asset ID for request API
       apiassetid: request-api-asset
     response:
-      # -- Endpoint of server for response
-      serverendpoint: *domain
       # -- Asset ID for response API
       apiassetid: response-api-asset
     statusrequest:
-      # -- Endpoint of server for statusrequest
-      serverendpoint: *domain
       # -- Asset ID for status-request API
       apiassetid: statusrequest-api-asset
     frameworkagreement:
@@ -432,8 +428,6 @@ backend:
     edr:
       # -- Number of minutes before received authentication data of a consumer pull is removed from memory
       deletiontimer: 2
-      # -- Endpoint for EDR
-      endpoint: *domain
     dtr:
       # --Endpoint for DTR
       url: http://localhost:4243

--- a/local/tractus-x-edc/config/customer/puris-backend.properties
+++ b/local/tractus-x-edc/config/customer/puris-backend.properties
@@ -12,6 +12,7 @@ puris.frameworkagreement.use=true
 puris.frameworkagreement.credential=FrameworkAgreement.traceability
 puris.api.key=${CUSTOMER_BACKEND_API_KEY}
 puris.dtr.url=http://dtr-customer:4243
+puris.parttypeinformation.serverendpoint=http://customer-backend:8081/catena/parttype
 puris.generatematerialcatenaxid=true
 
 edc.controlplane.key=${EDC_API_PW}

--- a/local/tractus-x-edc/config/customer/puris-backend.properties
+++ b/local/tractus-x-edc/config/customer/puris-backend.properties
@@ -1,18 +1,14 @@
 server.port=8081
 puris.demonstrator.role=customer
-puris.edr.endpoint=http://customer-backend:8081/catena/edrendpoint
+puris.baseurl=http://customer-backend:8081/
 puris.edr.deletiontimer=2
-puris.request.serverendpoint=http://customer-backend:8081/catena/item-stock/request
 puris.request.apiassetid=request-api-asset
-puris.statusrequest.serverendpoint=http://customer-backend:8081/catena/item-stock/status
 puris.statusrequest.apiassetid=statusrequest-api-asset
-puris.response.serverendpoint=http://customer-backend:8081/catena/item-stock/response
 puris.response.apiassetid=response-api-asset
 puris.frameworkagreement.use=true
 puris.frameworkagreement.credential=FrameworkAgreement.traceability
 puris.api.key=${CUSTOMER_BACKEND_API_KEY}
 puris.dtr.url=http://dtr-customer:4243
-puris.parttypeinformation.serverendpoint=http://customer-backend:8081/catena/parttype
 puris.generatematerialcatenaxid=true
 
 edc.controlplane.key=${EDC_API_PW}

--- a/local/tractus-x-edc/config/supplier/puris-backend.properties
+++ b/local/tractus-x-edc/config/supplier/puris-backend.properties
@@ -1,18 +1,14 @@
 server.port=8082
 puris.demonstrator.role=supplier
-puris.edr.endpoint=http://supplier-backend:8082/catena/edrendpoint
+puris.baseurl=http://supplier-backend:8082/
 puris.edr.deletiontimer=2
-puris.request.serverendpoint=http://supplier-backend:8082/catena/item-stock/request
 puris.request.apiassetid=request-api-asset
-puris.statusrequest.serverendpoint=http://supplier-backend:8082/catena/item-stock/status
 puris.statusrequest.apiassetid=statusrequest-api-asset
-puris.response.serverendpoint=http://supplier-backend:8082/catena/item-stock/response
 puris.response.apiassetid=response-api-asset
 puris.frameworkagreement.use=true
 puris.frameworkagreement.credential=FrameworkAgreement.traceability
 puris.api.key=${SUPPLIER_BACKEND_API_KEY}
 puris.dtr.url=http://dtr-supplier:4243
-puris.parttypeinformation.serverendpoint=http://supplier-backend:8082/catena/parttype
 puris.generatematerialcatenaxid=true
 
 edc.controlplane.key=${EDC_API_PW}

--- a/local/tractus-x-edc/config/supplier/puris-backend.properties
+++ b/local/tractus-x-edc/config/supplier/puris-backend.properties
@@ -12,6 +12,7 @@ puris.frameworkagreement.use=true
 puris.frameworkagreement.credential=FrameworkAgreement.traceability
 puris.api.key=${SUPPLIER_BACKEND_API_KEY}
 puris.dtr.url=http://dtr-supplier:4243
+puris.parttypeinformation.serverendpoint=http://supplier-backend:8082/catena/parttype
 puris.generatematerialcatenaxid=true
 
 edc.controlplane.key=${EDC_API_PW}


### PR DESCRIPTION
- added parttype enpoint for delivering parttype information to customer partners
- added routine to fetch a supplier partner's CX-Id in the MaterialPartnerRelationService
- simplified env-variables for the various api-endpoints in the backend
- solves #188 


Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
