### PR TITLE
Ci(helm-test): don't fail on chart version check failure

### DIFF
--- a/.act/pr_event.json
+++ b/.act/pr_event.json
@@ -1,0 +1,5 @@
+{
+    "repository": {
+        "default_branch": "main"
+    }
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+<!-- 
+Thanks for your contribution! 
+Please follow the instructions on your PRs title and description.
+aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
+Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
+Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
+-->
+
+## Description
+<!-- 
+Please describe your PR: 
+- What does this PR introduce? 
+- Does it fix a bug? 
+- Does it add a new feature?
+- Is it enhancing documentation?
+-->
+
+<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
+
+## Pre-review checks
+
+Please ensure to do as many of the following checks as possible, before asking for committer review:
+
+- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
+- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
+- [ ] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).

--- a/.github/workflows/build-image-backend.yml
+++ b/.github/workflows/build-image-backend.yml
@@ -41,7 +41,7 @@ env:
     IMAGE_NAME: "app-puris-backend"
 
 jobs:
-    docker:
+    docker-backend:
         if: github.repository_owner == 'eclipse-tractusx' # prevent running on forks
         runs-on: ubuntu-latest
         permissions:

--- a/.github/workflows/build-image-frontend.yml
+++ b/.github/workflows/build-image-frontend.yml
@@ -45,7 +45,7 @@ env:
     REPOSITORY: "${{ github.repository }}"
 
 jobs:
-    docker:
+    docker-frontend:
         if: github.repository_owner == 'eclipse-tractusx' # prevent running on forks
         runs-on: ubuntu-latest
         permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ on:
 
 jobs:
   analyze:
-    name: Analyze
+    name: Analyze CodeQl
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
     #   - https://gh.io/supported-runners-and-hardware-resources

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -103,7 +103,7 @@ jobs:
                     fi
 
             -   name: Run chart-testing (lint)
-                run: ct lint --validate-maintainers=false --target-branch ${{ github.event.repository.default_branch }}
+                run: ct lint --validate-maintainers=false --check-version-increment=false --target-branch ${{ github.event.repository.default_branch }}
 
             -   name: Run chart-testing (install)
                 run: |
@@ -126,3 +126,11 @@ jobs:
                     helm dependency update charts/puris
                     helm upgrade puris charts/puris
                 if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'
+
+            # check version increment should fail separately
+            # we don't directly release a chart and thus maybe don't need to increase the version.
+            # to enable this behaviour otterdog has been reconfigured
+            -   name: Run chart-testing (version update)
+                id: version-check
+                run: |
+                    ct lint --validate-maintainers=false --check-version-increment=true --target-branch ${{ github.event.repository.default_branch }}

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -39,7 +39,7 @@ on:
 
 jobs:
   analyze:
-    name: Analyze
+    name: Analyze KICS
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -223,6 +223,26 @@ docker exec -it {container-id} crictl rmi puris-backend:dev
 docker exec -it {container-id} crictl rmi puris-frontend:dev
 ```
 
+## Testing Workflows locally
+
+[act](https://github.com/nektos/act) is a tool to run jobs within `./workflows` locally. Configuration of events can
+be stored in `./act`
+
+Install by downloading the released binaries and add them to your path.
+
+```shell
+cd <root dir of repo>
+
+act --list
+>> Stage  Job ID                       Job name                     Workflow name                                   Workflow file              Events                                      
+>> 0      check-dependencies-backend   check-dependencies-backend   3rd Party Dependency Check (Eclipse Dash Tool)  dash-dependency-check.yml  workflow_dispatch,pull_request              
+>> 0      check-dependencies-frontend  check-dependencies-frontend  3rd Party Dependency Check (Eclipse Dash Tool)  dash-dependency-check.yml  workflow_dispatch,pull_request              
+>> 0      lint-test                    lint-test                    Lint and Test Charts                            helm-test.yml              pull_request,workflow_dispatch     
+
+# run action with job-id lint-test for event as defined in pr-event.json
+act --job lint-test -e .act/pr-event.json
+```
+
 ## NOTICE
 
 This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

We currently do not always release every change in the helm chart. Thus increasing the version leads to confusion.

As a result I updated the workflow to
- exclude version check as a failure reason during lint
- in the end perform version check to fail (reminder to check on what to do)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
