### PR TITLE
Add truffle hog workflow

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -36,15 +36,28 @@ jobs:
         with:
           path: ./  # Scan the entire repository
           base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
-          extra_args: --filter-entropy=4 --results=verified,unknown --json-output=results.json
-      
-      - name: Save TruffleHog results
-        run: cat results.json
-        continue-on-error: true  # Allow workflow to continue even if secrets are found
-        id: trufflehog_output
+          extra_args: --filter-entropy=4 --results=verified,unknown --json ./ > output.txt
 
-      - name: Upload TruffleHog results
-        uses: actions/upload-artifact@v3
+      - name: Format TruffleHog results
+        id: format_trufflehog
+        run: |
+          cat output.txt | grep -oE "\"stringsFound\"\:.[.\"]}" | sed -e "s/,\"]//" -e "s/}//" | sed "s/\"stringsFound\"://" | grep -o "\".\"" | awk -F "," '{ for(i=1;i<=NF;i++) print $i}' > formatted_results.txt
+          cat formatted_results.txt
+
+      - name: Save TruffleHog results
+        id: save_results
+        run: cat formatted_results.txt
+        continue-on-error: true
+      
+      - name: Post TruffleHog results in summary
+        uses: actions/github-script@v6
         with:
-          name: trufflehog-results
-          path: results.json
+          script: |
+            const fs = require('fs');
+            const results = fs.readFileSync('formatted_results.txt', 'utf8');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `### TruffleHog Scan Results\n\`\`\`\n${results}\n\`\`\``
+            });

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           path: ./  # Scan the entire repository
           base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
-          extra_args: --filter-entropy=4 --results=verified,unknown --json . > output.txt
+          extra_args: --filter-entropy=4 --results=verified,unknown --json > output.txt
 
       - name: Format TruffleHog results
         id: format_trufflehog

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           path: ./  # Scan the entire repository
           base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
-          extra_args: --filter-entropy=4 --results=verified,unknown --json 
+          extra_args: --filter-entropy=4 --results=verified,unknown
       
       - name: Scan Results Status
         if: steps.trufflehog.outcome == 'failure'

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -36,29 +36,3 @@ jobs:
           path: ./  # Scan the entire repository
           base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
           extra_args: --filter-entropy=4 --results=verified,unknown --json 
-
-      - name: Post TruffleHog results in summary
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const fs = require('fs');
-
-            try {
-              // Read the TruffleHog JSON output
-              const results = fs.readFileSync('trufflehog.json', 'utf8');
-              const parsedResults = JSON.parse(results);
-
-              // Check for findings
-              if (parsedResults.stringsFound.length > 0) {
-                core.info('### TruffleHog Scan Results - Found Potential Secrets!');
-                core.info('```json');
-                core.info(results);
-                core.info('```');
-              } else {
-                core.info('### TruffleHog Scan Results - No Secrets Found!');
-                core.info('No potential secrets were found in your code.');
-              }
-            } catch (error) {
-              core.error(`Error reading or parsing TruffleHog output: ${error.message}`);
-              core.setFailed('Failed to process TruffleHog output');
-            }

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           path: ./  # Scan the entire repository
           base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
-          extra_args: --filter-entropy=4 --results=verified,unknown
+          extra_args: --filter-entropy=4 --results=verified,unknown --debug
       
       - name: Scan Results Status
         if: steps.trufflehog.outcome == 'failure'

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -22,9 +22,6 @@ jobs:
   ScanSecrets:
     name: Scan secrets
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -36,12 +36,7 @@ jobs:
         with:
           path: ./  # Scan the entire repository
           base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
-          extra_args: --filter-entropy=4 --results=verified,unknown --json . > results.sarif
-      
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: results.sarif
+          extra_args: --filter-entropy=4 --results=verified,unknown ﻿.
       
       - name: Scan Results Status
         if: steps.trufflehog.outcome == 'failure'

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -35,29 +35,33 @@ jobs:
         with:
           path: ./  # Scan the entire repository
           base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
-          extra_args: --filter-entropy=4 --results=verified,unknown --json  # Removed redirection (> output.txt)
+          extra_args: --filter-entropy=4 --results=verified,unknown --json 
 
-      - name: Format TruffleHog results (Optional)
-        id: format_trufflehog
-        run: |
-          # This step is optional and can be removed if raw JSON output is preferred
-          cat trufflehog.json | jq -r '.stringsFound | .[]' | awk -F "," '{ for(i=1;i<=NF;i++) print $i}' > formatted_results.txt
-          cat formatted_results.txt  # Display formatted results for debugging (optional)
+  - name: Post TruffleHog results in summary
+  uses: actions/github-script@v6
+  with:
+    script: |
+      const fs = require('fs');
 
-      - name: Upload TruffleHog results
-        uses: actions/upload-artifact@v3
-        with:
-          name: trufflehog-results
-          path: formatted_results.txt  # Upload formatted results (optional)
+      // Read the TruffleHog output file (raw JSON or formatted)
+      const results = fs.readFileSync('formatted_results.txt' || 'trufflehog.json', 'utf8');
 
-      - name: Post TruffleHog results in summary
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const fs = require('fs');
-            # Read the TruffleHog output file (raw JSON or formatted)
-            const results = fs.readFileSync('formatted_results.txt' || 'trufflehog.json', 'utf8');  # Adjust file path based on your preference
-            core.summary
-              .addHeading('TruffleHog Scan Results')
-              .addCodeBlock(results, 'json')
-              .write();
+      // Parse the JSON results
+      const parsedResults = JSON.parse(results);
+
+      // Check for any findings
+      if (parsedResults.stringsFound.length > 0) {
+        // Found potential secrets! Take action.
+        core.summary
+          .addHeading('TruffleHog Scan Results - Found Potential Secrets!')
+          .addAlert('Potential secrets were found in your code!')
+          .write();
+
+      } else {
+        // No findings! Good news.
+        core.summary
+          .addHeading('TruffleHog Scan Results - No Secrets Found!')
+          .addSuccess('Your code appears to be free of secrets!')
+          .write();
+      }
+

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           path: ./  # Scan the entire repository
           base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
-          extra_args: --filter-entropy=4 --output results.sarif --results=verified,unknown
+          extra_args: --filter-entropy=4 --results=verified,unknown --json | tee results.sarif
       
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -22,6 +22,9 @@ jobs:
   ScanSecrets:
     name: Scan secrets
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,5 +1,4 @@
-name: "Trufflehog"
-
+name: "TruffleHog"
 on:
   push:
     branches:
@@ -36,26 +35,28 @@ jobs:
         with:
           path: ./  # Scan the entire repository
           base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
-          extra_args: --filter-entropy=4 --results=verified,unknown --json > output.txt
+          extra_args: --filter-entropy=4 --results=verified,unknown --json  # Removed redirection (> output.txt)
 
-      - name: Format TruffleHog results
+      - name: Format TruffleHog results (Optional)
         id: format_trufflehog
         run: |
-          cat output.txt | grep -oE "\"stringsFound\"\:.[.\"]}" | sed -e "s/,\"]//" -e "s/}//" | sed "s/\"stringsFound\"://" | grep -o "\".\"" | awk -F "," '{ for(i=1;i<=NF;i++) print $i}' > formatted_results.txt
-          cat formatted_results.txt
+          # This step is optional and can be removed if raw JSON output is preferred
+          cat trufflehog.json | jq -r '.stringsFound | .[]' | awk -F "," '{ for(i=1;i<=NF;i++) print $i}' > formatted_results.txt
+          cat formatted_results.txt  # Display formatted results for debugging (optional)
 
       - name: Upload TruffleHog results
         uses: actions/upload-artifact@v3
         with:
           name: trufflehog-results
-          path: formatted_results.txt
+          path: formatted_results.txt  # Upload formatted results (optional)
 
       - name: Post TruffleHog results in summary
         uses: actions/github-script@v6
         with:
           script: |
             const fs = require('fs');
-            const results = fs.readFileSync('formatted_results.txt', 'utf8');
+            # Read the TruffleHog output file (raw JSON or formatted)
+            const results = fs.readFileSync('formatted_results.txt' || 'trufflehog.json', 'utf8');  # Adjust file path based on your preference
             core.summary
               .addHeading('TruffleHog Scan Results')
               .addCodeBlock(results, 'json')

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -29,10 +29,14 @@ jobs:
           fetch-depth: 0  # Ensure full clone for pull request workflows
           ref: ${{ github.head_ref }}  # Fetch specific branch/commit for pull requests
 
-      - name: Run TruffleHog OSS
+      - name: TruffleHog OSS
         id: trufflehog
-        run: trufflehog --entropy=NO --regex --json . > output.txt
+        uses: trufflesecurity/trufflehog@main
         continue-on-error: true  # Allow workflow to continue even if secrets are found
+        with:
+          path: ./  # Scan the entire repository
+          base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
+          extra_args: --filter-entropy=4 --results=verified,unknown --json . > output.txt
 
       - name: Format TruffleHog results
         id: format_trufflehog

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           path: ./  # Scan the entire repository
           base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
-          extra_args: --filter-entropy=4 --results=verified,unknown --json | tee results.sarif
+          extra_args: --filter-entropy=4 --results=verified,unknown --json . > results.sarif
       
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -6,6 +6,8 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *" # Once a day
 
 permissions:
   actions: read

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -2,12 +2,14 @@ name: "TruffleHog"
 
 on:
   push:
-    branches:
-      - main
+    branches: [ main ]
   pull_request:
-  workflow_dispatch:
+  
   schedule:
     - cron: "0 0 * * *" # Once a day
+    
+  workflow_dispatch:
+  # Trigger manually
 
 permissions:
   actions: read

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -37,31 +37,30 @@ jobs:
           base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
           extra_args: --filter-entropy=4 --results=verified,unknown --json 
 
-  - name: Post TruffleHog results in summary
-  uses: actions/github-script@v6
-  with:
-    script: |
-      const fs = require('fs');
+      - name: Post TruffleHog results in summary
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require('fs');
 
-      // Read the TruffleHog output file (raw JSON or formatted)
-      const results = fs.readFileSync('formatted_results.txt' || 'trufflehog.json', 'utf8');
+            // Read the TruffleHog output file (raw JSON or formatted)
+            const results = fs.readFileSync('formatted_results.txt' || 'trufflehog.json', 'utf8');
 
-      // Parse the JSON results
-      const parsedResults = JSON.parse(results);
+            // Parse the JSON results
+            const parsedResults = JSON.parse(results);
 
-      // Check for any findings
-      if (parsedResults.stringsFound.length > 0) {
-        // Found potential secrets! Take action.
-        core.summary
-          .addHeading('TruffleHog Scan Results - Found Potential Secrets!')
-          .addAlert('Potential secrets were found in your code!')
-          .write();
+            // Check for any findings
+            if (parsedResults.stringsFound.length > 0) {
+              // Found potential secrets! Take action.
+              core.summary
+                .addHeading('TruffleHog Scan Results - Found Potential Secrets!')
+                .addAlert('Potential secrets were found in your code!')
+                .write();
 
-      } else {
-        // No findings! Good news.
-        core.summary
-          .addHeading('TruffleHog Scan Results - No Secrets Found!')
-          .addSuccess('Your code appears to be free of secrets!')
-          .write();
-      }
-
+            } else {
+              // No findings! Good news.
+              core.summary
+                .addHeading('TruffleHog Scan Results - No Secrets Found!')
+                .addSuccess('Your code appears to be free of secrets!')
+                .write();
+            }

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,0 +1,50 @@
+name: "Trufflehog"
+
+on:
+  push:
+    branches:
+      - main
+      - test  # Add your test branch here
+  pull_request:
+    branches:
+      - main
+      - test  # Add your test branch here
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+  id-token: write
+  issues: write
+
+jobs:
+  ScanSecrets:
+    name: Scan secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Ensure full clone for pull request workflows
+          ref: ${{ github.head_ref }}  # Fetch specific branch/commit for pull requests
+
+      - name: TruffleHog OSS
+        id: trufflehog
+        uses: trufflesecurity/trufflehog@main
+        #continue-on-error: true  # Allow workflow to continue even if secrets are found
+        with:
+          path: ./  # Scan the entire repository
+          base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
+          extra_args: --filter-entropy=4 --results=verified,unknown
+      
+      - name: Save TruffleHog results
+        run: cat results.json
+        continue-on-error: true  # Allow workflow to continue even if secrets are found
+        id: trufflehog_output
+
+      - name: Upload TruffleHog results
+        uses: actions/upload-artifact@v3
+        with:
+          name: trufflehog-results
+          path: results.json

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -32,11 +32,11 @@ jobs:
       - name: TruffleHog OSS
         id: trufflehog
         uses: trufflesecurity/trufflehog@main
-        #continue-on-error: true  # Allow workflow to continue even if secrets are found
+        continue-on-error: true  # Allow workflow to continue even if secrets are found
         with:
           path: ./  # Scan the entire repository
           base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
-          extra_args: --filter-entropy=4 --results=verified,unknown
+          extra_args: --filter-entropy=4 --results=verified,unknown --json-output=results.json
       
       - name: Save TruffleHog results
         run: cat results.json

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           path: ./  # Scan the entire repository
           base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
-          extra_args: --filter-entropy=4 -o results.sarif --results=verified,unknown
+          extra_args: --filter-entropy=4 --output results.sarif --results=verified,unknown
       
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -4,11 +4,7 @@ on:
   push:
     branches:
       - main
-      - test  # Add your test branch here
   pull_request:
-    branches:
-      - main
-      - test  # Add your test branch here
   workflow_dispatch:
 
 permissions:
@@ -32,7 +28,7 @@ jobs:
       - name: TruffleHog OSS
         id: trufflehog
         uses: trufflesecurity/trufflehog@main
-        continue-on-error: true  # Allow workflow to continue even if secrets are found
+        continue-on-error: true
         with:
           path: ./  # Scan the entire repository
           base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -29,14 +29,10 @@ jobs:
           fetch-depth: 0  # Ensure full clone for pull request workflows
           ref: ${{ github.head_ref }}  # Fetch specific branch/commit for pull requests
 
-      - name: TruffleHog OSS
+      - name: Run TruffleHog OSS
         id: trufflehog
-        uses: trufflesecurity/trufflehog@main
+        run: trufflehog --entropy=NO --regex --json . > output.txt
         continue-on-error: true  # Allow workflow to continue even if secrets are found
-        with:
-          path: ./  # Scan the entire repository
-          base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
-          extra_args: --filter-entropy=4 --results=verified,unknown --json ./ > output.txt
 
       - name: Format TruffleHog results
         id: format_trufflehog
@@ -44,20 +40,19 @@ jobs:
           cat output.txt | grep -oE "\"stringsFound\"\:.[.\"]}" | sed -e "s/,\"]//" -e "s/}//" | sed "s/\"stringsFound\"://" | grep -o "\".\"" | awk -F "," '{ for(i=1;i<=NF;i++) print $i}' > formatted_results.txt
           cat formatted_results.txt
 
-      - name: Save TruffleHog results
-        id: save_results
-        run: cat formatted_results.txt
-        continue-on-error: true
-      
+      - name: Upload TruffleHog results
+        uses: actions/upload-artifact@v3
+        with:
+          name: trufflehog-results
+          path: formatted_results.txt
+
       - name: Post TruffleHog results in summary
         uses: actions/github-script@v6
         with:
           script: |
             const fs = require('fs');
             const results = fs.readFileSync('formatted_results.txt', 'utf8');
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `### TruffleHog Scan Results\n\`\`\`\n${results}\n\`\`\``
-            });
+            core.summary
+              .addHeading('TruffleHog Scan Results')
+              .addCodeBlock(results, 'json')
+              .write();

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -36,3 +36,7 @@ jobs:
           path: ./  # Scan the entire repository
           base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
           extra_args: --filter-entropy=4 --results=verified,unknown --json 
+      
+      - name: Scan Results Status
+        if: steps.trufflehog.outcome == 'failure'
+        run: exit 1  # Set workflow run to failure if TruffleHog finds secrets 

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           path: ./  # Scan the entire repository
           base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
-          extra_args: --filter-entropy=4 --results=verified,unknown ﻿.
+          extra_args: --filter-entropy=4 --results=verified,unknown
       
       - name: Scan Results Status
         if: steps.trufflehog.outcome == 'failure'

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -43,24 +43,22 @@ jobs:
           script: |
             const fs = require('fs');
 
-            // Read the TruffleHog output file (raw JSON or formatted)
-            const results = fs.readFileSync('formatted_results.txt' || 'trufflehog.json', 'utf8');
+            try {
+              // Read the TruffleHog JSON output
+              const results = fs.readFileSync('trufflehog.json', 'utf8');
+              const parsedResults = JSON.parse(results);
 
-            // Parse the JSON results
-            const parsedResults = JSON.parse(results);
-
-            // Check for any findings
-            if (parsedResults.stringsFound.length > 0) {
-              // Found potential secrets! Take action.
-              core.summary
-                .addHeading('TruffleHog Scan Results - Found Potential Secrets!')
-                .addAlert('Potential secrets were found in your code!')
-                .write();
-
-            } else {
-              // No findings! Good news.
-              core.summary
-                .addHeading('TruffleHog Scan Results - No Secrets Found!')
-                .addSuccess('Your code appears to be free of secrets!')
-                .write();
+              // Check for findings
+              if (parsedResults.stringsFound.length > 0) {
+                core.info('### TruffleHog Scan Results - Found Potential Secrets!');
+                core.info('```json');
+                core.info(results);
+                core.info('```');
+              } else {
+                core.info('### TruffleHog Scan Results - No Secrets Found!');
+                core.info('No potential secrets were found in your code.');
+              }
+            } catch (error) {
+              core.error(`Error reading or parsing TruffleHog output: ${error.message}`);
+              core.setFailed('Failed to process TruffleHog output');
             }

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,4 +1,5 @@
 name: "TruffleHog"
+
 on:
   push:
     branches:
@@ -23,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Ensure full clone for pull request workflows
           ref: ${{ github.head_ref }}  # Fetch specific branch/commit for pull requests
@@ -35,7 +36,12 @@ jobs:
         with:
           path: ./  # Scan the entire repository
           base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
-          extra_args: --filter-entropy=4 --results=verified,unknown
+          extra_args: --filter-entropy=4 -o results.sarif --results=verified,unknown
+      
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
       
       - name: Scan Results Status
         if: steps.trufflehog.outcome == 'failure'


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.

-->

## Description
This PR introduces TruffleHog as a new open source tool for secret scanning to be used alongside native Github Secret scanning. This is being enforced as a replacement to the existing GitGuardian (commercial) tool.

Please note: The TRG checks continues for 24.08 under GitGuardian for secret scanning.
If you have already implemented TruffleHog, it can also be considered for the TRG checks.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [ ] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
