### PR TITLE
feat(supplier-dashboard): new dashboard layout

### DIFF
--- a/frontend/src/components/TableWithRowHeader.tsx
+++ b/frontend/src/components/TableWithRowHeader.tsx
@@ -1,0 +1,46 @@
+/*
+Copyright (c) 2024 Volkswagen AG
+Copyright (c) 2024 Contributors to the Eclipse Foundation
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Apache License, Version 2.0 which is available at
+https://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+import { Table, TableProps } from '@catena-x/portal-shared-components';
+import { Box } from '@mui/material';
+
+type TableWithRowHeaderProps = TableProps;
+
+export const TableWithRowHeader = ({ rows, ...tableProps }: TableWithRowHeaderProps) => {
+    return (
+        <Box sx={{width: '100%'}}>
+            <div className="table-container">
+                <Table
+                    title=''
+                    columns={[{ field: 'name', headerName: '', width: 180 }]}
+                    rows={rows}
+                    rowSelection={false}
+                    hideFooter={true}
+                    disableColumnFilter
+                    disableColumnMenu
+                    sortingMode={'server'}
+                />
+                <Box sx={{width: '100%', display: 'flex', overflowX: 'auto'}}>
+                    <Table {...tableProps} rows={rows} disableColumnFilter disableColumnMenu sortingMode={'server'} showCellVerticalBorder showColumnVerticalBorder />
+                </Box>
+            </div>
+        </Box>
+    );
+};

--- a/frontend/src/features/dashboard/components/Dashboard.tsx
+++ b/frontend/src/features/dashboard/components/Dashboard.tsx
@@ -1,0 +1,118 @@
+/*
+Copyright (c) 2024 Volkswagen AG
+Copyright (c) 2024 Contributors to the Eclipse Foundation
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Apache License, Version 2.0 which is available at
+https://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+import { usePartnerStocks } from '@features/stock-view/hooks/usePartnerStocks';
+import { useStocks } from '@features/stock-view/hooks/useStocks';
+import { MaterialDescriptor } from '@models/types/data/material-descriptor';
+import { Site } from '@models/types/edc/site';
+import { useState } from 'react';
+import { DashboardFilters } from './DashboardFilters';
+import { DemandTable } from './DemandTable';
+import { ProductionTable } from './ProductionTable';
+import { Stack, Typography, capitalize } from '@mui/material';
+import { Delivery } from '@models/types/data/delivery';
+import { DeliveryInformationModal } from './DeliveryInformationModal';
+
+const NUMBER_OF_DAYS = 42;
+
+export const Dashboard = ({ type }: { type: 'customer' | 'supplier' }) => {
+    const [selectedMaterial, setSelectedMaterial] = useState<MaterialDescriptor | null>(null);
+    const [selectedSite, setSelectedSite] = useState<Site | null>(null);
+    const [selectedPartnerSites, setSelectedPartnerSites] = useState<Site[] | null>(null);
+    const { stocks } = useStocks(type === 'customer' ? 'material' : 'product');
+    const { partnerStocks } = usePartnerStocks(type === 'customer' ? 'material' : 'product', selectedMaterial?.ownMaterialNumber ?? null);
+    const [open, setOpen] = useState(false);
+    const [delivery, setDelivery] = useState<Delivery | null>(null);
+    const openDeliveryDialog = (d: Delivery) => {
+        setDelivery(d);
+        setOpen(true);
+    };
+    const handleMaterialSelect = (material: MaterialDescriptor | null) => {
+        setSelectedMaterial(material);
+        setSelectedSite(null);
+        setSelectedPartnerSites(null);
+    };
+    return (
+        <>
+            <Stack spacing={3} alignItems={'center'}>
+                <DashboardFilters
+                    type={type}
+                    material={selectedMaterial}
+                    site={selectedSite}
+                    partnerSites={selectedPartnerSites}
+                    onMaterialChange={handleMaterialSelect}
+                    onSiteChange={setSelectedSite}
+                    onPartnerSitesChange={setSelectedPartnerSites}
+                />
+                <Typography variant="h5" component="h2" marginBottom={0}>
+                    Our Stock Information {selectedMaterial && selectedSite && <>for {selectedMaterial.description}</>}
+                </Typography>
+                {selectedSite ? (
+                    type === 'customer' ? (
+                        <ProductionTable
+                            numberOfDays={NUMBER_OF_DAYS}
+                            stocks={stocks}
+                            site={selectedSite}
+                            onDeliveryClick={openDeliveryDialog}
+                        />
+                    ) : (
+                        <DemandTable
+                            numberOfDays={NUMBER_OF_DAYS}
+                            stocks={stocks}
+                            site={selectedSite}
+                            onDeliveryClick={openDeliveryDialog}
+                        />
+                    )
+                ) : (
+                    <Typography variant="body1">Select a Site to show production data</Typography>
+                )}
+                {selectedSite && (
+                    <>
+                        <Typography variant="h5" component="h2">
+                            {`${capitalize(type)} Stocks ${selectedMaterial ? `for ${selectedMaterial?.description}` : ''}`}
+                        </Typography>
+                        {selectedPartnerSites ? (
+                            selectedPartnerSites.map((ps) =>
+                                type === 'customer' ? (
+                                    <DemandTable
+                                        numberOfDays={NUMBER_OF_DAYS}
+                                        stocks={partnerStocks}
+                                        site={ps}
+                                        onDeliveryClick={openDeliveryDialog}
+                                    />
+                                ) : (
+                                    <ProductionTable
+                                        numberOfDays={NUMBER_OF_DAYS}
+                                        stocks={partnerStocks}
+                                        site={ps}
+                                        onDeliveryClick={openDeliveryDialog}
+                                    />
+                                )
+                            )
+                        ) : (
+                            <Typography variant="body1">{`Select a ${type} site to show their stock information`}</Typography>
+                        )}
+                    </>
+                )}
+            </Stack>
+            <DeliveryInformationModal open={open} onClose={() => setOpen(false)} delivery={delivery} />
+        </>
+    );
+};

--- a/frontend/src/features/dashboard/components/Dashboard.tsx
+++ b/frontend/src/features/dashboard/components/Dashboard.tsx
@@ -29,6 +29,7 @@ import { ProductionTable } from './ProductionTable';
 import { Stack, Typography, capitalize } from '@mui/material';
 import { Delivery } from '@models/types/data/delivery';
 import { DeliveryInformationModal } from './DeliveryInformationModal';
+import { getPartnerType } from '../util/helpers';
 
 const NUMBER_OF_DAYS = 42;
 
@@ -65,7 +66,7 @@ export const Dashboard = ({ type }: { type: 'customer' | 'supplier' }) => {
                     Our Stock Information {selectedMaterial && selectedSite && <>for {selectedMaterial.description}</>}
                 </Typography>
                 {selectedSite ? (
-                    type === 'customer' ? (
+                    type === 'supplier' ? (
                         <ProductionTable
                             numberOfDays={NUMBER_OF_DAYS}
                             stocks={stocks}
@@ -86,11 +87,11 @@ export const Dashboard = ({ type }: { type: 'customer' | 'supplier' }) => {
                 {selectedSite && (
                     <>
                         <Typography variant="h5" component="h2">
-                            {`${capitalize(type)} Stocks ${selectedMaterial ? `for ${selectedMaterial?.description}` : ''}`}
+                            {`${capitalize(getPartnerType(type))} Stocks ${selectedMaterial ? `for ${selectedMaterial?.description}` : ''}`}
                         </Typography>
                         {selectedPartnerSites ? (
                             selectedPartnerSites.map((ps) =>
-                                type === 'customer' ? (
+                                type === 'supplier' ? (
                                     <DemandTable
                                         numberOfDays={NUMBER_OF_DAYS}
                                         stocks={partnerStocks}
@@ -107,7 +108,7 @@ export const Dashboard = ({ type }: { type: 'customer' | 'supplier' }) => {
                                 )
                             )
                         ) : (
-                            <Typography variant="body1">{`Select a ${type} site to show their stock information`}</Typography>
+                            <Typography variant="body1">{`Select a ${getPartnerType(type)} site to show their stock information`}</Typography>
                         )}
                     </>
                 )}

--- a/frontend/src/features/dashboard/components/DashboardFilters.tsx
+++ b/frontend/src/features/dashboard/components/DashboardFilters.tsx
@@ -25,6 +25,7 @@ import { useSites } from '@features/stock-view/hooks/useSites';
 import { MaterialDescriptor } from '@models/types/data/material-descriptor';
 import { Site } from '@models/types/edc/site';
 import { Autocomplete, Grid, capitalize } from '@mui/material';
+import { getPartnerType } from '../util/helpers';
 
 type DashboardFiltersProps = {
     type: 'customer' | 'supplier';
@@ -73,14 +74,18 @@ export const DashboardFilters = ({
             </Grid>
             <Grid item md={12} paddingTop='0 !important'>
                 <Autocomplete
-                    id="customer-site"
+                    id="partner-site"
                     value={partnerSites ?? []}
                     options={partners?.reduce((acc: Site[], p) => [...acc, ...p.sites], []) ?? []}
                     disabled={!site}
                     getOptionLabel={(option) => `${option.name} (${option.bpns})`}
                     isOptionEqualToValue={(option, value) => option.bpns === value.bpns}
                     renderInput={(params) => (
-                        <Input {...params} label={`${capitalize(type)} Sites*`} placeholder="Select a Customer site" />
+                        <Input
+                            {...params}
+                            label={`${capitalize(getPartnerType(type))} Sites*`}
+                            placeholder={`Select a ${capitalize(getPartnerType(type))} site`}
+                        />
                     )}
                     onChange={(_, newValue) => onPartnerSitesChange(newValue?.length > 0 ? newValue : null)}
                     multiple={true}

--- a/frontend/src/features/dashboard/components/DashboardFilters.tsx
+++ b/frontend/src/features/dashboard/components/DashboardFilters.tsx
@@ -1,0 +1,91 @@
+/*
+Copyright (c) 2024 Volkswagen AG
+Copyright (c) 2024 Contributors to the Eclipse Foundation
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Apache License, Version 2.0 which is available at
+https://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+import { Input } from '@catena-x/portal-shared-components';
+import { useMaterials } from '@features/stock-view/hooks/useMaterials';
+import { usePartners } from '@features/stock-view/hooks/usePartners';
+import { useSites } from '@features/stock-view/hooks/useSites';
+import { MaterialDescriptor } from '@models/types/data/material-descriptor';
+import { Site } from '@models/types/edc/site';
+import { Autocomplete, Grid, capitalize } from '@mui/material';
+
+type DashboardFiltersProps = {
+    type: 'customer' | 'supplier';
+    material: MaterialDescriptor | null;
+    site: Site | null;
+    partnerSites: Site[] | null;
+    onMaterialChange: (material: MaterialDescriptor | null) => void;
+    onSiteChange: (site: Site | null) => void;
+    onPartnerSitesChange: (sites: Site[] | null) => void;
+};
+
+export const DashboardFilters = ({
+    type,
+    material,
+    site,
+    partnerSites,
+    onMaterialChange,
+    onSiteChange,
+    onPartnerSitesChange,
+}: DashboardFiltersProps) => {
+    const { materials } = useMaterials(type === 'customer' ? 'material' : 'product');
+    const { partners } = usePartners(type === 'customer' ? 'material' : 'product', material?.ownMaterialNumber ?? null);
+    const { sites } = useSites();
+    return (
+        <Grid container spacing={2} maxWidth={1024}>
+            <Grid item md={6} paddingTop='0 !important'>
+                <Autocomplete
+                    id="material"
+                    value={material}
+                    options={materials ?? []}
+                    getOptionLabel={(option) => option.ownMaterialNumber}
+                    renderInput={(params) => <Input {...params} label="Material*" placeholder="Select a Material" />}
+                    onChange={(_, newValue) => onMaterialChange(newValue || null)}
+                />
+            </Grid>
+            <Grid item md={6} paddingTop='0 !important'>
+                <Autocomplete
+                    id="site"
+                    value={site}
+                    options={sites ?? []}
+                    getOptionLabel={(option) => `${option.name} (${option.bpns})`}
+                    disabled={!material}
+                    renderInput={(params) => <Input {...params} label="Site*" placeholder="Select a Site" />}
+                    onChange={(_, newValue) => onSiteChange(newValue || null)}
+                />
+            </Grid>
+            <Grid item md={12} paddingTop='0 !important'>
+                <Autocomplete
+                    id="customer-site"
+                    value={partnerSites ?? []}
+                    options={partners?.reduce((acc: Site[], p) => [...acc, ...p.sites], []) ?? []}
+                    disabled={!site}
+                    getOptionLabel={(option) => `${option.name} (${option.bpns})`}
+                    isOptionEqualToValue={(option, value) => option.bpns === value.bpns}
+                    renderInput={(params) => (
+                        <Input {...params} label={`${capitalize(type)} Sites*`} placeholder="Select a Customer site" />
+                    )}
+                    onChange={(_, newValue) => onPartnerSitesChange(newValue?.length > 0 ? newValue : null)}
+                    multiple={true}
+                />
+            </Grid>
+        </Grid>
+    );
+};

--- a/frontend/src/features/dashboard/components/DeliveryInformationModal.tsx
+++ b/frontend/src/features/dashboard/components/DeliveryInformationModal.tsx
@@ -1,0 +1,63 @@
+/*
+Copyright (c) 2024 Volkswagen AG
+Copyright (c) 2024 Contributors to the Eclipse Foundation
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Apache License, Version 2.0 which is available at
+https://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+import { Delivery } from '@models/types/data/delivery';
+import { Button, Dialog, DialogTitle, Grid, Stack, Typography } from '@mui/material';
+
+const GridItem = ({ label, value }: { label: string; value: string }) => (
+    <Grid item xs={6}>
+        <Stack>
+            <Typography variant="caption1" fontWeight={500}>
+                {label}:
+            </Typography>
+            <Typography variant="body3" paddingLeft=".5rem">
+                {value}
+            </Typography>
+        </Stack>
+    </Grid>
+);
+
+type DeliveryInformationModalProps = {
+    open: boolean;
+    onClose: () => void;
+    delivery: Delivery | null;
+};
+
+export const DeliveryInformationModal = ({ open, onClose, delivery }: DeliveryInformationModalProps) => {
+    return (
+        <Dialog open={open && delivery !== null} onClose={onClose} title="Delivery Information">
+            <DialogTitle fontWeight={600} textAlign='center'>Delivery Information</DialogTitle>
+            <Stack padding="0 2rem 2rem">
+                <Grid container spacing={2} width="32rem" padding='.25rem'>
+                    <GridItem label="Incoterm" value="EXW" />
+                    <GridItem label="Tracking Number" value="1Z9829WDE02128" />
+                    <GridItem label="Origin" value={delivery?.origin?.bpns ?? ''} />
+                    <GridItem label="Destination" value={delivery?.destination?.bpns ?? ''} />
+                    <GridItem label="ETD" value={delivery?.etd ?? ''} />
+                    <GridItem label="ETA" value={new Date().toLocaleDateString('en-US', { weekday: 'long', day: '2-digit', month: '2-digit', year: 'numeric' })} />
+                    <GridItem label="Delivery Quantity" value={`${delivery?.quantity} pieces`} />
+                </Grid>
+                <Button variant="contained" sx={{ marginTop: '2rem' }} onClick={onClose}>
+                    Close
+                </Button>
+            </Stack>
+        </Dialog>
+    );
+};

--- a/frontend/src/features/dashboard/components/DemandTable.tsx
+++ b/frontend/src/features/dashboard/components/DemandTable.tsx
@@ -21,7 +21,7 @@ SPDX-License-Identifier: Apache-2.0
 import { TableWithRowHeader } from '@components/TableWithRowHeader';
 import { Stock } from '@models/types/data/stock';
 import { Site } from '@models/types/edc/site';
-import { createDateColumnHeaders } from '../util/table-helpers';
+import { createDateColumnHeaders } from '../util/helpers';
 import { Box, Typography } from '@mui/material';
 import { Delivery } from '@models/types/data/delivery';
 
@@ -47,7 +47,7 @@ const createDemandRows = (numberOfDays: number, stocks: Stock[], site: Site) => 
         ...Object.keys(Array.from({ length: numberOfDays })).reduce(
             (acc, _, index) => ({
                 ...acc,
-                [index]: Math.max(itemStock[index as keyof typeof itemStock] / demands[index as keyof typeof demands], 0),
+                [index]: Math.max(itemStock[index as keyof typeof itemStock] / demands[index as keyof typeof demands], 0).toFixed(2),
             }),
             {}
         ),

--- a/frontend/src/features/dashboard/components/DemandTable.tsx
+++ b/frontend/src/features/dashboard/components/DemandTable.tsx
@@ -1,0 +1,98 @@
+/*
+Copyright (c) 2024 Volkswagen AG
+Copyright (c) 2024 Contributors to the Eclipse Foundation
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Apache License, Version 2.0 which is available at
+https://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+import { TableWithRowHeader } from '@components/TableWithRowHeader';
+import { Stock } from '@models/types/data/stock';
+import { Site } from '@models/types/edc/site';
+import { createDateColumnHeaders } from '../util/table-helpers';
+import { Box, Typography } from '@mui/material';
+import { Delivery } from '@models/types/data/delivery';
+
+const createDemandRows = (numberOfDays: number, stocks: Stock[], site: Site) => {
+    const demands = { ...Object.keys(Array.from({ length: numberOfDays })).reduce((acc, _, index) => ({ ...acc, [index]: 30 }), {}) };
+    const deliveries = {
+        ...Object.keys(Array.from({ length: numberOfDays })).reduce((acc, _, index) => ({ ...acc, [index]: index % 3 === 0 ? 45 : 0 }), {}),
+    };
+    const currentStock = stocks.find((s) => s.stockLocationBpns === site.bpns)?.quantity ?? 0;
+    const itemStock = {
+        ...Object.keys(Array.from({ length: numberOfDays })).reduce(
+            (acc, _, index) => ({
+                ...acc,
+                [index]:
+                    (index === 0 ? currentStock : acc[(index - 1) as keyof typeof acc]) +
+                    deliveries[index as keyof typeof deliveries] -
+                    demands[index as keyof typeof demands],
+            }),
+            {}
+        ),
+    };
+    const daysOfSupply = {
+        ...Object.keys(Array.from({ length: numberOfDays })).reduce(
+            (acc, _, index) => ({
+                ...acc,
+                [index]: Math.max(itemStock[index as keyof typeof itemStock] / demands[index as keyof typeof demands], 0),
+            }),
+            {}
+        ),
+    };
+    return [
+        { id: 'demand', name: 'Demand', ...demands },
+        { id: 'itemStock', name: 'Item Stock', ...itemStock },
+        { id: 'daysOfSupply', name: 'Days of Supply', ...daysOfSupply },
+        { id: 'delivery', name: 'Delivery', ...deliveries },
+    ];
+};
+
+type DemandTableProps = { numberOfDays: number; stocks: Stock[] | null; site: Site; onDeliveryClick: (delivery: Delivery) => void };
+
+export const DemandTable = ({ numberOfDays, stocks, site, onDeliveryClick }: DemandTableProps) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const handleDeliveryClick = (cellData: any) => {
+        if (cellData.id !== 'delivery') return;
+        if (cellData.value === 0) return;
+        onDeliveryClick({
+            quantity: cellData.value,
+            etd: cellData.colDef.headerName,
+            origin: {
+                bpns: site?.bpns,
+            },
+            destination: {
+                bpns: site?.bpns,
+            },
+        });
+    };
+    return (
+        <>
+            <Box display="flex" justifyContent="start" width="100%" gap="0.5rem" marginBlock="0.5rem" paddingLeft=".5rem">
+                <Typography variant="caption1" component="h3" fontWeight={600}> Site: </Typography>
+                {site.name} ({site.bpns})
+            </Box>
+            <TableWithRowHeader
+                title=""
+                noRowsMsg="Select a Material to show the customer demand"
+                columns={createDateColumnHeaders(numberOfDays)}
+                rows={createDemandRows(numberOfDays, stocks ?? [], site)}
+                onCellClick={handleDeliveryClick}
+                getRowId={(row) => row.id}
+                hideFooter={true}
+            />
+        </>
+    );
+};

--- a/frontend/src/features/dashboard/components/ProductionTable.tsx
+++ b/frontend/src/features/dashboard/components/ProductionTable.tsx
@@ -1,0 +1,92 @@
+/*
+Copyright (c) 2024 Volkswagen AG
+Copyright (c) 2024 Contributors to the Eclipse Foundation
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Apache License, Version 2.0 which is available at
+https://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+import { TableWithRowHeader } from '@components/TableWithRowHeader';
+import { Stock } from '@models/types/data/stock';
+import { Site } from '@models/types/edc/site';
+import { createDateColumnHeaders } from '../util/table-helpers';
+import { Box, Typography } from '@mui/material';
+import { Delivery } from '@models/types/data/delivery';
+
+const createProductionRows = (numberOfDays: number, stocks: Stock[], site: Site) => {
+    const shipments = {
+        ...Object.keys(Array.from({ length: numberOfDays })).reduce((acc, _, index) => ({ ...acc, [index]: index % 3 === 1 ? 90 : 0 }), {}),
+    };
+    const production = { ...Object.keys(Array.from({ length: numberOfDays })).reduce((acc, _, index) => ({ ...acc, [index]: 30 }), {}) };
+    const stockQuantity = stocks.filter((stock) => stock.stockLocationBpns === site.bpns).reduce((acc, stock) => acc + stock.quantity, 0);
+    const allocatedStocks = {
+        ...Object.keys(Array.from({ length: numberOfDays })).reduce(
+            (acc, _, index) => ({
+                ...acc,
+                [index]:
+                    index === 0
+                        ? stockQuantity
+                        : acc[(index - 1) as keyof typeof acc] -
+                          shipments[index as keyof typeof shipments] +
+                          production[(index - 1) as keyof typeof production],
+            }),
+            {}
+        ),
+    };
+    return [
+        { id: 'shipment', name: 'Shipments', ...shipments },
+        { id: 'itemStock', name: 'Item Stock', ...allocatedStocks },
+        { id: 'plannedProduction', name: 'Planned Production', ...production },
+    ];
+};
+
+type ProductionTableProps = { numberOfDays: number; stocks: Stock[] | null; site: Site, onDeliveryClick: (delivery: Delivery) => void };
+
+export const ProductionTable = ({ numberOfDays, stocks, site, onDeliveryClick }: ProductionTableProps) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const handleDeliveryClick = (cellData: any) => {
+        if (cellData.id !== 'shipment') return;
+        if (cellData.value === 0) return;
+        onDeliveryClick({
+            quantity: cellData.value,
+            etd: cellData.colDef.headerName,
+            origin: {
+                bpns: site?.bpns,
+            },
+            destination: {
+                bpns: site?.bpns,
+            },
+        });
+    };
+    return (
+        <>
+            <Box display="flex" justifyContent="start" width="100%" gap="0.5rem" marginBlock="0.5rem" paddingLeft=".5rem">
+                <Typography variant="caption1" component="h3" fontWeight={600}>
+                    Site:{' '}
+                </Typography>{' '}
+                {site.name} ({site.bpns})
+            </Box>
+            <TableWithRowHeader
+                title=""
+                noRowsMsg="Select a Site to show production data"
+                columns={createDateColumnHeaders(numberOfDays)}
+                onCellClick={handleDeliveryClick}
+                rows={site ? createProductionRows(numberOfDays, stocks ?? [], site) : []}
+                getRowId={(row) => row.id}
+                hideFooter={true}
+            />
+        </>
+    );
+};

--- a/frontend/src/features/dashboard/components/ProductionTable.tsx
+++ b/frontend/src/features/dashboard/components/ProductionTable.tsx
@@ -21,7 +21,7 @@ SPDX-License-Identifier: Apache-2.0
 import { TableWithRowHeader } from '@components/TableWithRowHeader';
 import { Stock } from '@models/types/data/stock';
 import { Site } from '@models/types/edc/site';
-import { createDateColumnHeaders } from '../util/table-helpers';
+import { createDateColumnHeaders } from '../util/helpers';
 import { Box, Typography } from '@mui/material';
 import { Delivery } from '@models/types/data/delivery';
 

--- a/frontend/src/features/dashboard/util/helpers.tsx
+++ b/frontend/src/features/dashboard/util/helpers.tsx
@@ -40,3 +40,6 @@ export const createDateColumnHeaders = (numberOfDays: number) => {
         };
     });
 };
+
+export const getPartnerType = (type: 'customer' | 'supplier') => (type === 'customer' ? 'supplier' : 'customer');
+

--- a/frontend/src/features/dashboard/util/table-helpers.tsx
+++ b/frontend/src/features/dashboard/util/table-helpers.tsx
@@ -1,0 +1,42 @@
+/*
+Copyright (c) 2024 Volkswagen AG
+Copyright (c) 2024 Contributors to the Eclipse Foundation
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Apache License, Version 2.0 which is available at
+https://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+import { Info } from '@mui/icons-material';
+import { Box, Button } from '@mui/material';
+
+export const createDateColumnHeaders = (numberOfDays: number) => {
+    return Object.keys(Array.from({ length: numberOfDays })).map((_, index) => {
+        const date = new Date();
+        date.setDate(date.getDate() + index);
+        return {
+            field: `${index}`,
+            headerName: date.toLocaleDateString('en-US', { weekday: 'long', day: '2-digit', month: '2-digit', year: 'numeric' }),
+            width: 180,
+            renderCell: (data: { value?: number } & { row: {id: number | string }}) => {
+                return (
+                    <Box display='flex' textAlign='center' alignItems='center' justifyContent='center' width='100%' height='100%' color={data.value !== undefined && data.value < 0 ? 'red' : undefined}>
+                        {(data.row.id === 'delivery' || data.row.id === 'shipment') && data.value !== 0 ? <Button variant='text'>{data.value} <Info sx={{fontSize: '1.25rem'}}></Info></Button> : data.value} 
+                    </Box>
+                );
+            },
+            type: 'number',
+        };
+    });
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -19,27 +19,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
- * Copyright (c) 2022,2024 Volkswagen AG
- * Copyright (c) 2022,2024 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
- * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
- *
- * See the NOTICE file(s) distributed with this work for additional
- * information regarding copyright ownership.
- *
- * This program and the accompanying materials are made available under the
- * terms of the Apache License, Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0.
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations
- * under the License.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -48,7 +27,7 @@ body {
     @apply text-gray-700;
 }
 
-[role="tabpanel"] {
+[role='tabpanel'] {
     @apply w-full;
 }
 
@@ -56,3 +35,21 @@ body {
     display: none;
 }
 
+.table-container {
+    display: flex;
+    width: 100%;
+    border: 1px solid #e0e0e0;
+}
+
+.table-container .MuiDataGrid-root > .MuiBox-root {
+    display: none;
+}
+
+.table-container .MuiDataGrid-root {
+    border: none !important;
+    border-radius: 0;
+}
+
+.table-container .MuiDataGrid-columnHeader button {
+    display: none;
+}

--- a/frontend/src/models/types/data/delivery.ts
+++ b/frontend/src/models/types/data/delivery.ts
@@ -1,0 +1,34 @@
+/*
+Copyright (c) 2024 Volkswagen AG
+Copyright (c) 2024 Contributors to the Eclipse Foundation
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Apache License, Version 2.0 which is available at
+https://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+import { BPNA, BPNS } from '../edc/bpn';
+
+export type Delivery = {
+  quantity?: number;
+  etd: string;
+  origin: {
+    bpns: BPNS;
+    bpna?: BPNA;
+  },
+  destination: {
+    bpns: BPNS;
+    bpna?: BPNA;
+  },
+}

--- a/frontend/src/views/SupplierDashboardView.tsx
+++ b/frontend/src/views/SupplierDashboardView.tsx
@@ -1,7 +1,7 @@
 /*
-Copyright (c) 2023-2024 Volkswagen AG
-Copyright (c) 2023-2024 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
-Copyright (c) 2023-2024 Contributors to the Eclipse Foundation
+Copyright (c) 2023,2024 Volkswagen AG
+Copyright (c) 2023,2024 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
+Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
 
 See the NOTICE file(s) distributed with this work for additional
 information regarding copyright ownership.
@@ -19,237 +19,30 @@ under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
-import { Input, Table } from '@catena-x/portal-shared-components';
-import { useState } from 'react';
+import { Tab, TabPanel, Tabs } from '@catena-x/portal-shared-components';
 import { ConfidentialBanner } from '@components/ConfidentialBanner';
-import Autocomplete from '@mui/material/Autocomplete';
-
-type Customer = {
-    name: string;
-    materials: Material[];
-};
-
-type Material = {
-    name: string;
-    demandActual: number[];
-    demandAdditional: number[];
-    production: number[];
-};
-
-const mockCustomerDemands: Customer[] = [
-    {
-        name: 'Customer 1',
-        materials: [
-            {
-                name: 'Central Control Unit',
-                demandActual: [
-                    398, 23, 183, 53, 341, 492, 282, 80, 48, 199, 417, 223, 242, 263, 262, 185, 313, 78, 209, 405, 7, 134, 362, 196, 247,
-                    248, 336, 302,
-                ],
-                demandAdditional: [],
-                production: [
-                    398, 23, 183, 53, 341, 492, 282, 80, 48, 199, 417, 223, 242, 263, 262, 185, 313, 78, 209, 405, 7, 134, 362, 196, 247,
-                    248, 336, 302,
-                ],
-            },
-            {
-                name: 'Steering Wheel',
-                demandActual: [
-                    342, 294, 48, 32, 243, 180, 113, 395, 5, 477, 223, 31, 193, 418, 472, 338, 45, 219, 149, 324, 92, 28, 129, 481, 235,
-                    348, 132, 259,
-                ],
-                demandAdditional: [],
-                production: [
-                    342, 294, 48, 32, 243, 180, 113, 395, 5, 477, 223, 31, 193, 418, 472, 338, 45, 219, 149, 324, 92, 28, 129, 481, 235,
-                    348, 132, 259,
-                ],
-            },
-            {
-                name: 'Wheel',
-                demandActual: [
-                    311, 152, 173, 496, 418, 17, 79, 267, 22, 426, 103, 396, 469, 362, 299, 112, 105, 180, 141, 1, 133, 9, 476, 93, 118,
-                    373, 394, 376,
-                ],
-                demandAdditional: [],
-                production: [
-                    311, 152, 173, 496, 418, 17, 79, 267, 22, 426, 103, 396, 469, 362, 299, 112, 105, 180, 141, 1, 133, 9, 476, 93, 118,
-                    373, 394, 376,
-                ],
-            },
-        ],
-    },
-    {
-        name: 'Customer 2',
-        materials: [
-            {
-                name: 'Central Control Unit',
-                demandActual: [
-                    399, 238, 16, 187, 317, 496, 134, 189, 264, 15, 357, 203, 322, 388, 1, 65, 423, 441, 119, 28, 417, 460, 218, 129, 217,
-                    5, 63, 198,
-                ],
-                demandAdditional: [
-                    100, 50, 75, 0, 150, 500, 0, 20, 150, 0, 175, 200, 0, 40, 100, 50, 75, 0, 150, 500, 0, 20, 150, 0, 175, 200, 0, 40,
-                ],
-                production: [
-                    499, 288, 66, 187, 467, 996, 134, 209, 314, 15, 532, 403, 322, 248, 101, 115, 498, 441, 269, 528, 417, 460, 218, 129,
-                    392, 205, 63, 198,
-                ],
-            },
-            {
-                name: 'Steering Wheel',
-                demandActual: [
-                    299, 252, 313, 63, 497, 35, 351, 426, 419, 86, 127, 374, 6, 66, 120, 82, 89, 286, 162, 327, 454, 500, 98, 10, 140, 415,
-                    368, 178,
-                ],
-                demandAdditional: [
-                    100, 0, 50, 200, 150, 0, 75, 100, 0, 50, 200, 150, 0, 75, 100, 0, 50, 200, 150, 0, 75, 100, 0, 50, 200, 150, 0, 75,
-                ],
-                production: [
-                    399, 252, 313, 263, 647, 35, 426, 526, 419, 136, 327, 374, 6, 141, 220, 82, 139, 486, 312, 327, 454, 600, 98, 60, 340,
-                    565, 368, 253,
-                ],
-            },
-            {
-                name: 'Seats',
-                demandActual: [
-                    100, 200, 834, 325, 989, 442, 121, 609, 964, 789, 331, 923, 22, 315, 947, 956, 732, 422, 878, 425, 562, 737, 370, 904,
-                    727, 706, 823, 459,
-                ],
-                demandAdditional: [
-                    22, 300, 0, 200, 50, 350, 150, 100, 300, 400, 200, 50, 350, 150, 100, 300, 400, 200, 50, 350, 150, 100, 300, 400, 200,
-                    50, 350, 150,
-                ],
-                production: [
-                    122, 500, 940, 237, 977, 626, 915, 196, 749, 382, 48, 982, 95, 14, 831, 23, 542, 142, 10, 664, 333, 731, 611, 797, 366,
-                    485, 732, 357,
-                ],
-            },
-        ],
-    },
-];
-
-const dateColumns = [
-    {
-        field: 'name',
-        headerName: '',
-        width: 180,
-    },
-    ...[
-        'Tue, 01.08.2023',
-        'Wed, 02.08.2023',
-        'Thu, 03.08.2023',
-        'Fr, 04.08.2023',
-        'Sa, 05.08.2023',
-        'Su, 06.08.2023',
-        'Mo, 07.08.2023',
-        'Tue, 08.08.2023',
-        'Wed, 09.08.202',
-        'Thu, 10.08.2023',
-        'Fr, 11.08.2023',
-        'Sa, 12.08.2023',
-        'Su, 13.08.2023',
-        'Mo, 14.08.2023',
-        'Tue, 15.08.2023',
-        'Wed, 16.08.2023',
-        'Thu, 17.08.2023',
-        'Fr, 18.08.2023',
-        'Sa, 19.08.2023',
-        'So, 20.08.2023',
-        'Mo, 21.08.2023',
-        'Tue, 22.08.2023',
-        'Wed, 23.08.2023',
-        'Thu, 24.08.2023',
-        'Fr, 25.08.2023',
-        'Sa, 26.08.2023',
-        'So, 27.08.2023',
-        'Mo, 28.08.2023',
-    ].map((date, index) => ({
-        field: index.toString(),
-        headerName: date,
-        renderCell: (data: { row: { name: string; material?: Material } & { [key: string]: number } }) => {
-            const isInsufficientProduction =
-                data.row.id === 4 &&
-                data.row.material &&
-                data.row[index] < data.row.material.demandActual[index] + (data.row.material.demandAdditional[index] ?? 0);
-            return (
-                <span className={`grid place-items-center w-full h-full ${isInsufficientProduction ? ' text-red-400' : ''}`}>
-                    {data.row[index]}
-                </span>
-            );
-        },
-    })),
-];
-
-const createTableRows = (material: Material) => {
-    return [
-        {
-            id: 1,
-            name: 'Demand (Actual)',
-            ...material.demandActual.reduce((acc, value, index) => ({ ...acc, [index]: value }), {}),
-        },
-        {
-            id: 2,
-            name: 'Demand (Additional)',
-            ...material.demandAdditional.reduce((acc, value, index) => ({ ...acc, [index]: value }), {}),
-        },
-        {
-            id: 3,
-            name: 'Demand (Total)',
-            ...material.demandActual.reduce(
-                (acc, value, index) => ({ ...acc, [index]: value + (material.demandAdditional[index] ?? 0) }),
-                {}
-            ),
-        },
-        {
-            id: 4,
-            material,
-            name: 'Your Production',
-            ...material.production.reduce((acc, value, index) => ({ ...acc, [index]: value }), {}),
-        },
-    ];
-};
+import { Dashboard } from '@features/dashboard/components/Dashboard';
+import { Box, Stack, Typography } from '@mui/material';
+import { useState } from 'react';
 
 export const SupplierDashboardView = () => {
-    const [selectedCustomer, setSelectedCustomer] = useState<Customer | null>(null);
-    const [selectedMaterial, setSelectedMaterial] = useState<Material | null>(null);
-    const handleCustomerSelect = (customer: Customer | null) => {
-        setSelectedCustomer(customer);
-        setSelectedMaterial(null);
-    };
+    const [selectedTab, setSelectedTab] = useState<number>(0);
     return (
-        <div className="flex flex-col items-center w-full h-full">
+        <Stack spacing={2} alignItems='center' width='100%' height='100%'>
             <ConfidentialBanner />
-            <h1 className="text-3xl font-semibold text-gray-700">Supplier Dashboard</h1>
-            <div className="flex gap-2 w-[64rem] mb-10">
-                <Autocomplete
-                    id="customer"
-                    className="w-1/2"
-                    value={selectedCustomer}
-                    options={mockCustomerDemands ?? []}
-                    getOptionLabel={(option) => option.name}
-                    renderInput={(params) => <Input {...params} label="Customer*" placeholder="Select a Customer" />}
-                    onChange={(_, newValue) => handleCustomerSelect(newValue)}
-                />
-                <Autocomplete
-                    id="material"
-                    className="w-1/2"
-                    value={selectedMaterial}
-                    options={selectedCustomer?.materials ?? []}
-                    getOptionLabel={(option) => option.name}
-                    renderInput={(params) => <Input {...params} label="Material*" placeholder="Select a Material" />}
-                    onChange={(_, newValue) => setSelectedMaterial(newValue)}
-                />
-            </div>
-            <div className="w-full overflow-x-auto">
-                <Table
-                    title={`Customer Demand ${selectedMaterial ? `for ${selectedMaterial.name}` : ''}`}
-                    noRowsMsg="Select a Material to show the customer demand"
-                    columns={dateColumns}
-                    rows={selectedMaterial ? createTableRows(selectedMaterial) : []}
-                    getRowId={(row) => row.id}
-                    hideFooter={true}
-                />
-            </div>
-        </div>
+            <Typography variant='h4' component='h1' fontWeight={600}>Dashboard</Typography>
+            <Tabs value={selectedTab} onChange={(_, value: number) => setSelectedTab(value)}>
+                <Tab label="Customer"></Tab>
+                <Tab label="Supplier"></Tab>
+            </Tabs>
+            <Box width='100%' display='flex' marginTop='0 !important' paddingBottom='2rem'>
+                <TabPanel value={selectedTab} index={0}>
+                    <Dashboard type='customer'/>
+                </TabPanel>
+                <TabPanel value={selectedTab} index={1}>
+                    <Dashboard type='supplier'/>
+                </TabPanel>
+            </Box>
+        </Stack>
     );
-}
+};


### PR DESCRIPTION
## Description

- implements #211 
- new layout to include future support for ShortTermMaterialDemand, DeliveryInformation and PlannedProductionOutput
- support for multi-sourcing and multi-customer views

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
