### PR TITLE
chore: bump dtr version from 0.4.3 to 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Beside the dependencies provided in the Helm Chart, the following dependencies h
 | Application                                                                                                       | App Version | Chart Version |
 |-------------------------------------------------------------------------------------------------------------------|-------------|---------------|
 | [Tractus-X Connector](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector)       | 0.7.2       | 0.7.2         |
-| [Digital Twin Registry](https://github.com/eclipse-tractusx/sldt-digital-twin-registry/tree/main/charts/registry) | 0.4.3       | 0.4.11        |
+| [Digital Twin Registry](https://github.com/eclipse-tractusx/sldt-digital-twin-registry/tree/main/charts/registry) | 0.5.0       | 0.5.0         |
 
 ## Known Knows
 

--- a/local/docker-compose.yaml
+++ b/local/docker-compose.yaml
@@ -78,7 +78,7 @@ services:
       - "host.docker.internal:host-gateway" # Adjusts container's host file to allow for communication with docker-host machine
 
   dtr-customer:
-    image: tractusx/sldt-digital-twin-registry:0.4.3
+    image: tractusx/sldt-digital-twin-registry:0.5.0
     container_name: dtr-customer
     depends_on:
       postgres-all:
@@ -235,7 +235,7 @@ services:
       - "host.docker.internal:host-gateway" # Adjusts container's host file to allow for communication with docker-host machine
 
   dtr-supplier:
-    image: tractusx/sldt-digital-twin-registry:0.4.3
+    image: tractusx/sldt-digital-twin-registry:0.5.0
     container_name: dtr-supplier
     depends_on:
       postgres-all:


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

solves #488 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
