### PR TITLE
fix: delivery and production services

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/delivery/domain/repository/DeliveryRepository.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/delivery/domain/repository/DeliveryRepository.java
@@ -20,11 +20,37 @@
 
 package org.eclipse.tractusx.puris.backend.delivery.domain.repository;
 
-import java.util.UUID;
-
 import org.eclipse.tractusx.puris.backend.delivery.domain.model.Delivery;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.UUID;
+
 public interface DeliveryRepository<T extends Delivery> extends JpaRepository<T, UUID> {
-    
+
+    default List<T> getForOwnMaterialNumber(String ownMatNbr) {
+        // default implementation prevents Jpa from trying to
+        // auto-generate this method.
+        throw new UnsupportedOperationException("Implementation needed");
+    }
+
+    default List<T> getForOwnMaterialNumberAndPartnerBPNL(String ownMatNbr, String bpnl) {
+        // default implementation prevents Jpa from trying to
+        // auto-generate this method.
+        throw new UnsupportedOperationException("Implementation needed");
+    }
+
+    default List<T> getForOwnMaterialNumberAndBPNS(String ownMatNbr, String bpns) {
+        // default implementation prevents Jpa from trying to
+        // auto-generate this method.
+        throw new UnsupportedOperationException("Implementation needed");
+    }
+
+    default List<T> getForOwnMaterialNumberAndPartnerBPNLAndBPNS(String ownMatNbr, String bpnl, String bpns) {
+        // default implementation prevents Jpa from trying to
+        // auto-generate this method.
+        throw new UnsupportedOperationException("Implementation needed");
+    }
+
+
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/delivery/domain/repository/OwnDeliveryRepository.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/delivery/domain/repository/OwnDeliveryRepository.java
@@ -22,6 +22,45 @@ package org.eclipse.tractusx.puris.backend.delivery.domain.repository;
 
 import org.eclipse.tractusx.puris.backend.delivery.domain.model.OwnDelivery;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public interface OwnDeliveryRepository extends DeliveryRepository<OwnDelivery> {
+
+    List<OwnDelivery> findAllByMaterial_OwnMaterialNumber(String ownMaterialNumber);
+
+    @Override
+    default List<OwnDelivery> getForOwnMaterialNumber(String ownMatNbr) {
+        return findAllByMaterial_OwnMaterialNumber(ownMatNbr);
+    }
+
+    List<OwnDelivery> findAllByMaterial_OwnMaterialNumberAndPartner_Bpnl(String ownMatNbr, String partnerBpnl);
+
+    @Override
+    default List<OwnDelivery> getForOwnMaterialNumberAndPartnerBPNL(String ownMatNbr, String bpnl) {
+        return findAllByMaterial_OwnMaterialNumberAndPartner_Bpnl(ownMatNbr, bpnl);
+    }
+
+    List<OwnDelivery> findAllByMaterial_OwnMaterialNumberAndOriginBpns(String ownMatNbr, String originBpns);
+
+    List<OwnDelivery> findAllByMaterial_OwnMaterialNumberAndDestinationBpns(String ownMatNbr, String destinationBpns);
+
+    @Override
+    default List<OwnDelivery> getForOwnMaterialNumberAndBPNS(String ownMatNbr, String bpns) {
+        var resultList = new ArrayList<>(findAllByMaterial_OwnMaterialNumberAndOriginBpns(ownMatNbr, bpns));
+        resultList.addAll(findAllByMaterial_OwnMaterialNumberAndDestinationBpns(ownMatNbr, bpns));
+        return resultList;
+    }
+
+    List<OwnDelivery> findAllByMaterial_OwnMaterialNumberAndPartner_BpnlAndDestinationBpns(String ownMatNbr, String partnerBpnl, String destinationBpnl);
+
+    List<OwnDelivery> findAllByMaterial_OwnMaterialNumberAndPartner_BpnlAndOriginBpns(String ownMatNbr, String partnerBpnl, String originBpnl);
+
+    @Override
+    default List<OwnDelivery> getForOwnMaterialNumberAndPartnerBPNLAndBPNS(String ownMatNbr, String bpnl, String bpns) {
+        var resultList = new ArrayList<>(findAllByMaterial_OwnMaterialNumberAndPartner_BpnlAndDestinationBpns(ownMatNbr, bpnl, bpns));
+        resultList.addAll(findAllByMaterial_OwnMaterialNumberAndPartner_BpnlAndOriginBpns(ownMatNbr, bpnl, bpns));
+        return resultList;
+    }
     
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/delivery/domain/repository/ReportedDeliveryRepository.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/delivery/domain/repository/ReportedDeliveryRepository.java
@@ -22,6 +22,45 @@ package org.eclipse.tractusx.puris.backend.delivery.domain.repository;
 
 import org.eclipse.tractusx.puris.backend.delivery.domain.model.ReportedDelivery;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public interface ReportedDeliveryRepository extends DeliveryRepository<ReportedDelivery> {
+
+    List<ReportedDelivery> findAllByMaterial_OwnMaterialNumber(String ownMaterialNumber);
+
+    @Override
+    default List<ReportedDelivery> getForOwnMaterialNumber(String ownMatNbr) {
+        return findAllByMaterial_OwnMaterialNumber(ownMatNbr);
+    }
+
+    List<ReportedDelivery> findAllByMaterial_OwnMaterialNumberAndPartner_Bpnl(String ownMatNbr, String partnerBpnl);
+
+    @Override
+    default List<ReportedDelivery> getForOwnMaterialNumberAndPartnerBPNL(String ownMatNbr, String bpnl) {
+        return findAllByMaterial_OwnMaterialNumberAndPartner_Bpnl(ownMatNbr, bpnl);
+    }
+
+    List<ReportedDelivery> findAllByMaterial_OwnMaterialNumberAndOriginBpns(String ownMatNbr, String originBpns);
+
+    List<ReportedDelivery> findAllByMaterial_OwnMaterialNumberAndDestinationBpns(String ownMatNbr, String destinationBpns);
+
+    @Override
+    default List<ReportedDelivery> getForOwnMaterialNumberAndBPNS(String ownMatNbr, String bpns) {
+        var resultList = new ArrayList<>(findAllByMaterial_OwnMaterialNumberAndOriginBpns(ownMatNbr, bpns));
+        resultList.addAll(findAllByMaterial_OwnMaterialNumberAndDestinationBpns(ownMatNbr, bpns));
+        return resultList;
+    }
+
+    List<ReportedDelivery> findAllByMaterial_OwnMaterialNumberAndPartner_BpnlAndDestinationBpns(String ownMatNbr, String partnerBpnl, String destinationBpnl);
+
+    List<ReportedDelivery> findAllByMaterial_OwnMaterialNumberAndPartner_BpnlAndOriginBpns(String ownMatNbr, String partnerBpnl, String originBpnl);
+
+    @Override
+    default List<ReportedDelivery> getForOwnMaterialNumberAndPartnerBPNLAndBPNS(String ownMatNbr, String bpnl, String bpns) {
+        var resultList = new ArrayList<>(findAllByMaterial_OwnMaterialNumberAndPartner_BpnlAndDestinationBpns(ownMatNbr, bpnl, bpns));
+        resultList.addAll(findAllByMaterial_OwnMaterialNumberAndPartner_BpnlAndOriginBpns(ownMatNbr, bpnl, bpns));
+        return resultList;
+    }
 
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/delivery/logic/service/OwnDeliveryService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/delivery/logic/service/OwnDeliveryService.java
@@ -20,18 +20,16 @@
 
 package org.eclipse.tractusx.puris.backend.delivery.logic.service;
 
-import java.util.Date;
-import java.util.List;
-import java.util.function.Function;
-
-import javax.management.openmbean.KeyAlreadyExistsException;
-
 import org.eclipse.tractusx.puris.backend.delivery.domain.model.EventTypeEnumeration;
 import org.eclipse.tractusx.puris.backend.delivery.domain.model.OwnDelivery;
 import org.eclipse.tractusx.puris.backend.delivery.domain.repository.OwnDeliveryRepository;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.PartnerService;
 import org.springframework.stereotype.Service;
+
+import javax.management.openmbean.KeyAlreadyExistsException;
+import java.util.Date;
+import java.util.function.Function;
 
 @Service
 public class OwnDeliveryService extends DeliveryService<OwnDelivery> {
@@ -44,19 +42,10 @@ public class OwnDeliveryService extends DeliveryService<OwnDelivery> {
     private Partner ownPartnerEntity;
 
     public OwnDeliveryService(OwnDeliveryRepository repository, PartnerService partnerService) {
+        super(repository);
         this.repository = repository;
         this.partnerService = partnerService;
         this.validator = this::validate;
-    }
-
-    public final List<OwnDelivery> findAllByBpnl(String bpnl) {
-        return repository.findAll().stream().filter(delivery -> delivery.getPartner().getBpnl().equals(bpnl))
-                .toList();
-    }
-
-    public final List<OwnDelivery> findAllByOwnMaterialNumber(String ownMaterialNumber) {
-        return repository.findAll().stream().filter(delivery -> delivery.getMaterial().getOwnMaterialNumber().equals(ownMaterialNumber))
-                .toList();
     }
 
     public final OwnDelivery create(OwnDelivery delivery) {
@@ -69,17 +58,7 @@ public class OwnDeliveryService extends DeliveryService<OwnDelivery> {
         return repository.save(delivery);
     }
 
-    public final List<OwnDelivery> createAll(List<OwnDelivery> deliveries) {
-        if (deliveries.stream().anyMatch(delivery -> !validator.apply(delivery))) {
-            throw new IllegalArgumentException("Invalid delivery");
-        }
-        if (repository.findAll().stream()
-                .anyMatch(existing -> deliveries.stream().anyMatch(delivery -> delivery.equals(existing)))) {
-            throw new KeyAlreadyExistsException("delivery already exists");
-        }
-        return repository.saveAll(deliveries);
-    }
-
+    @Override
     public boolean validate(OwnDelivery delivery) {
         if (ownPartnerEntity == null) {
             ownPartnerEntity = partnerService.getOwnPartnerEntity();

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/delivery/logic/service/ReportedDeliveryService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/delivery/logic/service/ReportedDeliveryService.java
@@ -20,17 +20,15 @@
 
 package org.eclipse.tractusx.puris.backend.delivery.logic.service;
 
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
-import java.util.function.Function;
-
 import org.eclipse.tractusx.puris.backend.delivery.domain.model.EventTypeEnumeration;
 import org.eclipse.tractusx.puris.backend.delivery.domain.model.ReportedDelivery;
 import org.eclipse.tractusx.puris.backend.delivery.domain.repository.ReportedDeliveryRepository;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.PartnerService;
 import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.function.Function;
 
 @Service
 public class ReportedDeliveryService extends DeliveryService<ReportedDelivery> {
@@ -43,14 +41,10 @@ public class ReportedDeliveryService extends DeliveryService<ReportedDelivery> {
     private Partner ownPartnerEntity;
 
     public ReportedDeliveryService(ReportedDeliveryRepository repository, PartnerService partnerService) {
+        super(repository);
         this.repository = repository;
         this.partnerService = partnerService;
         this.validator = this::validate;
-    }
-
-    public final List<ReportedDelivery> findAllByReportedId(UUID reportedId) {
-        return repository.findAll().stream().filter(delivery -> delivery.getPartner().getUuid().equals(reportedId))
-            .toList();
     }
 
     public final ReportedDelivery create(ReportedDelivery delivery) {
@@ -63,17 +57,7 @@ public class ReportedDeliveryService extends DeliveryService<ReportedDelivery> {
         return repository.save(delivery);
     }
 
-    public final List<ReportedDelivery> createAll(List<ReportedDelivery> deliveries) {
-        if (deliveries.stream().anyMatch(delivery -> !validator.apply(delivery))) {
-            return null;
-        }
-        if (repository.findAll().stream()
-                .anyMatch(existing -> deliveries.stream().anyMatch(delivery -> delivery.equals(existing)))) {
-            return null;
-        }
-        return repository.saveAll(deliveries);
-    }
-
+    @Override
     public boolean validate(ReportedDelivery delivery) {
         return 
             delivery.getQuantity() > 0 && 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/production/domain/repository/OwnProductionRepository.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/production/domain/repository/OwnProductionRepository.java
@@ -23,7 +23,37 @@ package org.eclipse.tractusx.puris.backend.production.domain.repository;
 import org.eclipse.tractusx.puris.backend.production.domain.model.OwnProduction;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface OwnProductionRepository extends ProductionRepository<OwnProduction> {
+
+    List<OwnProduction> findAllByMaterial_OwnMaterialNumber(String ownMaterialNumber);
+
+    @Override
+    default List<OwnProduction> getForOwnMaterialNumber(String ownMatNbr) {
+        return findAllByMaterial_OwnMaterialNumber(ownMatNbr);
+    }
+
+    List<OwnProduction> findAllByMaterial_OwnMaterialNumberAndPartner_Bpnl(String ownMaterialNumber, String partnerBpnl);
+
+    @Override
+    default List<OwnProduction> getForOwnMaterialNumberAndPartnerBPNL(String ownMatNbr, String bpnl) {
+        return findAllByMaterial_OwnMaterialNumberAndPartner_Bpnl(ownMatNbr, bpnl);
+    }
+
+    List<OwnProduction> findAllByMaterial_OwnMaterialNumberAndPartner_BpnlAndProductionSiteBpns(String ownMaterialNumber, String partnerBpnl, String bpns);
+
+    @Override
+    default List<OwnProduction> getForOwnMaterialNumberAndPartnerBPNLAndBPNS(String ownMatNbr, String bpnl, String bpns) {
+        return findAllByMaterial_OwnMaterialNumberAndPartner_BpnlAndProductionSiteBpns(ownMatNbr, bpnl, bpns);
+    }
+
+    List<OwnProduction> findAllByMaterial_OwnMaterialNumberAndProductionSiteBpns(String ownMatNbr, String bpns);
+
+    @Override
+    default List<OwnProduction> getForOwnMaterialNumberAndBPNS(String ownMatNbr, String bpns) {
+        return findAllByMaterial_OwnMaterialNumberAndProductionSiteBpns(ownMatNbr, bpns);
+    }
 
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/production/domain/repository/ProductionRepository.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/production/domain/repository/ProductionRepository.java
@@ -23,8 +23,32 @@ package org.eclipse.tractusx.puris.backend.production.domain.repository;
 import org.eclipse.tractusx.puris.backend.production.domain.model.Production;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface ProductionRepository<T extends Production> extends JpaRepository<T, UUID> {
-    
+
+    default List<T> getForOwnMaterialNumber(String ownMatNbr) {
+        // default implementation prevents Jpa from trying to
+        // auto-generate this method.
+        throw new UnsupportedOperationException("Implementation needed");
+    }
+
+    default List<T> getForOwnMaterialNumberAndPartnerBPNL(String ownMatNbr, String bpnl) {
+        // default implementation prevents Jpa from trying to
+        // auto-generate this method.
+        throw new UnsupportedOperationException("Implementation needed");
+    }
+
+    default List<T> getForOwnMaterialNumberAndPartnerBPNLAndBPNS(String ownMatNbr, String bpnl, String bpns) {
+        // default implementation prevents Jpa from trying to
+        // auto-generate this method.
+        throw new UnsupportedOperationException("Implementation needed");
+    }
+
+    default List<T> getForOwnMaterialNumberAndBPNS(String ownMatNbr, String bpns) {
+        // default implementation prevents Jpa from trying to
+        // auto-generate this method.
+        throw new UnsupportedOperationException("Implementation needed");
+    }
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/production/domain/repository/ReportedProductionRepository.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/production/domain/repository/ReportedProductionRepository.java
@@ -23,7 +23,38 @@ package org.eclipse.tractusx.puris.backend.production.domain.repository;
 import org.eclipse.tractusx.puris.backend.production.domain.model.ReportedProduction;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ReportedProductionRepository extends ProductionRepository<ReportedProduction> {
+
+
+    List<ReportedProduction> findAllByMaterial_OwnMaterialNumber(String ownMaterialNumber);
+
+    @Override
+    default List<ReportedProduction> getForOwnMaterialNumber(String ownMatNbr) {
+        return findAllByMaterial_OwnMaterialNumber(ownMatNbr);
+    }
+
+    List<ReportedProduction> findByMaterial_OwnMaterialNumberAndPartner_Bpnl(String ownMaterialNumber, String partnerBpnl);
+
+    @Override
+    default List<ReportedProduction> getForOwnMaterialNumberAndPartnerBPNL(String ownMatNbr, String bpnl) {
+        return findByMaterial_OwnMaterialNumberAndPartner_Bpnl(ownMatNbr, bpnl);
+    }
+
+    List<ReportedProduction> findByMaterial_OwnMaterialNumberAndPartner_BpnlAndProductionSiteBpns(String ownMaterialNumber, String partnerBpnl, String bpns);
+
+    @Override
+    default List<ReportedProduction> getForOwnMaterialNumberAndPartnerBPNLAndBPNS(String ownMatNbr, String bpnl, String bpns) {
+        return findByMaterial_OwnMaterialNumberAndPartner_BpnlAndProductionSiteBpns(ownMatNbr, bpnl, bpns);
+    }
+
+    List<ReportedProduction> findByMaterial_OwnMaterialNumberAndProductionSiteBpns(String ownMatNbr, String bpns);
+
+    @Override
+    default List<ReportedProduction> getForOwnMaterialNumberAndBPNS(String ownMatNbr, String bpns) {
+        return findByMaterial_OwnMaterialNumberAndProductionSiteBpns(ownMatNbr, bpns);
+    }
 
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/production/logic/service/OwnProductionService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/production/logic/service/OwnProductionService.java
@@ -20,16 +20,15 @@ SPDX-License-Identifier: Apache-2.0
 
 package org.eclipse.tractusx.puris.backend.production.logic.service;
 
-import java.util.List;
-import java.util.function.Function;
-
-import javax.management.openmbean.KeyAlreadyExistsException;
-
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.PartnerService;
 import org.eclipse.tractusx.puris.backend.production.domain.model.OwnProduction;
 import org.eclipse.tractusx.puris.backend.production.domain.repository.OwnProductionRepository;
 import org.springframework.stereotype.Service;
+
+import javax.management.openmbean.KeyAlreadyExistsException;
+import java.util.List;
+import java.util.function.Function;
 
 @Service
 public class OwnProductionService extends ProductionService<OwnProduction> {
@@ -40,6 +39,7 @@ public class OwnProductionService extends ProductionService<OwnProduction> {
     protected final Function<OwnProduction, Boolean> validator;
 
     public OwnProductionService(OwnProductionRepository repository, PartnerService partnerService) {
+        super(repository);
         this.repository = repository;
         this.partnerService = partnerService;
         this.validator = this::validate;
@@ -67,6 +67,7 @@ public class OwnProductionService extends ProductionService<OwnProduction> {
         return repository.saveAll(productions);
     }
 
+    @Override
     public boolean validate(OwnProduction production) {
         Partner ownPartnerEntity = partnerService.getOwnPartnerEntity();
         return 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/production/logic/service/ReportedProductionService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/production/logic/service/ReportedProductionService.java
@@ -20,12 +20,12 @@ SPDX-License-Identifier: Apache-2.0
 
 package org.eclipse.tractusx.puris.backend.production.logic.service;
 
-import java.util.List;
-import java.util.function.Function;
-
 import org.eclipse.tractusx.puris.backend.production.domain.model.ReportedProduction;
 import org.eclipse.tractusx.puris.backend.production.domain.repository.ReportedProductionRepository;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.function.Function;
 
 @Service
 public class ReportedProductionService extends ProductionService<ReportedProduction> {
@@ -34,6 +34,7 @@ public class ReportedProductionService extends ProductionService<ReportedProduct
     protected final Function<ReportedProduction, Boolean> validator;
 
     public ReportedProductionService(ReportedProductionRepository repository) {
+        super(repository);
         this.repository = repository;
         this.validator = this::validate;
     }
@@ -59,6 +60,7 @@ public class ReportedProductionService extends ProductionService<ReportedProduct
         return repository.saveAll(productions);
     }
 
+    @Override
     public boolean validate(ReportedProduction production) {
         return 
             production.getQuantity() > 0 && 


### PR DESCRIPTION

## Description
- the "findAllByFilters" methods were heavily reliant on using the repositories' "findAll" methods. This will cause avoidable performance issues, when a larger number of entities is stored in the databases
- created parametrized requests for the repositories, which are now used instead
- added validation checks for the "update" methods in the services


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
