### PR TITLE
fix: remove own partner from partner/all endpoint

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartnerController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartnerController.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023, 2024 Volkswagen AG
- * Copyright (c) 2023, 2024 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * Copyright (c) 2023 Volkswagen AG
+ * Copyright (c) 2023 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
  * (represented by Fraunhofer ISST)
  * Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
  *
@@ -29,6 +29,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Validator;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.tractusx.puris.backend.common.util.PatternStore;
+import org.eclipse.tractusx.puris.backend.common.util.VariablesService;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Address;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
@@ -58,6 +59,9 @@ public class PartnerController {
 
     @Autowired
     private PartnerService partnerService;
+
+    @Autowired
+    private VariablesService variablesService;
 
     @Autowired
     private Validator validator;
@@ -221,8 +225,11 @@ public class PartnerController {
     @GetMapping("/all")
     @Operation(description = "Returns a list of all Partners. ")
     public ResponseEntity<List<PartnerDto>> listPartners() {
-        return new ResponseEntity<>(partnerService.findAll().
-            stream().map(partner -> modelMapper.map(partner, PartnerDto.class)).collect(Collectors.toList()),
+        final String ownBpnl = variablesService.getOwnBpnl();
+        return new ResponseEntity<>(partnerService.findAll().stream()
+            .filter(partner -> !partner.getBpnl().equals(ownBpnl))
+            .map(partner -> modelMapper.map(partner, PartnerDto.class))
+            .collect(Collectors.toList()),
             HttpStatusCode.valueOf(200));
     }
 


### PR DESCRIPTION

## Description
- added filter to exclude own partner entity from output in GET partner/all endpoint
- solves #524 
- solves #423 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
