### PR TITLE
Fix: Publishing cxId to DTR

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/MaterialPartnerRelationServiceImpl.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/MaterialPartnerRelationServiceImpl.java
@@ -90,10 +90,18 @@ public class MaterialPartnerRelationServiceImpl implements MaterialPartnerRelati
 
     /**
      * Call this method when a partnerCXId for a Material was needed but not found.
-     * This method will trigger a new PartTypeInformation Task for any material that
-     * the given partner supplies, but still misses a partnerCXId.
+     * This method will trigger a new Task for any material that
+     * the given partner supplies, but still misses a partnerCXId. This task will
+     * try to fetch the partner's CX Id for all materials that this partner supplies
+     * and where this partner's CX Id is still unknown.
      *
      * This method will block until all tasks have finished, if any.
+     * <p>
+     * Please consider that calling this method can only bring any meaningful results, when
+     * the corresponding material entity is properly registered and there exists a
+     * MaterialPartnerRelation for the given material and the given partner, where the
+     * partner is designated as supplier. I.e. please make sure to always keep your masterdata
+     * entities up-to-date.
      *
      * @param supplierPartner The supplier partner
      */
@@ -104,7 +112,7 @@ public class MaterialPartnerRelationServiceImpl implements MaterialPartnerRelati
             .stream()
             .filter(mpr -> mpr.getPartnerCXNumber() == null)
             .filter(mpr -> !currentPartTypeFetches.contains(mpr))
-            .map(mpr -> executorService.submit(new PartTypeInformationRetrievalTask(mpr, 1)))
+            .map(mpr -> executorService.submit(new DtrRegistrationTask(mpr, 1)))
             .toList();
         if (futures.isEmpty()) {
             return;


### PR DESCRIPTION
## Description
- i noticed that when the triggerPartTypeRetrievalTask method is called, there is currently no mechanism to make sure that a cx id that was fetched as a result of that method call is immediately published to the respective shell descriptor at the DTR. 
- the fix for this is to initiate a DtrRegistration Task instead of just a PartTypeInformationRetrievalTask. A DtrRegistrationTask will always trigger a PartTypeInformationRetrievalTask when it notices that there is a missing CX id from a supplier partner. But beyond that it will also send an update for the approriate shell descriptor to the DTR
 


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
