### PR TITLE
Refactor/dtr registrationtasks

### DIFF
--- a/DEPENDENCIES_FRONTEND
+++ b/DEPENDENCIES_FRONTEND
@@ -211,7 +211,7 @@ npm/npmjs/-/reusify/1.0.4, MIT, approved, clearlydefined
 npm/npmjs/-/rimraf/3.0.2, ISC, approved, clearlydefined
 npm/npmjs/-/rollup/4.9.5, MIT, approved, clearlydefined
 npm/npmjs/-/run-parallel/1.2.0, MIT, approved, clearlydefined
-npm/npmjs/-/scheduler/0.23.0, MIT, approved, clearlydefined
+npm/npmjs/-/scheduler/0.23.0, MIT, approved, #14589
 npm/npmjs/-/semver/6.3.1, ISC, approved, clearlydefined
 npm/npmjs/-/semver/7.5.4, ISC, approved, clearlydefined
 npm/npmjs/-/shebang-command/2.0.0, MIT, approved, clearlydefined

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/DataInjectionCommandLineRunner.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/DataInjectionCommandLineRunner.java
@@ -148,7 +148,7 @@ public class DataInjectionCommandLineRunner implements CommandLineRunner {
         Partner supplierPartner = createAndGetSupplierPartner();
         Material semiconductorMaterial = getNewSemiconductorMaterialForCustomer();
         Partner mySelf = partnerService.getOwnPartnerEntity();
-
+        semiconductorMaterial.setProductFlag(true);
         semiconductorMaterial = materialService.create(semiconductorMaterial);
         log.info(String.format("Created material: %s", semiconductorMaterial));
         List<Material> materialsFound = materialService.findAllMaterials();
@@ -161,7 +161,7 @@ public class DataInjectionCommandLineRunner implements CommandLineRunner {
 
 
         MaterialPartnerRelation semiconductorPartnerRelation = new MaterialPartnerRelation(semiconductorMaterial,
-            supplierPartner, semiconductorMatNbrSupplier, true, false);
+            supplierPartner, semiconductorMatNbrSupplier, true, true);
 //        semiconductorPartnerRelation.setPartnerCXNumber(semiconductorMatNbrCatenaX);
         mprService.create(semiconductorPartnerRelation);
         semiconductorPartnerRelation = mprService.find(semiconductorMaterial, supplierPartner);
@@ -220,6 +220,28 @@ public class DataInjectionCommandLineRunner implements CommandLineRunner {
             .build();
         reportedMaterialItemStock = reportedMaterialItemStockService.create(reportedMaterialItemStock);
         log.info("Created ReportedMaterialItemStock: \n" + reportedMaterialItemStock);
+
+        ProductItemStock productItemStock = ProductItemStock.builder()
+            .partner(supplierPartner)
+            .material(semiconductorMaterial)
+            .lastUpdatedOnDateTime(new Date())
+            .measurementUnit(ItemUnitEnumeration.UNIT_PIECE)
+            .quantity(33)
+            .locationBpna(mySelf.getSites().first().getAddresses().first().getBpna())
+            .locationBpns(mySelf.getSites().first().getBpns())
+            .build();
+        productItemStockService.create(productItemStock);
+
+        ReportedProductItemStock reportedProductItemStock = ReportedProductItemStock.builder()
+            .partner(supplierPartner)
+            .material(semiconductorMaterial)
+            .lastUpdatedOnDateTime(new Date())
+            .measurementUnit(ItemUnitEnumeration.UNIT_PIECE)
+            .quantity(44)
+            .locationBpns(supplierPartner.getSites().first().getBpns())
+            .locationBpna(supplierPartner.getSites().first().getAddresses().first().getBpna())
+            .build();
+        reportedProductItemStockService.create(reportedProductItemStock);
     }
 
     /**
@@ -228,6 +250,7 @@ public class DataInjectionCommandLineRunner implements CommandLineRunner {
     private void setupSupplierRole() {
         Partner customerPartner = createAndGetCustomerPartner();
         Material semiconductorMaterial = getNewSemiconductorMaterialForSupplier();
+        semiconductorMaterial.setMaterialFlag(true);
         Partner mySelf = partnerService.getOwnPartnerEntity();
 
         Site secondSite = new Site(
@@ -247,7 +270,7 @@ public class DataInjectionCommandLineRunner implements CommandLineRunner {
         log.info(String.format("Created product: %s", semiconductorMaterial));
 
         MaterialPartnerRelation semiconductorPartnerRelation = new MaterialPartnerRelation(semiconductorMaterial,
-            customerPartner, semiconductorMatNbrCustomer, false, true);
+            customerPartner, semiconductorMatNbrCustomer, true, true);
 //        semiconductorPartnerRelation.setPartnerCXNumber(semiconductorMatNbrCatenaX);
         semiconductorPartnerRelation = mprService.create(semiconductorPartnerRelation);
 
@@ -308,6 +331,28 @@ public class DataInjectionCommandLineRunner implements CommandLineRunner {
             .build();
         reportedProductItemStock = reportedProductItemStockService.create(reportedProductItemStock);
         log.info("Created ReportedProductItemStock \n" + reportedProductItemStock);
+
+       MaterialItemStock materialItemStock = MaterialItemStock.builder()
+           .partner(customerPartner)
+           .material(semiconductorMaterial)
+           .lastUpdatedOnDateTime(new Date())
+           .measurementUnit(ItemUnitEnumeration.UNIT_PIECE)
+           .quantity(400)
+           .locationBpna(siteLa.getAddresses().stream().findFirst().get().getBpna())
+           .locationBpns(siteLa.getBpns())
+           .build();
+       materialItemStockService.create(materialItemStock);
+
+       ReportedMaterialItemStock reportedMaterialItemStock = ReportedMaterialItemStock.builder()
+           .partner(customerPartner)
+           .material(semiconductorMaterial)
+           .lastUpdatedOnDateTime(new Date())
+           .measurementUnit(ItemUnitEnumeration.UNIT_PIECE)
+           .quantity(23)
+           .locationBpna(customerPartner.getSites().first().getAddresses().first().getBpna())
+           .locationBpns(customerPartner.getSites().first().getBpns())
+           .build();
+       reportedMaterialItemStockService.create(reportedMaterialItemStock);
     }
 
     /**
@@ -402,7 +447,7 @@ public class DataInjectionCommandLineRunner implements CommandLineRunner {
     private Material getNewSemiconductorMaterialForSupplier() {
         Material material = new Material();
         material.setOwnMaterialNumber(semiconductorMatNbrSupplier);
-        material.setMaterialNumberCx(semiconductorMatNbrCatenaX);
+//        material.setMaterialNumberCx(semiconductorMatNbrCatenaX);
         material.setProductFlag(true);
         material.setName("Semiconductor");
         return material;

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/DataInjectionCommandLineRunner.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/DataInjectionCommandLineRunner.java
@@ -162,7 +162,6 @@ public class DataInjectionCommandLineRunner implements CommandLineRunner {
 
         MaterialPartnerRelation semiconductorPartnerRelation = new MaterialPartnerRelation(semiconductorMaterial,
             supplierPartner, semiconductorMatNbrSupplier, true, true);
-//        semiconductorPartnerRelation.setPartnerCXNumber(semiconductorMatNbrCatenaX);
         mprService.create(semiconductorPartnerRelation);
         semiconductorPartnerRelation = mprService.find(semiconductorMaterial, supplierPartner);
         log.info("Found Relation: " + semiconductorPartnerRelation);
@@ -271,7 +270,6 @@ public class DataInjectionCommandLineRunner implements CommandLineRunner {
 
         MaterialPartnerRelation semiconductorPartnerRelation = new MaterialPartnerRelation(semiconductorMaterial,
             customerPartner, semiconductorMatNbrCustomer, true, true);
-//        semiconductorPartnerRelation.setPartnerCXNumber(semiconductorMatNbrCatenaX);
         semiconductorPartnerRelation = mprService.create(semiconductorPartnerRelation);
 
         log.info("Created Relation " + semiconductorPartnerRelation);
@@ -447,7 +445,6 @@ public class DataInjectionCommandLineRunner implements CommandLineRunner {
     private Material getNewSemiconductorMaterialForSupplier() {
         Material material = new Material();
         material.setOwnMaterialNumber(semiconductorMatNbrSupplier);
-//        material.setMaterialNumberCx(semiconductorMatNbrCatenaX);
         material.setProductFlag(true);
         material.setName("Semiconductor");
         return material;
@@ -456,7 +453,6 @@ public class DataInjectionCommandLineRunner implements CommandLineRunner {
     private Material getNewSemiconductorMaterialForCustomer() {
         Material material = new Material();
         material.setOwnMaterialNumber(semiconductorMatNbrCustomer);
-//        material.setMaterialNumberCx(semiconductorMatNbrCatenaX);
         material.setMaterialFlag(true);
         material.setName("Semiconductor");
         return material;

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/ddtr/domain/model/DigitalTwinMapping.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/ddtr/domain/model/DigitalTwinMapping.java
@@ -20,12 +20,10 @@
 
 package org.eclipse.tractusx.puris.backend.common.ddtr.domain.model;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @Entity
 @AllArgsConstructor
@@ -40,11 +38,5 @@ public class DigitalTwinMapping {
     private String ownMaterialNumber;
 
     private String productTwinId;
-
-    @ElementCollection
-    @CollectionTable(name = "suppliersmap", joinColumns = @JoinColumn(name = "own_mat_nbr", referencedColumnName = "ownMaterialNumber"))
-    @MapKeyColumn(name = "key")
-    @Column(name = "value")
-    private Map<String, String> materialSupplierTwinIds = new HashMap<>();
 
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/ddtr/logic/DigitalTwinMappingService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/ddtr/logic/DigitalTwinMappingService.java
@@ -24,7 +24,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.eclipse.tractusx.puris.backend.common.ddtr.domain.model.DigitalTwinMapping;
 import org.eclipse.tractusx.puris.backend.common.ddtr.domain.repository.DigitalTwinMappingRepository;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
-import org.eclipse.tractusx.puris.backend.masterdata.domain.model.MaterialPartnerRelation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -36,6 +35,7 @@ public class DigitalTwinMappingService {
 
     @Autowired
     private DigitalTwinMappingRepository repository;
+
 
     public DigitalTwinMapping create(Material material) {
         if(repository.findById(material.getOwnMaterialNumber()).isPresent()) {
@@ -59,19 +59,6 @@ public class DigitalTwinMappingService {
         var dtm = searchResult.get();
         if (material.isProductFlag()) {
             dtm.setProductTwinId(UUID.randomUUID().toString());
-        }
-        return repository.save(dtm);
-    }
-
-    public DigitalTwinMapping update(MaterialPartnerRelation mpr) {
-        var searchResult = repository.findById(mpr.getMaterial().getOwnMaterialNumber());
-        if (searchResult.isEmpty()) {
-            log.error("DTR Mapping did not exist. Update failed for " + mpr);
-            return null;
-        }
-        var dtm = searchResult.get();
-        if (mpr.getMaterial().isMaterialFlag() && mpr.isPartnerSuppliesMaterial()) {
-            dtm.getMaterialSupplierTwinIds().put(mpr.getPartner().getBpnl(), mpr.getPartnerCXNumber());
         }
         return repository.save(dtm);
     }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/ddtr/logic/DtrAdapterService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/ddtr/logic/DtrAdapterService.java
@@ -103,84 +103,73 @@ public class DtrAdapterService {
     /**
      * Updates an existing product-AAS with all corresponding customer partners.
      *
-     * @param material  The given Material
-     * @param mprs      The list of all MaterialProductRelations that exist with customers of the given Material
-     * @return          true, if the DTR signaled a successful registration
+     * @param material The given Material
+     * @param mprs     The list of all MaterialProductRelations that exist with customers of the given Material
+     * @return The HTTP response code from the DTR, or null if none was received
      */
-    public boolean updateProduct(Material material, List<MaterialPartnerRelation> mprs) {
+    public Integer updateProduct(Material material, List<MaterialPartnerRelation> mprs) {
         String twinId = digitalTwinMappingService.get(material).getProductTwinId();
         String idAsBase64 = Base64.getEncoder().encodeToString(twinId.getBytes(StandardCharsets.UTF_8));
         var body = dtrRequestBodyBuilder.createProductRegistrationRequestBody(material, twinId, mprs);
         try (var response = sendDtrPutRequest(body, List.of("api", "v3.0", "shell-descriptors", idAsBase64))) {
-            var bodyString = response.body().string();
-            log.info("Response Code " + response.code());
-            if (response.isSuccessful()) {
-                return true;
-            }
-            log.error("Failure in update for product twin " + material.getOwnMaterialNumber() + "\n" + bodyString);
+            return response.code();
         } catch (Exception e) {
             log.error("Failure in update for product twin " + material.getOwnMaterialNumber(), e);
         }
-        return false;
+        return null;
     }
 
     /**
      * Call this method when a new Material with a product flag was created in your MaterialService - or if a product
      * flag was later added to an existing Material.
-     *
+     * <p>
      * A new AAS will be registered for this Material at your dDTR.
      *
-     * @param material  The Material
-     * @return          true, if the DTR signaled a successful registration
+     * @param material The Material
+     * @return The HTTP response code from the DTR, or null if none was received
      */
-    public boolean registerProductAtDtr(Material material) {
+    public Integer registerProductAtDtr(Material material) {
         String twinId = digitalTwinMappingService.get(material).getProductTwinId();
         var body = dtrRequestBodyBuilder.createProductRegistrationRequestBody(material, twinId, List.of());
         try (var response = sendDtrPostRequest(body, List.of("api", "v3.0", "shell-descriptors"))) {
-            var bodyString = response.body().string();
-            if (response.isSuccessful()) {
-                return true;
-            }
-            log.error("Failed to register product at DTR " + material.getOwnMaterialNumber() + "\n" + bodyString);
+            return response.code();
         } catch (Exception e) {
             log.error("Failed to register product at DTR " + material.getOwnMaterialNumber(), e);
         }
-        return false;
+        return null;
     }
 
     /**
      * Call this method when a MaterialPartnerRelation was created or updated it's flag signals that this partner is
      * a supplier for the referenced Material.
      *
-     * @param supplierPartnerRelation   The MaterialPartnerRelation indicating a supplier for a given Material.
-     * @return
+     * @param supplierPartnerRelation The MaterialPartnerRelation indicating a supplier for a given Material.
+     * @return The HTTP response code from the DTR, or null if none was received
      */
-    public boolean registerMaterialAtDtr(MaterialPartnerRelation supplierPartnerRelation) {
+    public Integer registerMaterialAtDtr(MaterialPartnerRelation supplierPartnerRelation) {
         var body = dtrRequestBodyBuilder.createMaterialRegistrationRequestBody(supplierPartnerRelation);
         try (var response = sendDtrPostRequest(body, List.of("api", "v3.0", "shell-descriptors"))) {
-            var bodyString = response.body().string();
-            if(response.isSuccessful()) {
-                return true;
-            }
-            log.error("Failed to register material at DTR " + supplierPartnerRelation.getMaterial().getOwnMaterialNumber() + "\n" + bodyString);
+            return response.code();
         } catch (Exception e) {
             log.error("Failed to register material at DTR " + supplierPartnerRelation.getMaterial().getOwnMaterialNumber(), e);
         }
-        return false;
+        return null;
     }
 
-    public boolean updateMaterialAtDtr(MaterialPartnerRelation supplierPartnerRelation) {
+    /**
+     * Updates an existing material-AAS with the Information from the given MaterialPartnerRelation
+     *
+     * @param supplierPartnerRelation The MPR that indicates the material and the partner
+     * @return The HTTP response code from the DTR, or null if none was received
+     */
+    public Integer updateMaterialAtDtr(MaterialPartnerRelation supplierPartnerRelation) {
         var body = dtrRequestBodyBuilder.createMaterialRegistrationRequestBody(supplierPartnerRelation);
         String idAsBase64 = Base64.getEncoder().encodeToString(supplierPartnerRelation.getPartnerCXNumber().getBytes(StandardCharsets.UTF_8));
         try (var response = sendDtrPutRequest(body, List.of("api", "v3.0", "shell-descriptors", idAsBase64))) {
-            var bodyString = response.body().string();
-            if(response.isSuccessful()) {
-                return true;
-            }
-            log.error("Failed to register material at DTR " + supplierPartnerRelation.getMaterial().getOwnMaterialNumber() + "\n" + bodyString);
+            return response.code();
         } catch (Exception e) {
             log.error("Failed to register material at DTR " + supplierPartnerRelation.getMaterial().getOwnMaterialNumber(), e);
         }
-        return false;
+        return null;
     }
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/ddtr/logic/DtrAdapterService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/ddtr/logic/DtrAdapterService.java
@@ -111,7 +111,7 @@ public class DtrAdapterService {
         String twinId = digitalTwinMappingService.get(material).getProductTwinId();
         String idAsBase64 = Base64.getEncoder().encodeToString(twinId.getBytes(StandardCharsets.UTF_8));
         var body = dtrRequestBodyBuilder.createProductRegistrationRequestBody(material, twinId, mprs);
-        try (var response = sendDtrPutRequest(body, List.of("api", "v3.0", "shell-descriptors", idAsBase64))) {
+        try (var response = sendDtrPutRequest(body, List.of("api", "v3", "shell-descriptors", idAsBase64))) {
             return response.code();
         } catch (Exception e) {
             log.error("Failure in update for product twin " + material.getOwnMaterialNumber(), e);
@@ -131,7 +131,7 @@ public class DtrAdapterService {
     public Integer registerProductAtDtr(Material material) {
         String twinId = digitalTwinMappingService.get(material).getProductTwinId();
         var body = dtrRequestBodyBuilder.createProductRegistrationRequestBody(material, twinId, List.of());
-        try (var response = sendDtrPostRequest(body, List.of("api", "v3.0", "shell-descriptors"))) {
+        try (var response = sendDtrPostRequest(body, List.of("api", "v3", "shell-descriptors"))) {
             return response.code();
         } catch (Exception e) {
             log.error("Failed to register product at DTR " + material.getOwnMaterialNumber(), e);
@@ -148,7 +148,7 @@ public class DtrAdapterService {
      */
     public Integer registerMaterialAtDtr(MaterialPartnerRelation supplierPartnerRelation) {
         var body = dtrRequestBodyBuilder.createMaterialRegistrationRequestBody(supplierPartnerRelation);
-        try (var response = sendDtrPostRequest(body, List.of("api", "v3.0", "shell-descriptors"))) {
+        try (var response = sendDtrPostRequest(body, List.of("api", "v3", "shell-descriptors"))) {
             return response.code();
         } catch (Exception e) {
             log.error("Failed to register material at DTR " + supplierPartnerRelation.getMaterial().getOwnMaterialNumber(), e);
@@ -165,7 +165,7 @@ public class DtrAdapterService {
     public Integer updateMaterialAtDtr(MaterialPartnerRelation supplierPartnerRelation) {
         var body = dtrRequestBodyBuilder.createMaterialRegistrationRequestBody(supplierPartnerRelation);
         String idAsBase64 = Base64.getEncoder().encodeToString(supplierPartnerRelation.getPartnerCXNumber().getBytes(StandardCharsets.UTF_8));
-        try (var response = sendDtrPutRequest(body, List.of("api", "v3.0", "shell-descriptors", idAsBase64))) {
+        try (var response = sendDtrPutRequest(body, List.of("api", "v3", "shell-descriptors", idAsBase64))) {
             return response.code();
         } catch (Exception e) {
             log.error("Failed to register material at DTR " + supplierPartnerRelation.getMaterial().getOwnMaterialNumber(), e);

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
@@ -22,7 +22,6 @@ package org.eclipse.tractusx.puris.backend.common.edc.logic.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.*;
 import org.eclipse.tractusx.puris.backend.common.edc.domain.model.SubmodelType;
@@ -40,6 +39,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 /**
@@ -743,6 +743,13 @@ public class EdcAdapterService {
                 var jsonResponse = objectMapper.readTree(bodyString);
                 var resultArray = jsonResponse.get("result");
                 if (resultArray.isArray()) {
+                    if (resultArray.isEmpty()) {
+                        log.warn("No results found for query " + query);
+                    }
+                    if (resultArray.size() > 1) {
+                        log.warn("Found more than one result for query " + query);
+                        log.info(resultArray.toPrettyString());
+                    }
                     String aasId = resultArray.get(0).asText();
                     urlBuilder = HttpUrl.parse(edrDto.endpoint()).newBuilder()
                         .addPathSegment("api")

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/domain/model/MaterialPartnerRelation.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/domain/model/MaterialPartnerRelation.java
@@ -92,6 +92,18 @@ public class MaterialPartnerRelation {
             '}';
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof MaterialPartnerRelation that)) return false;
+        return Objects.equals(key, that.key);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(key);
+    }
+
     @Embeddable
     @Getter
     @Setter

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/controller/StockViewController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/controller/StockViewController.java
@@ -543,6 +543,7 @@ public class StockViewController {
             return new ResponseEntity<>(HttpStatusCode.valueOf(400));
         }
         Material materialEntity = materialService.findByOwnMaterialNumber(ownMaterialNumber);
+        log.info("Trigger Reported MaterialStockUpdate");
         log.info("Found material: " + (materialEntity != null) + " " + ownMaterialNumber);
         List<Partner> allSupplierPartnerEntities = mprService.findAllSuppliersForOwnMaterialNumber(ownMaterialNumber);
 
@@ -571,6 +572,7 @@ public class StockViewController {
             return new ResponseEntity<>(HttpStatusCode.valueOf(400));
         }
         Material materialEntity = materialService.findByOwnMaterialNumber(ownMaterialNumber);
+        log.info("Trigger Reported ProductStockUpdate");
         log.info("Found material: " + (materialEntity != null) + " " + ownMaterialNumber);
         List<Partner> allCustomerPartnerEntities = mprService.findAllCustomersForOwnMaterialNumber(ownMaterialNumber);
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/adapter/ItemStockSammMapper.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/adapter/ItemStockSammMapper.java
@@ -117,8 +117,7 @@ public class ItemStockSammMapper {
         String matNbrCatenaX = samm.getMaterialGlobalAssetId();
         ArrayList<ReportedProductItemStock> outputList = new ArrayList<>();
         if (samm.getDirection() != DirectionCharacteristic.INBOUND) {
-            log.warn("Direction should be INBOUND, aborting");
-            return outputList;
+            throw new IllegalArgumentException("Direction should be INBOUND, aborting");
         }
 
         // When deserializing a Samm from a customer, who has sent a report on the
@@ -127,11 +126,14 @@ public class ItemStockSammMapper {
         // the Samm is the one in our Material entity.
         Material material = materialService.findByMaterialNumberCx(matNbrCatenaX);
         if (material == null) {
-            log.warn("Could not identify materialPartnerRelation with matNbrCatenaX " + matNbrCatenaX + " and partner bpnl " + partner.getBpnl());
-            return outputList;
+            throw new IllegalArgumentException("Could not identify material with CatenaXNbr " + matNbrCatenaX);
         }
 
         var mpr = mprService.find(material, partner);
+        if (mpr == null) {
+            throw new IllegalArgumentException("Could not identify materialPartnerRelation with matNbrCatenaX "
+                + matNbrCatenaX + " and partner bpnl " + partner.getBpnl());
+        }
 
         for (var position : samm.getPositions()) {
             String supplierOrderId = null, customerOrderPositionId = null, customerOrderId = null;
@@ -165,23 +167,21 @@ public class ItemStockSammMapper {
         String matNbrCatenaX = samm.getMaterialGlobalAssetId();
         ArrayList<ReportedMaterialItemStock> outputList = new ArrayList<>();
         if (samm.getDirection() != DirectionCharacteristic.OUTBOUND) {
-            log.warn("Direction should be OUTBOUND, aborting");
-            return outputList;
+            throw new IllegalArgumentException("Direction should be OUTBOUND, aborting");
         }
         var mpr = mprService.findByPartnerAndPartnerCXNumber(partner, matNbrCatenaX);
 
         if (mpr == null) {
-            log.warn("Could not identify materialPartnerRelation with matNbrCatenaX " + matNbrCatenaX + " and partner bpnl " + partner.getBpnl());
-            return outputList;
+            throw new IllegalArgumentException("Could not identify materialPartnerRelation with matNbrCatenaX "
+                + matNbrCatenaX + " and partner bpnl " + partner.getBpnl());
         }
         // When deserializing a Samm from a supplier, who has sent a report on the
         // stocks he has prepared for us, the materialGlobalAssetId used in the communication
-        // was set by the supplying partner. Therefore the materialGlobalAssetId in
+        // was set by the supplying partner. Therefore, the materialGlobalAssetId in
         // the Samm is the one in our MaterialPartnerRelation entity with that partner.
         Material material = mpr.getMaterial();
         if (material == null) {
-            log.warn("Could not identify material with CatenaXNbr " + matNbrCatenaX);
-            return outputList;
+            throw new IllegalArgumentException("Could not identify material with CatenaXNbr " + matNbrCatenaX);
         }
 
         for (var position : samm.getPositions()) {

--- a/local/docker-compose.yaml
+++ b/local/docker-compose.yaml
@@ -90,6 +90,7 @@ services:
     ports:
       - "127.0.0.1:4243:4243"
     environment:
+      REGISTRY_IDM_OWNING_TENANT_ID: BPNL4444444444XX
       SPRING_DATASOURCE_DRIVERCLASSNAME: org.postgresql.Driver
       SPRING_DATASOURCE_URL: jdbc:postgresql://customer-postgres:5432/dtr_database
       SPRING_DATASOURCE_USERNAME: ${PG_USER}
@@ -234,6 +235,7 @@ services:
     ports:
       - "127.0.0.1:4244:4243"
     environment:
+      REGISTRY_IDM_OWNING_TENANT_ID: BPNL1234567890ZZ
       SPRING_DATASOURCE_DRIVERCLASSNAME: org.postgresql.Driver
       SPRING_DATASOURCE_URL: jdbc:postgresql://supplier-postgres:5432/dtr_database
       SPRING_DATASOURCE_USERNAME: ${PG_USER}

--- a/local/docker-compose.yaml
+++ b/local/docker-compose.yaml
@@ -77,13 +77,13 @@ services:
       - "host.docker.internal:host-gateway" # Adjusts container's host file to allow for communication with docker-host machine
 
   dtr-customer:
-    image: tractusx/sldt-digital-twin-registry:0.3.23
+    image: tractusx/sldt-digital-twin-registry:0.4.3
     container_name: dtr-customer
     depends_on:
       postgres-customer:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "wget", "-q", "--spider", "http://localhost:4243/api/v3.0/shell-descriptors" ]
+      test: [ "CMD", "wget", "-q", "--spider", "http://localhost:4243/api/v3/shell-descriptors" ]
       interval: 4s
       timeout: 3s
       retries: 15
@@ -222,13 +222,13 @@ services:
       - "host.docker.internal:host-gateway" # Adjusts container's host file to allow for communication with docker-host machine
 
   dtr-supplier:
-    image: tractusx/sldt-digital-twin-registry:0.3.23
+    image: tractusx/sldt-digital-twin-registry:0.4.3
     container_name: dtr-supplier
     depends_on:
       postgres-supplier:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "wget", "-q", "--spider", "http://localhost:4243/api/v3.0/shell-descriptors" ]
+      test: [ "CMD", "wget", "-q", "--spider", "http://localhost:4243/api/v3/shell-descriptors" ]
       interval: 4s
       timeout: 3s
       retries: 15


### PR DESCRIPTION

## Description
- Removed DtrRegistrationTask from MaterialServiceImpl
- Refactored DtrRegistrationTask in MaterialPartnerRelationImpl for better resilience
- previously, a product registration was not performed as long as an eventual material registration failed, under these circumstances, all registrations failed in cases where two partners are supplier und customer for the same material to each other
- edited the DataInjectionCommandlineRunner in order to test the aforementioned scenario. It is debatable whether these changes should be included into the main branch. If not, we should remove them before merging. 
- Updated DTR to version 0.4.3 (from 0.3.23)
- included API changes resulting from that upgrade
- removed unused fields from DigitalTwinMapping entity
- in ItemStockSammMapper, replaced warnings with IllegalArgumentExceptions, because otherwise a faulty Samm would cause the ItemStockRequestApiService would delete all previous ItemStock data without receiving update data from a valid Samm. 


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
