### PR TITLE
fix: swagger_ui inconsistencies

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/delivery/controller/DeliveryController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/delivery/controller/DeliveryController.java
@@ -20,15 +20,12 @@
 
 package org.eclipse.tractusx.puris.backend.delivery.controller;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
-import javax.management.openmbean.KeyAlreadyExistsException;
-
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Validator;
+import lombok.extern.slf4j.Slf4j;
 import org.eclipse.tractusx.puris.backend.common.util.PatternStore;
 import org.eclipse.tractusx.puris.backend.delivery.domain.model.OwnDelivery;
 import org.eclipse.tractusx.puris.backend.delivery.domain.model.ReportedDelivery;
@@ -47,24 +44,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.validation.Validator;
-import lombok.extern.slf4j.Slf4j;
+import javax.management.openmbean.KeyAlreadyExistsException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("delivery")
@@ -119,10 +108,10 @@ public class DeliveryController {
     @ResponseBody
     @Operation(summary = "Creates a new delivery")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Delivery was created."),
-            @ApiResponse(responseCode = "400", description = "Malformed or invalid request body."),
-            @ApiResponse(responseCode = "409", description = "Delivery already exists."),
-            @ApiResponse(responseCode = "500", description = "Internal Server Error.")
+            @ApiResponse(responseCode = "201", description = "Delivery was created."),
+            @ApiResponse(responseCode = "400", description = "Malformed or invalid request body.", content = @Content),
+            @ApiResponse(responseCode = "409", description = "Delivery already exists.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error.", content = @Content)
     })
     @ResponseStatus(HttpStatus.CREATED)
     public DeliveryDto createDelivery(@RequestBody DeliveryDto deliveryDto) {
@@ -153,12 +142,12 @@ public class DeliveryController {
     @PutMapping()
     @Operation(summary = "Updates a delivery by its UUID")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "Delivery was updated."),
-            @ApiResponse(responseCode = "400", description = "Malformed or invalid request body."),
-            @ApiResponse(responseCode = "404", description = "Delivery does not exist."),
-            @ApiResponse(responseCode = "500", description = "Internal Server Error.")
+            @ApiResponse(responseCode = "202", description = "Delivery was updated."),
+            @ApiResponse(responseCode = "400", description = "Malformed or invalid request body.", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Delivery does not exist.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error.", content = @Content)
     })
-    @ResponseStatus(HttpStatus.OK)
+    @ResponseStatus(HttpStatus.ACCEPTED)
     public DeliveryDto updateDelivery(@RequestBody DeliveryDto dto) {
         OwnDelivery updatedDelivery = ownDeliveryService.update(convertToEntity(dto));
         if (updatedDelivery == null) {

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/delivery/controller/DeliveryRequestApiController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/delivery/controller/DeliveryRequestApiController.java
@@ -21,6 +21,7 @@
 package org.eclipse.tractusx.puris.backend.delivery.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.extern.slf4j.Slf4j;
@@ -49,12 +50,13 @@ public class DeliveryRequestApiController {
     private final Pattern urnPattern = PatternStore.URN_OR_UUID_PATTERN;
 
 
-    @Operation(summary = "This endpoint receives the Delivery Information Submodel 2.0.0 requests")
+    @Operation(summary = "This endpoint receives the Delivery Information Submodel 2.0.0 requests. " +
+        "This endpoint is meant to be accessed by partners via EDC only. ")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Ok"),
-        @ApiResponse(responseCode = "400", description = "Bad Request"),
-        @ApiResponse(responseCode = "500", description = "Internal Server Error"),
-        @ApiResponse(responseCode = "501", description = "Unsupported representation")
+        @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content),
+        @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content),
+        @ApiResponse(responseCode = "501", description = "Unsupported representation", content = @Content)
     })
     @GetMapping("request/{materialNumberCx}/{representation}")
     public ResponseEntity<DeliveryInformation> getDeliveryMapping(

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/demand/controller/DemandController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/demand/controller/DemandController.java
@@ -19,15 +19,11 @@ SPDX-License-Identifier: Apache-2.0
 */
 package org.eclipse.tractusx.puris.backend.demand.controller;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
-import javax.management.openmbean.KeyAlreadyExistsException;
-
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Validator;
 import org.eclipse.tractusx.puris.backend.common.util.PatternStore;
 import org.eclipse.tractusx.puris.backend.demand.domain.model.OwnDemand;
 import org.eclipse.tractusx.puris.backend.demand.domain.model.ReportedDemand;
@@ -41,7 +37,6 @@ import org.eclipse.tractusx.puris.backend.masterdata.logic.dto.PartnerDto;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.MaterialPartnerRelationService;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.MaterialService;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.PartnerService;
-
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -50,10 +45,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.validation.Validator;
+import javax.management.openmbean.KeyAlreadyExistsException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("demand")
@@ -100,9 +98,9 @@ public class DemandController {
     @Operation(summary = "Creates a new demand")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Demand was created."),
-            @ApiResponse(responseCode = "400", description = "Malformed or invalid request body."),
-            @ApiResponse(responseCode = "409", description = "Demand already exists. Use PUT instead."),
-            @ApiResponse(responseCode = "500", description = "Internal Server Error.")
+            @ApiResponse(responseCode = "400", description = "Malformed or invalid request body.", content = @Content),
+            @ApiResponse(responseCode = "409", description = "Demand already exists. Use PUT instead.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error.", content = @Content)
     })
     @ResponseStatus(HttpStatus.CREATED)
     public DemandDto createDemand(@RequestBody DemandDto demandDto) {
@@ -133,9 +131,9 @@ public class DemandController {
     @Operation(summary = "Updates a demand by its UUID")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Demand was updated."),
-            @ApiResponse(responseCode = "400", description = "Malformed or invalid request body."),
-            @ApiResponse(responseCode = "404", description = "Demand does not exist."),
-            @ApiResponse(responseCode = "500", description = "Internal Server Error.")
+            @ApiResponse(responseCode = "400", description = "Malformed or invalid request body.", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Demand does not exist.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error.", content = @Content)
     })
     @ResponseStatus(HttpStatus.OK)
     public DemandDto updateDemand(@RequestBody DemandDto dto) {

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/demand/controller/DemandRequestApiController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/demand/controller/DemandRequestApiController.java
@@ -21,6 +21,7 @@
 package org.eclipse.tractusx.puris.backend.demand.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.extern.slf4j.Slf4j;
@@ -49,12 +50,13 @@ public class DemandRequestApiController {
     private final Pattern urnPattern = PatternStore.URN_OR_UUID_PATTERN;
 
 
-    @Operation(summary = "This endpoint receives the ShortTermMaterialDemand Submodel 1.0.0 requests")
+    @Operation(summary = "This endpoint receives the ShortTermMaterialDemand Submodel 1.0.0 requests. " +
+        "This endpoint is meant to be accessed by partners via EDC only. ")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Ok"),
-        @ApiResponse(responseCode = "400", description = "Bad Request"),
-        @ApiResponse(responseCode = "500", description = "Internal Server Error"),
-        @ApiResponse(responseCode = "501", description = "Unsupported representation")
+        @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content),
+        @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content),
+        @ApiResponse(responseCode = "501", description = "Unsupported representation", content = @Content)
     })
     @GetMapping("request/{materialnumbercx}/{representation}")
     public ResponseEntity<ShortTermMaterialDemand> getDemandMapping(

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/demandandcapacitynotification/controller/DemandAndCapacityNotificationController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/demandandcapacitynotification/controller/DemandAndCapacityNotificationController.java
@@ -19,17 +19,13 @@ SPDX-License-Identifier: Apache-2.0
 */
 package org.eclipse.tractusx.puris.backend.demandandcapacitynotification.controller;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.stream.Collectors;
-
-import javax.management.openmbean.KeyAlreadyExistsException;
-
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Validator;
+import jakarta.validation.constraints.Pattern;
 import org.eclipse.tractusx.puris.backend.common.util.PatternStore;
-import org.eclipse.tractusx.puris.backend.demand.logic.services.DemandRequestApiService;
 import org.eclipse.tractusx.puris.backend.demandandcapacitynotification.domain.model.OwnDemandAndCapacityNotification;
 import org.eclipse.tractusx.puris.backend.demandandcapacitynotification.domain.model.ReportedDemandAndCapacityNotification;
 import org.eclipse.tractusx.puris.backend.demandandcapacitynotification.logic.dto.DemandAndCapacityNotificationDto;
@@ -39,22 +35,21 @@ import org.eclipse.tractusx.puris.backend.demandandcapacitynotification.logic.se
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Site;
-import org.eclipse.tractusx.puris.backend.masterdata.logic.dto.PartnerDto;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.MaterialService;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.PartnerService;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.validation.Validator;
-import jakarta.validation.constraints.Pattern;
+import javax.management.openmbean.KeyAlreadyExistsException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("demand-and-capacity-notification")
@@ -99,9 +94,9 @@ public class DemandAndCapacityNotificationController {
     @Operation(summary = "Creates a new notification")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Notification was created."),
-            @ApiResponse(responseCode = "400", description = "Malformed or invalid request body."),
-            @ApiResponse(responseCode = "409", description = "Notification already exists. Use PUT instead."),
-            @ApiResponse(responseCode = "500", description = "Internal Server Error.")
+            @ApiResponse(responseCode = "400", description = "Malformed or invalid request body.", content = @Content),
+            @ApiResponse(responseCode = "409", description = "Notification already exists. Use PUT instead.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error.", content = @Content)
     })
     @ResponseStatus(HttpStatus.CREATED)
     public DemandAndCapacityNotificationDto createNotification(@RequestBody DemandAndCapacityNotificationDto notificationDto) {
@@ -131,9 +126,9 @@ public class DemandAndCapacityNotificationController {
     @Operation(summary = "Updates a notification by its UUID")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Notification was updated."),
-            @ApiResponse(responseCode = "400", description = "Malformed or invalid request body."),
-            @ApiResponse(responseCode = "404", description = "Notification does not exist."),
-            @ApiResponse(responseCode = "500", description = "Internal Server Error.")
+            @ApiResponse(responseCode = "400", description = "Malformed or invalid request body.", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Notification does not exist.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error.", content = @Content)
     })
     @ResponseStatus(HttpStatus.OK)
     public DemandAndCapacityNotificationDto updateNotification(@RequestBody DemandAndCapacityNotificationDto dto) {

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/demandandcapacitynotification/controller/DemandAndCapacityNotificationRequestApiController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/demandandcapacitynotification/controller/DemandAndCapacityNotificationRequestApiController.java
@@ -51,7 +51,8 @@ public class DemandAndCapacityNotificationRequestApiController {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @Operation(summary = "This endpoint receives the DemandAndCapacityNotification 2.0.0 requests")
+    @Operation(summary = "This endpoint receives the DemandAndCapacityNotification 2.0.0 requests. " +
+        "This endpoint is meant to be accessed by partners via EDC only. ")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Ok", content = @Content),
         @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content),

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/MaterialController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/MaterialController.java
@@ -23,6 +23,7 @@ package org.eclipse.tractusx.puris.backend.masterdata.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Validator;
@@ -130,8 +131,8 @@ public class MaterialController {
     @Operation(description = "Returns the requested Material dto, specified by the given ownMaterialNumber.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Returns the requested Material."),
-        @ApiResponse(responseCode = "400", description = "Invalid parameter"),
-        @ApiResponse(responseCode = "404", description = "Requested Material was not found.")
+        @ApiResponse(responseCode = "400", description = "Invalid parameter", content = @Content),
+        @ApiResponse(responseCode = "404", description = "Requested Material was not found.", content = @Content)
     })
     public ResponseEntity<MaterialEntityDto> getMaterial(@Parameter(name = "ownMaterialNumber",
         description = "The Material Number that is used in your own company to identify the Material.",

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartTypeInformationController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartTypeInformationController.java
@@ -22,6 +22,7 @@ package org.eclipse.tractusx.puris.backend.masterdata.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +30,7 @@ import org.eclipse.tractusx.puris.backend.common.util.PatternStore;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.adapter.PartTypeInformationSammMapper;
+import org.eclipse.tractusx.puris.backend.masterdata.logic.dto.parttypeinformation.PartTypeInformationSAMM;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.MaterialPartnerRelationService;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.MaterialService;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.PartnerService;
@@ -57,20 +59,21 @@ public class PartTypeInformationController {
     private PartTypeInformationSammMapper sammMapper;
 
     @Operation(description = "Endpoint that delivers PartTypeInformation of own products to customer partners. " +
-        "'materialnumber' must be set to the ownMaterialNumber of " +
-        "the party, that receives the request")
+        "'materialnumber' must be set to the ownMaterialNumber of the party, that receives the request. Please note that the " +
+        "SAMMs delivered by this endpoint don't provide partClassification and partSitesInformationAsPlanned data. " +
+        "This endpoint is meant to be accessed by partners via EDC only. ")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Ok"),
-        @ApiResponse(responseCode = "400", description = "Invalid request parameters. "),
-        @ApiResponse(responseCode = "401", description = "Access forbidden. "),
-        @ApiResponse(responseCode = "404", description = "Product not found for given parameters. "),
-        @ApiResponse(responseCode = "501", description = "Unsupported representation requested. ")
+        @ApiResponse(responseCode = "400", description = "Invalid request parameters. ", content = @Content),
+        @ApiResponse(responseCode = "401", description = "Access forbidden. ", content = @Content),
+        @ApiResponse(responseCode = "404", description = "Product not found for given parameters. ", content = @Content),
+        @ApiResponse(responseCode = "501", description = "Unsupported representation requested. ", content = @Content)
     })
     @GetMapping("/{materialnumber}/{representation}")
-    public ResponseEntity<?> getMapping(@RequestHeader("edc-bpn") String bpnl,
-                                        @Parameter(description = "The material number that the request receiving party uses for the material in question")
+    public ResponseEntity<PartTypeInformationSAMM> getMapping(@RequestHeader("edc-bpn") String bpnl,
+                                                              @Parameter(description = "The material number that the request receiving party uses for the material in question")
                                         @PathVariable String materialnumber,
-                                        @Parameter(description = "Must be set to '$value'") @PathVariable String representation) {
+                                                              @Parameter(description = "Must be set to '$value'") @PathVariable String representation) {
         materialnumber = new String (Base64.getDecoder().decode(materialnumber.getBytes(StandardCharsets.UTF_8)));
         if (!bpnlPattern.matcher(bpnl).matches() || !materialNumberPattern.matcher(materialnumber).matches()) {
             return ResponseEntity.badRequest().build();

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartnerController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartnerController.java
@@ -23,6 +23,7 @@ package org.eclipse.tractusx.puris.backend.masterdata.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Validator;
@@ -195,9 +196,9 @@ public class PartnerController {
     @Operation(description = "Returns the requested PartnerDto.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Found Partner, returning it in response body."),
-        @ApiResponse(responseCode = "400", description = "Invalid parameter."),
-        @ApiResponse(responseCode = "404", description = "Requested Partner not found."),
-        @ApiResponse(responseCode = "500", description = "Internal Server Error.")
+        @ApiResponse(responseCode = "400", description = "Invalid parameter.", content = @Content),
+        @ApiResponse(responseCode = "404", description = "Requested Partner not found.", content = @Content),
+        @ApiResponse(responseCode = "500", description = "Internal Server Error.", content = @Content)
     })
     public ResponseEntity<PartnerDto> getPartner(
         @Parameter(description = "The unique BPNL that was assigned to that Partner.",

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/production/controller/ProductionController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/production/controller/ProductionController.java
@@ -20,15 +20,11 @@
 
 package org.eclipse.tractusx.puris.backend.production.controller;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
-import javax.management.openmbean.KeyAlreadyExistsException;
-
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Validator;
 import org.eclipse.tractusx.puris.backend.common.util.PatternStore;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
@@ -39,9 +35,9 @@ import org.eclipse.tractusx.puris.backend.masterdata.logic.service.PartnerServic
 import org.eclipse.tractusx.puris.backend.production.domain.model.OwnProduction;
 import org.eclipse.tractusx.puris.backend.production.domain.model.ReportedProduction;
 import org.eclipse.tractusx.puris.backend.production.logic.dto.ProductionDto;
-import org.eclipse.tractusx.puris.backend.production.logic.service.ReportedProductionService;
 import org.eclipse.tractusx.puris.backend.production.logic.service.OwnProductionService;
 import org.eclipse.tractusx.puris.backend.production.logic.service.ProductionRequestApiService;
+import org.eclipse.tractusx.puris.backend.production.logic.service.ReportedProductionService;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -50,10 +46,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.validation.Validator;
+import javax.management.openmbean.KeyAlreadyExistsException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("production")
@@ -100,9 +99,9 @@ public class ProductionController {
     @Operation(summary = "Creates a new planned production")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Planned Production was created."),
-            @ApiResponse(responseCode = "400", description = "Malformed or invalid request body."),
-            @ApiResponse(responseCode = "409", description = "Planned Production already exists."),
-            @ApiResponse(responseCode = "500", description = "Internal Server Error.")
+            @ApiResponse(responseCode = "400", description = "Malformed or invalid request body.", content = @Content),
+            @ApiResponse(responseCode = "409", description = "Planned Production already exists.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error.", content = @Content)
     })
     @ResponseStatus(HttpStatus.CREATED)
     public ProductionDto createProduction(@RequestBody ProductionDto productionDto) {
@@ -135,9 +134,9 @@ public class ProductionController {
     @Operation(summary = "Creates a range of planned productions")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "Planned Productions were created."),
-            @ApiResponse(responseCode = "400", description = "Malformed or invalid request body."),
-            @ApiResponse(responseCode = "409", description = "Planned Productions already exist."),
-            @ApiResponse(responseCode = "500", description = "Internal Server Error.")
+            @ApiResponse(responseCode = "400", description = "Malformed or invalid request body.", content = @Content),
+            @ApiResponse(responseCode = "409", description = "Planned Productions already exist.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error.", content = @Content)
     })
     @ResponseStatus(HttpStatus.CREATED)
     public List<ProductionDto> createProductionRange(@RequestBody List<ProductionDto> productionDtos) {
@@ -169,9 +168,9 @@ public class ProductionController {
     @Operation(summary = "Updates a planned production by its UUID")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Planned Productions was updated."),
-            @ApiResponse(responseCode = "400", description = "Malformed or invalid request body."),
-            @ApiResponse(responseCode = "404", description = "Planned Production does not exist."),
-            @ApiResponse(responseCode = "500", description = "Internal Server Error.")
+            @ApiResponse(responseCode = "400", description = "Malformed or invalid request body.", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Planned Production does not exist.", content = @Content),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error.", content = @Content)
     })
     @ResponseStatus(HttpStatus.OK)
     public ProductionDto updateProduction(@RequestBody ProductionDto dto) {

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/production/controller/ProductionRequestApiController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/production/controller/ProductionRequestApiController.java
@@ -21,6 +21,7 @@
 package org.eclipse.tractusx.puris.backend.production.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.extern.slf4j.Slf4j;
@@ -49,12 +50,13 @@ public class ProductionRequestApiController {
     private final Pattern urnPattern = PatternStore.URN_OR_UUID_PATTERN;
 
 
-    @Operation(summary = "This endpoint receives the PlannedProduction Submodel 2.0.0 requests")
+    @Operation(summary = "This endpoint receives the PlannedProduction Submodel 2.0.0 requests. " +
+        "This endpoint is meant to be accessed by partners via EDC only. ")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Ok"),
-        @ApiResponse(responseCode = "400", description = "Bad Request"),
-        @ApiResponse(responseCode = "500", description = "Internal Server Error"),
-        @ApiResponse(responseCode = "501", description = "Unsupported representation")
+        @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content),
+        @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content),
+        @ApiResponse(responseCode = "501", description = "Unsupported representation", content = @Content)
     })
     @GetMapping("request/{materialnumbercx}/{representation}")
     public ResponseEntity<PlannedProductionOutput> getProductionMapping(

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/controller/ItemStockRequestApiController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/controller/ItemStockRequestApiController.java
@@ -21,6 +21,7 @@
 package org.eclipse.tractusx.puris.backend.stock.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.extern.slf4j.Slf4j;
@@ -51,12 +52,13 @@ public class ItemStockRequestApiController {
     private final Pattern urnPattern = PatternStore.URN_OR_UUID_PATTERN;
 
 
-    @Operation(summary = "This endpoint receives the ItemStock Submodel 2.0.0 requests")
+    @Operation(summary = "This endpoint receives the ItemStock Submodel 2.0.0 requests. " +
+        "This endpoint is meant to be accessed by partners via EDC only. ")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Ok"),
-        @ApiResponse(responseCode = "400", description = "Bad Request"),
-        @ApiResponse(responseCode = "500", description = "Internal Server Error"),
-        @ApiResponse(responseCode = "501", description = "Unsupported representation")
+        @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content),
+        @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content),
+        @ApiResponse(responseCode = "501", description = "Unsupported representation", content = @Content)
     })
     @GetMapping("request/{materialnumber}/{direction}/{representation}")
     public ResponseEntity<ItemStockSamm> getMappingItemStock2(@RequestHeader("edc-bpn") String bpnl,

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/controller/StockViewController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/controller/StockViewController.java
@@ -120,7 +120,7 @@ public class StockViewController {
             @ExampleObject(name = "Basic sample", value = "{" +
                 "  \"BPNL1234567890ZZ\": \"MNR-8101-ID146955.001\"," +
                 "  \"BPNL4444444444XX\": \"MNR-7307-AU340474.002\"}")})),
-        @ApiResponse(responseCode = "400", description = "Invalid parameter")})
+        @ApiResponse(responseCode = "400", description = "Invalid parameter", content = @Content)})
     public ResponseEntity<Map<String, String>> getMaterialNumbers(@RequestParam String ownMaterialNumber) {
         if (!materialPattern.matcher(ownMaterialNumber).matches()) {
             return new ResponseEntity<>(HttpStatusCode.valueOf(400));
@@ -152,9 +152,9 @@ public class StockViewController {
     @Operation(description = "Creates a new product-stock")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Product Stock was created."),
-        @ApiResponse(responseCode = "400", description = "Malformed or invalid request body."),
-        @ApiResponse(responseCode = "409", description = "Product Stock does already exist."),
-        @ApiResponse(responseCode = "500", description = "Internal Server Error.")
+        @ApiResponse(responseCode = "400", description = "Malformed or invalid request body.", content = @Content),
+        @ApiResponse(responseCode = "409", description = "Product Stock does already exist.", content = @Content),
+        @ApiResponse(responseCode = "500", description = "Internal Server Error.", content = @Content)
     })
     public ProductStockDto createProductStocks(@RequestBody ProductStockDto productStockDto) {
         if(!validator.validate(productStockDto).isEmpty()) {
@@ -210,8 +210,8 @@ public class StockViewController {
     @Operation(description = "Updates an existing productstock")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Product Stock was updated."),
-        @ApiResponse(responseCode = "400", description = "Malformed request body."),
-        @ApiResponse(responseCode = "500", description = "Internal Server Error.")
+        @ApiResponse(responseCode = "400", description = "Malformed request body.", content = @Content),
+        @ApiResponse(responseCode = "500", description = "Internal Server Error.", content = @Content)
     })
     public ProductStockDto updateProductStocks(@RequestBody ProductStockDto productStockDto) {
         if(!validator.validate(productStockDto).isEmpty()) {
@@ -300,9 +300,9 @@ public class StockViewController {
     @Operation(description = "Creates a new material-stock")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Material Stock was created."),
-        @ApiResponse(responseCode = "400", description = "Malformed or invalid request body."),
-        @ApiResponse(responseCode = "409", description = "Material Stock does already exist."),
-        @ApiResponse(responseCode = "500", description = "Internal Server Error.")
+        @ApiResponse(responseCode = "400", description = "Malformed or invalid request body.", content = @Content),
+        @ApiResponse(responseCode = "409", description = "Material Stock does already exist.", content = @Content),
+        @ApiResponse(responseCode = "500", description = "Internal Server Error.", content = @Content)
     })
     public MaterialStockDto createMaterialStocks(@RequestBody MaterialStockDto materialStockDto) {
         if(!validator.validate(materialStockDto).isEmpty()) {
@@ -355,8 +355,8 @@ public class StockViewController {
     @Operation(description = "Updates an existing material-stock")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Material Stock was updated."),
-        @ApiResponse(responseCode = "400", description = "Malformed request body."),
-        @ApiResponse(responseCode = "500", description = "Internal Server Error.")
+        @ApiResponse(responseCode = "400", description = "Malformed request body.", content = @Content),
+        @ApiResponse(responseCode = "500", description = "Internal Server Error.", content = @Content)
     })
     public MaterialStockDto updateMaterialStocks(@RequestBody MaterialStockDto materialStockDto) {
         if(!validator.validate(materialStockDto).isEmpty()) {
@@ -431,7 +431,7 @@ public class StockViewController {
         " Only stocks for the given material number are returned.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "OK"),
-        @ApiResponse(responseCode = "400", description = "Invalid parameter")
+        @ApiResponse(responseCode = "400", description = "Invalid parameter", content = @Content)
     })
     public ResponseEntity<List<ReportedMaterialStockDto>> getSupplierMaterialStocks(@RequestParam String ownMaterialNumber) {
         if (!materialPattern.matcher(ownMaterialNumber).matches()) {
@@ -467,7 +467,7 @@ public class StockViewController {
         " Only stocks for the given material number are returned.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "OK"),
-        @ApiResponse(responseCode = "400", description = "Invalid parameter")
+        @ApiResponse(responseCode = "400", description = "Invalid parameter", content = @Content)
     })
     public ResponseEntity<List<ReportedProductStockDto>> getCustomerProductStocks(@RequestParam String ownMaterialNumber) {
         if (!materialPattern.matcher(ownMaterialNumber).matches()) {
@@ -502,7 +502,7 @@ public class StockViewController {
     @Operation(description = "Returns a list of all Partners that are ordering the given material")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "OK"),
-        @ApiResponse(responseCode = "400", description = "Invalid parameter")
+        @ApiResponse(responseCode = "400", description = "Invalid parameter", content = @Content)
     })
     public ResponseEntity<List<PartnerDto>> getCustomerPartnersOrderingMaterial(@RequestParam String ownMaterialNumber) {
         if (!materialPattern.matcher(ownMaterialNumber).matches()) {
@@ -517,7 +517,7 @@ public class StockViewController {
     @Operation(description = "Returns a list of all Partners that are supplying the given material")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "OK"),
-        @ApiResponse(responseCode = "400", description = "Invalid parameter")
+        @ApiResponse(responseCode = "400", description = "Invalid parameter", content = @Content)
     })
     public ResponseEntity<List<PartnerDto>> getSupplierPartnersSupplyingMaterial(@RequestParam String ownMaterialNumber) {
         if (!materialPattern.matcher(ownMaterialNumber).matches()) {
@@ -536,7 +536,7 @@ public class StockViewController {
         "call to the GET reported-material-stocks endpoint.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "OK"),
-        @ApiResponse(responseCode = "400", description = "Invalid parameter")
+        @ApiResponse(responseCode = "400", description = "Invalid parameter", content = @Content)
     })
     public ResponseEntity<List<PartnerDto>> triggerReportedMaterialStockUpdateForMaterialNumber(@RequestParam String ownMaterialNumber) {
         if (!materialPattern.matcher(ownMaterialNumber).matches()) {
@@ -565,7 +565,7 @@ public class StockViewController {
         "call to the GET reported-material-stocks endpoint.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "OK"),
-        @ApiResponse(responseCode = "400", description = "Invalid parameter")
+        @ApiResponse(responseCode = "400", description = "Invalid parameter", content = @Content)
     })
     public ResponseEntity<List<PartnerDto>> triggerReportedProductStockUpdateForMaterialNumber(@RequestParam String ownMaterialNumber) {
         if (!materialPattern.matcher(ownMaterialNumber).matches()) {


### PR DESCRIPTION
## Description
- made edits to various rest controller classes, where the current swagger ui was indicating a response body in error cases
- some minor inconsistency fixes
- solves #515 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
