### PR TITLE
fix: potential information loss

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/erpadapter/domain/model/ErpAdapterTriggerDataset.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/erpadapter/domain/model/ErpAdapterTriggerDataset.java
@@ -29,6 +29,7 @@ import org.eclipse.tractusx.puris.backend.common.edc.domain.model.AssetType;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.Objects;
 
 @Entity
 @IdClass(ErpAdapterTriggerDataset.Key.class)
@@ -36,7 +37,6 @@ import java.util.Date;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-@EqualsAndHashCode
 public class ErpAdapterTriggerDataset {
 
     @Id
@@ -65,6 +65,20 @@ public class ErpAdapterTriggerDataset {
             ", lastPartnerRequest=" + new Date(lastPartnerRequest) +
             ", nextErpRequestScheduled=" + new Date(nextErpRequestScheduled) +
             '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ErpAdapterTriggerDataset dataset)) return false;
+        return Objects.equals(partnerBpnl, dataset.partnerBpnl) && Objects.equals(ownMaterialNumber,
+            dataset.ownMaterialNumber) && assetType == dataset.assetType &&
+            Objects.equals(directionCharacteristic, dataset.directionCharacteristic);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(partnerBpnl, ownMaterialNumber, assetType, directionCharacteristic);
     }
 
     @Getter


### PR DESCRIPTION
## Description
- there is a potential case, that the most recent information can get lost, if a scheduled erp adapter request and a call to the notifyPartnerRequest are happening at nearly the same time
- provided a fix for this


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
