### PR TITLE
chore: update tx-edc 0.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Beside the dependencies provided in the Helm Chart, the following dependencies h
 
 | Application                                                                                                       | App Version | Chart Version |
 |-------------------------------------------------------------------------------------------------------------------|-------------|---------------|
-| [Tractus-X Connector](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector)       | 0.7.2       | 0.7.2         |
+| [Tractus-X Connector](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector)       | 0.7.3       | 0.7.3         |
 | [Digital Twin Registry](https://github.com/eclipse-tractusx/sldt-digital-twin-registry/tree/main/charts/registry) | 0.5.0       | 0.5.0         |
 
 ## Known Knows

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
@@ -34,8 +34,6 @@ import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
 import org.eclipse.tractusx.puris.backend.stock.logic.dto.itemstocksamm.DirectionCharacteristic;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.RequestEntity;
-import org.springframework.http.RequestEntity.BodyBuilder;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
@@ -202,7 +200,7 @@ public class EdcAdapterService {
 
     private boolean createSubmodelContractDefinitionForPartner(String semanticId, String assetId, Partner partner) {
         var body = edcRequestBodyBuilder.buildSubmodelContractDefinitionWithBpnRestrictedPolicy(assetId, partner);
-        try (var response = sendPostRequest(body, List.of("v2", "contractdefinitions"))) {
+        try (var response = sendPostRequest(body, List.of("v3", "contractdefinitions"))) {
             if (!response.isSuccessful()) {
                 log.warn("Contract definition registration failed for partner " + partner.getBpnl() + " and {} Submodel", semanticId);
                 if (response.body() != null) {
@@ -219,7 +217,7 @@ public class EdcAdapterService {
 
     private boolean createDtrContractDefinitionForPartner(Partner partner) {
         var body = edcRequestBodyBuilder.buildDtrContractDefinitionForPartner(partner);
-        try (var response = sendPostRequest(body, List.of("v2", "contractdefinitions"))) {
+        try (var response = sendPostRequest(body, List.of("v3", "contractdefinitions"))) {
             if (!response.isSuccessful()) {
                 log.warn("Contract definition registration failed for partner " + partner.getBpnl() + " and DTR");
                 return false;
@@ -241,7 +239,7 @@ public class EdcAdapterService {
      */
     private boolean createBpnlAndMembershipPolicyDefinitionForPartner(Partner partner) {
         var body = edcRequestBodyBuilder.buildBpnAndMembershipRestrictedPolicy(partner);
-        try (var response = sendPostRequest(body, List.of("v2", "policydefinitions"))) {
+        try (var response = sendPostRequest(body, List.of("v3", "policydefinitions"))) {
             if (!response.isSuccessful()) {
                 log.warn("Policy Registration failed");
                 if (response.body() != null) {
@@ -263,7 +261,7 @@ public class EdcAdapterService {
      */
     private boolean createContractPolicy() {
         var body = edcRequestBodyBuilder.buildFrameworkPolicy();
-        try (var response = sendPostRequest(body, List.of("v2", "policydefinitions"))) {
+        try (var response = sendPostRequest(body, List.of("v3", "policydefinitions"))) {
             if (!response.isSuccessful()) {
                 log.warn("Framework Policy Registration failed");
                 if (response.body() != null) {
@@ -325,7 +323,7 @@ public class EdcAdapterService {
      * @return The response containing the full catalog, if successful
      */
     public Response getCatalogResponse(String dspUrl, String partnerBpnl, Map<String, String> filter) throws IOException {
-        return sendPostRequest(edcRequestBodyBuilder.buildBasicCatalogRequestBody(dspUrl, partnerBpnl, filter), List.of("v2", "catalog", "request"));
+        return sendPostRequest(edcRequestBodyBuilder.buildBasicCatalogRequestBody(dspUrl, partnerBpnl, filter), List.of("v3", "catalog", "request"));
     }
 
     /**
@@ -376,7 +374,7 @@ public class EdcAdapterService {
         // use dspUrl as provided, if set - else use partner
         dspUrl = dspUrl != null && !dspUrl.isEmpty() ? dspUrl : partner.getEdcUrl();
         var requestBody = edcRequestBodyBuilder.buildAssetNegotiationBody(partner, catalogItem, dspUrl);
-        try (Response response = sendPostRequest(requestBody, List.of("v2", "contractnegotiations"))) {
+        try (Response response = sendPostRequest(requestBody, List.of("v3", "contractnegotiations"))) {
             JsonNode responseNode = objectMapper.readTree(response.body().string());
             log.debug("Result from negotiation {}", responseNode.toPrettyString());
             return responseNode;
@@ -393,7 +391,7 @@ public class EdcAdapterService {
      * @throws IOException If the connection to your control plane fails
      */
     public JsonNode getNegotiationState(String negotiationId) throws IOException {
-        try (var response = sendGetRequest(List.of("v2", "contractnegotiations", negotiationId))) {
+        try (var response = sendGetRequest(List.of("v3", "contractnegotiations", negotiationId))) {
             String stringData = response.body().string();
             return objectMapper.readTree(stringData);
         }
@@ -408,7 +406,7 @@ public class EdcAdapterService {
      */
     public Response getAllNegotiations() throws IOException {
         var requestBody = edcRequestBodyBuilder.buildNegotiationsRequestBody();
-        return sendPostRequest(requestBody, List.of("v2", "contractnegotiations", "request"));
+        return sendPostRequest(requestBody, List.of("v3", "contractnegotiations", "request"));
     }
 
     /**
@@ -423,7 +421,7 @@ public class EdcAdapterService {
      */
     public JsonNode initiateProxyPullTransfer(Partner partner, String contractId, String assetId, String partnerEdcUrl) throws IOException {
         var body = edcRequestBodyBuilder.buildProxyPullRequestBody(partner, contractId, assetId, partnerEdcUrl);
-        try (var response = sendPostRequest(body, List.of("v2", "transferprocesses"))) {
+        try (var response = sendPostRequest(body, List.of("v3", "transferprocesses"))) {
             String data = response.body().string();
             JsonNode result = objectMapper.readTree(data);
             log.debug("Got response from Proxy pull transfer init: {}", result.toPrettyString());
@@ -445,7 +443,7 @@ public class EdcAdapterService {
      * @throws IOException If the connection to your control plane fails
      */
     public JsonNode getTransferState(String transferId) throws IOException {
-        try (var response = sendGetRequest(List.of("v2", "transferprocesses", transferId))) {
+        try (var response = sendGetRequest(List.of("v3", "transferprocesses", transferId))) {
             String data = response.body().string();
             return objectMapper.readTree(data);
         }
@@ -461,7 +459,7 @@ public class EdcAdapterService {
     public Response getAllTransfers() throws IOException {
         var requestBody = edcRequestBodyBuilder.buildTransfersRequestBody();
         log.debug("GetAllTransfers Request: {}", requestBody.toPrettyString());
-        return sendPostRequest(requestBody, List.of("v2", "transferprocesses", "request"));
+        return sendPostRequest(requestBody, List.of("v3", "transferprocesses", "request"));
     }
 
     /**
@@ -473,7 +471,7 @@ public class EdcAdapterService {
      * @throws IOException If the connection to your control plane fails
      */
     public String getContractAgreement(String contractAgreementId) throws IOException {
-        try (var response = sendGetRequest(List.of("v2", "contractagreements", contractAgreementId))) {
+        try (var response = sendGetRequest(List.of("v3", "contractagreements", contractAgreementId))) {
             return response.body().string();
         }
     }
@@ -987,7 +985,7 @@ public class EdcAdapterService {
 
         JsonNode body = edcRequestBodyBuilder.buildTransferProcessTerminationBody("Transfer done.");
 
-        try (Response response = sendPostRequest(body, List.of("v2", "transferprocesses", transferProcessId, "terminate"))) {
+        try (Response response = sendPostRequest(body, List.of("v3", "transferprocesses", transferProcessId, "terminate"))) {
 
             JsonNode resultNode = objectMapper.readTree(response.body().string());
             if (!response.isSuccessful()) {

--- a/local/tractus-x-edc/config/customer/data-plane.properties
+++ b/local/tractus-x-edc/config/customer/data-plane.properties
@@ -57,3 +57,5 @@ edc.iam.trusted-issuer.portal.id=did:web:mock-util-service/trusted-issuer
 tx.iam.credentialservice.url=http://mock-util-service:80
 # don't use https during did resolving in catalog request
 edc.iam.did.web.use.https=false
+
+edc.dpf.selector.url=http://customer-control-plane:8183/api/controlplane/control/v1/dataplanes

--- a/local/tractus-x-edc/config/supplier/data-plane.properties
+++ b/local/tractus-x-edc/config/supplier/data-plane.properties
@@ -58,3 +58,5 @@ edc.iam.trusted-issuer.portal.id=did:web:mock-util-service/trusted-issuer
 tx.iam.credentialservice.url=http://mock-util-service:80
 # don't use https during did resolving in catalog request
 edc.iam.did.web.use.https=false
+
+edc.dpf.selector.url=http://supplier-control-plane:9183/api/controlplane/control/v1/dataplanes

--- a/local/tractus-x-edc/docker-compose.yaml
+++ b/local/tractus-x-edc/docker-compose.yaml
@@ -21,13 +21,13 @@
 version: "3"
 services:
   control-plane:
-    image: tractusx/edc-controlplane-postgresql-hashicorp-vault:0.7.2
+    image: tractusx/edc-controlplane-postgresql-hashicorp-vault:0.7.3
     volumes:
       - ./config/default/opentelemetry.properties:/app/opentelemetry.properties
       - ./config/default/logging.properties:/app/logging.properties
 
   data-plane:
-    image: tractusx/edc-dataplane-hashicorp-vault:0.7.2
+    image: tractusx/edc-dataplane-hashicorp-vault:0.7.3
     volumes:
       - ./config/default/opentelemetry.properties:/app/opentelemetry.properties
       - ./config/default/logging.properties:/app/logging.properties


### PR DESCRIPTION
## Description
- local docker deployment uses TX-EDC version 0.7.3
- EdcAdapterService now calls 'v3' management api endpoints on control-plane


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
