### PR TITLE
feat: added handling for 409 responses on asset registration

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
@@ -263,6 +263,10 @@ public class EdcAdapterService {
         var body = edcRequestBodyBuilder.buildFrameworkPolicy();
         try (var response = sendPostRequest(body, List.of("v3", "policydefinitions"))) {
             if (!response.isSuccessful()) {
+                if (response.code() == 409) {
+                    log.info("Framework agreement policy definition already existed");
+                    return true;
+                }
                 log.warn("Framework Policy Registration failed");
                 if (response.body() != null) {
                     log.warn("Response: \n" + response.body().string());
@@ -300,6 +304,10 @@ public class EdcAdapterService {
     private boolean sendAssetRegistrationRequest(JsonNode body, String assetId) {
         try (var response = sendPostRequest(body, List.of("v3", "assets"))) {
             if (!response.isSuccessful()) {
+                if (response.code() == 409) {
+                    log.info("Asset {} already existed", assetId);
+                    return true;
+                }
                 log.warn("Asset registration failed for {}", assetId);
                 if (response.body() != null) {
                     log.warn("Response: \n" + response.body().string());


### PR DESCRIPTION

## Description
-  added handling for 409 responses on asset registration
- solves #525 


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
