### PR TITLE
fix: docker compose properties

### DIFF
--- a/local/bdrs/application.properties
+++ b/local/bdrs/application.properties
@@ -5,5 +5,5 @@ web.http.directory.port=8582
 web.http.directory.path=/api/directory
 # looking up DIDs should not use https
 edc.iam.did.web.use.https=false
-edc.iam.trusted-issuer.issuer.id=did:web:mock-util-service/trusted-issuer
+#edc.iam.trusted-issuer.issuer.id=did:web:mock-util-service/trusted-issuer
 _level=DEBUG

--- a/local/docker-compose-infrastructure.yaml
+++ b/local/docker-compose-infrastructure.yaml
@@ -104,6 +104,7 @@ services:
     environment:
       WEB_HTTP_PORT: 8580
       WEB_HTTP_PATH: /api
+      edc.iam.trusted-issuer.issuer.id: did:web:mock-util-service/trusted-issuer
     ports:
       - "127.0.0.1:8580:8580"
       - "127.0.0.1:8581:8581"

--- a/local/docker-compose.yaml
+++ b/local/docker-compose.yaml
@@ -73,6 +73,11 @@ services:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres-all:5432/puris_customer
       SPRING_DATASOURCE_USERNAME: ${PG_USER}
       SPRING_DATASOURCE_PASSWORD: ${PG_PW}
+      server.error.include-message: always
+      puris.dtr.idp.edc-client.id: ${KC_MANAGE_CLIENT_ID}
+      puris.dtr.idp.edc-client.secret.alias: ${CUSTOMER_KC_DTR_PURIS_CLIENT_ALIAS}
+      puris.dtr.idp.puris-client.id: ${KC_MANAGE_CLIENT_ID}
+      puris.dtr.idp.puris-client.secret: ${CUSTOMER_KC_DTR_PURIS_CLIENT_SECRET}
     networks:
       - miw-net
     extra_hosts:
@@ -152,6 +157,12 @@ services:
       - "127.0.0.1:8182:8182"
       - "127.0.0.1:8183:8183"
       - "127.0.0.1:8184:8184"
+    environment:
+      edc.datasource.policy-monitor.name: policy-monitor
+      edc.datasource.policy-monitor.url: jdbc:postgresql://postgres-all:5432/edc_customer
+      edc.datasource.policy-monitor.user: ${PG_USER}
+      edc.datasource.policy-monitor.password: ${PG_PW}
+      edc.iam.trusted-issuer.portal.id: did:web:mock-util-service/trusted-issuer
     networks:
       - miw-net
     extra_hosts:
@@ -172,6 +183,8 @@ services:
       - "127.0.0.1:8283:8283"
       - "127.0.0.1:8285:8285"
       - "127.0.0.1:8299:8299"
+    environment:
+      edc.iam.trusted-issuer.portal.id: did:web:mock-util-service/trusted-issuer
     env_file:
       - ./tractus-x-edc/config/customer/data-plane.properties
     networks:
@@ -231,6 +244,11 @@ services:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres-all:5432/puris_supplier
       SPRING_DATASOURCE_USERNAME: ${PG_USER}
       SPRING_DATASOURCE_PASSWORD: ${PG_PW}
+      server.error.include-message: always
+      puris.dtr.idp.edc-client.id: ${KC_MANAGE_CLIENT_ID}
+      puris.dtr.idp.edc-client.secret.alias: ${SUPPLIER_KC_DTR_PURIS_CLIENT_ALIAS}
+      puris.dtr.idp.puris-client.id: ${KC_MANAGE_CLIENT_ID}
+      puris.dtr.idp.puris-client.secret: ${SUPPLIER_KC_DTR_PURIS_CLIENT_SECRET}
     networks:
       - miw-net
     extra_hosts:
@@ -283,6 +301,12 @@ services:
       - "127.0.0.1:9183:9183"
       - "127.0.0.1:9184:9184"
       - "127.0.0.1:1044:1044"
+    environment:
+      edc.datasource.policy-monitor.name: policy-monitor
+      edc.datasource.policy-monitor.url: jdbc:postgresql://postgres-all:5432/edc_supplier
+      edc.datasource.policy-monitor.user: ${PG_USER}
+      edc.datasource.policy-monitor.password: ${PG_PW}
+      edc.iam.trusted-issuer.portal.id: did:web:mock-util-service/trusted-issuer
     env_file:
       - ./tractus-x-edc/config/supplier/control-plane.properties
     networks:
@@ -305,6 +329,8 @@ services:
       - "127.0.0.1:9283:9283"
       - "127.0.0.1:9285:9285"
       - "127.0.0.1:9299:9299"
+    environment:
+      edc.iam.trusted-issuer.portal.id: did:web:mock-util-service/trusted-issuer
     env_file:
       - ./tractus-x-edc/config/supplier/data-plane.properties
     networks:

--- a/local/tractus-x-edc/config/customer/control-plane.properties
+++ b/local/tractus-x-edc/config/customer/control-plane.properties
@@ -24,7 +24,7 @@ edc.iam.sts.oauth.token.url=http://keycloak:8080/realms/miw_test/protocol/openid
 edc.iam.sts.oauth.client.id=${CUSTOMER_OAUTH_CLIENT_ID}
 edc.iam.sts.oauth.client.secret.alias=${CUSTOMER_OAUTH_SECRET_ALIAS}
 tx.edc.iam.sts.dim.url=http://mock-util-service:80/sts
-edc.iam.trusted-issuer.portal.id=did:web:mock-util-service/trusted-issuer
+#edc.iam.trusted-issuer.portal.id=did:web:mock-util-service/trusted-issuer
 # configure one Credential service for all (else pulled from did, nevertheless done)
 tx.iam.iatp.credentialservice.url=http://mock-util-service:80
 # don't use https during did resolving
@@ -52,9 +52,9 @@ edc.dataplane.selector.edchttp.sourcetypes=HttpData
 edc.dataplane.selector.edchttp.destinationtypes=HttpData,HttpProxy
 edc.dataplane.selector.edchttp.properties={"publicApiUrl" : "http://customer-data-plane:8285/api/public"}
 # backend receiver for static Endpoint Data References
-edc.receiver.http.dynamic.endpoint=http://customer-backend:8081/catena/edrendpoint
-edc.receiver.http.dynamic.auth-key=X-API-KEY
-edc.receiver.http.dynamic.auth-code=${CUSTOMER_BACKEND_API_KEY}
+#edc.receiver.http.dynamic.endpoint=http://customer-backend:8081/catena/edrendpoint
+#edc.receiver.http.dynamic.auth-key=X-API-KEY
+#edc.receiver.http.dynamic.auth-code=${CUSTOMER_BACKEND_API_KEY}
 # Postgresql related configuration
 edc.datasource.asset.name=asset
 edc.datasource.asset.url=jdbc:postgresql://postgres-all:5432/edc_customer
@@ -81,11 +81,11 @@ edc.datasource.transferprocess.url=jdbc:postgresql://postgres-all:5432/edc_custo
 # edc.datasource.transferprocess.user and edc.datasource.transferprocess.password are set via .env
 edc.datasource.transferprocess.user=${PG_USER}
 edc.datasource.transferprocess.password=${PG_PW}
-edc.datasource.policy-monitor.name=policy-monitor
-edc.datasource.policy-monitor.url=jdbc:postgresql://postgres-all:5432/edc_customer
+#edc.datasource.policy-monitor.name=policy-monitor
+#edc.datasource.policy-monitor.url=jdbc:postgresql://postgres-all:5432/edc_customer
 # edc.datasource.policy-monitor.user and edc.datasource.policy-monitor.password are set via .env
-edc.datasource.policy-monitor.user=${PG_USER}
-edc.datasource.policy-monitor.password=${PG_PW}
+#edc.datasource.policy-monitor.user=${PG_USER}
+#edc.datasource.policy-monitor.password=${PG_PW}
 # see extension https://github.com/eclipse-tractusx/tractusx-edc/tree/main/edc-extensions/bpn-validation/business-partner-store-sql
 edc.datasource.bpn.name=policy-monitor
 edc.datasource.bpn.url=jdbc:postgresql://postgres-all:5432/edc_customer

--- a/local/tractus-x-edc/config/customer/data-plane.properties
+++ b/local/tractus-x-edc/config/customer/data-plane.properties
@@ -52,7 +52,7 @@ edc.iam.sts.oauth.token.url=http://keycloak:8080/realms/miw_test/protocol/openid
 edc.iam.sts.oauth.client.id=${CUSTOMER_OAUTH_CLIENT_ID}
 edc.iam.sts.oauth.client.secret.alias=${CUSTOMER_OAUTH_SECRET_ALIAS}
 edc.iam.sts.dim.url=http://mock-util-service:80/sts
-edc.iam.trusted-issuer.portal.id=did:web:mock-util-service/trusted-issuer
+#edc.iam.trusted-issuer.portal.id=did:web:mock-util-service/trusted-issuer
 # configure one Credential service for all (else pulled from did): https://github.com/eclipse-tractusx/tractusx-edc/blob/d7d3586ffc4ef03c858e38fde6bfa8687efa50c9/edc-extensions/bdrs-client/src/main/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientExtension.java#L50
 tx.iam.credentialservice.url=http://mock-util-service:80
 # don't use https during did resolving in catalog request

--- a/local/tractus-x-edc/config/customer/puris-backend.properties
+++ b/local/tractus-x-edc/config/customer/puris-backend.properties
@@ -1,5 +1,5 @@
 server.port=8081
-server.error.include-message=always
+#server.error.include-message=always
 puris.demonstrator.role=customer
 puris.baseurl=http://customer-backend:8081/
 puris.itemstocksubmodel.apiassetid=itemstocksubmodel-api-asset
@@ -19,10 +19,10 @@ puris.generatematerialcatenaxid=true
 puris.dtr.idp.enabled=true
 puris.dtr.idp.tokenurl=http://keycloak:8080/realms/Customer/protocol/openid-connect/token
 # Note: Currently DTR only allows one client, thus manage client must be used for all.
-puris.dtr.idp.edc-client.id=${KC_MANAGE_CLIENT_ID}
-puris.dtr.idp.edc-client.secret.alias=${CUSTOMER_KC_DTR_PURIS_CLIENT_ALIAS}
-puris.dtr.idp.puris-client.id=${KC_MANAGE_CLIENT_ID}
-puris.dtr.idp.puris-client.secret=${CUSTOMER_KC_DTR_PURIS_CLIENT_SECRET}
+#puris.dtr.idp.edc-client.id=${KC_MANAGE_CLIENT_ID}
+#puris.dtr.idp.edc-client.secret.alias=${CUSTOMER_KC_DTR_PURIS_CLIENT_ALIAS}
+#puris.dtr.idp.puris-client.id=${KC_MANAGE_CLIENT_ID}
+#puris.dtr.idp.puris-client.secret=${CUSTOMER_KC_DTR_PURIS_CLIENT_SECRET}
 
 puris.erpadapter.enabled=false
 puris.erpadapter.url=http://host.docker.internal:5555/

--- a/local/tractus-x-edc/config/supplier/control-plane.properties
+++ b/local/tractus-x-edc/config/supplier/control-plane.properties
@@ -25,7 +25,7 @@ edc.iam.sts.oauth.token.url=http://keycloak:8080/realms/miw_test/protocol/openid
 edc.iam.sts.oauth.client.id=${SUPPLIER_OAUTH_CLIENT_ID}
 edc.iam.sts.oauth.client.secret.alias=${SUPPLIER_OAUTH_SECRET_ALIAS}
 tx.edc.iam.sts.dim.url=http://mock-util-service:80/sts
-edc.iam.trusted-issuer.portal.id=did:web:mock-util-service/trusted-issuer
+#edc.iam.trusted-issuer.portal.id=did:web:mock-util-service/trusted-issuer
 # configure one Credential service for all (else pulled from did, nevertheless done)
 tx.iam.iatp.credentialservice.url=http://mock-util-service:80
 # don't use https during did resolving
@@ -53,9 +53,9 @@ edc.dataplane.selector.edchttp.sourcetypes=HttpData
 edc.dataplane.selector.edchttp.destinationtypes=HttpData,HttpProxy
 edc.dataplane.selector.edchttp.properties={"publicApiUrl" : "http://supplier-data-plane:9285/api/public"}
 # puris backend receiver for dynamic Endpoint Data References
-edc.receiver.http.dynamic.endpoint=http://supplier-backend:8082/catena/edrendpoint
-edc.receiver.http.dynamic.auth-key=X-API-KEY
-edc.receiver.http.dynamic.auth-code=${SUPPLIER_BACKEND_API_KEY}
+#edc.receiver.http.dynamic.endpoint=http://supplier-backend:8082/catena/edrendpoint
+#edc.receiver.http.dynamic.auth-key=X-API-KEY
+#edc.receiver.http.dynamic.auth-code=${SUPPLIER_BACKEND_API_KEY}
 # Postgresql related configuration
 edc.datasource.asset.name=asset
 edc.datasource.asset.url=jdbc:postgresql://postgres-all:5432/edc_supplier
@@ -82,11 +82,11 @@ edc.datasource.transferprocess.url=jdbc:postgresql://postgres-all:5432/edc_suppl
 # edc.datasource.transferprocess.user and edc.datasource.transferprocess.password are set via .env
 edc.datasource.transferprocess.user=${PG_USER}
 edc.datasource.transferprocess.password=${PG_PW}
-edc.datasource.policy-monitor.name=policy-monitor
-edc.datasource.policy-monitor.url=jdbc:postgresql://postgres-all:5432/edc_supplier
+#edc.datasource.policy-monitor.name=policy-monitor
+#edc.datasource.policy-monitor.url=jdbc:postgresql://postgres-all:5432/edc_supplier
 # edc.datasource.policy-monitor.user and edc.datasource.policy-monitor.password are set via .env
-edc.datasource.policy-monitor.user=${PG_USER}
-edc.datasource.policy-monitor.password=${PG_PW}
+#edc.datasource.policy-monitor.user=${PG_USER}
+#edc.datasource.policy-monitor.password=${PG_PW}
 # see extension https://github.com/eclipse-tractusx/tractusx-edc/tree/main/edc-extensions/bpn-validation/business-partner-store-sql
 edc.datasource.bpn.name=policy-monitor
 edc.datasource.bpn.url=jdbc:postgresql://postgres-all:5432/edc_supplier

--- a/local/tractus-x-edc/config/supplier/data-plane.properties
+++ b/local/tractus-x-edc/config/supplier/data-plane.properties
@@ -53,7 +53,7 @@ edc.iam.sts.oauth.token.url=http://keycloak:8080/realms/miw_test/protocol/openid
 edc.iam.sts.oauth.client.id=${SUPPLIER_OAUTH_CLIENT_ID}
 edc.iam.sts.oauth.client.secret.alias=${SUPPLIER_OAUTH_SECRET_ALIAS}
 edc.iam.sts.dim.url=http://mock-util-service:80/sts
-edc.iam.trusted-issuer.portal.id=did:web:mock-util-service/trusted-issuer
+#edc.iam.trusted-issuer.portal.id=did:web:mock-util-service/trusted-issuer
 # configure one Credential service for all (else pulled from did): https://github.com/eclipse-tractusx/tractusx-edc/blob/d7d3586ffc4ef03c858e38fde6bfa8687efa50c9/edc-extensions/bdrs-client/src/main/java/org/eclipse/tractusx/edc/identity/mapper/BdrsClientExtension.java#L50
 tx.iam.credentialservice.url=http://mock-util-service:80
 # don't use https during did resolving in catalog request

--- a/local/tractus-x-edc/config/supplier/puris-backend.properties
+++ b/local/tractus-x-edc/config/supplier/puris-backend.properties
@@ -1,5 +1,5 @@
 server.port=8082
-server.error.include-message=always
+#server.error.include-message=always
 puris.demonstrator.role=supplier
 puris.baseurl=http://supplier-backend:8082/
 puris.itemstocksubmodel.apiassetid=itemstocksubmodel-api-asset
@@ -19,10 +19,10 @@ puris.generatematerialcatenaxid=true
 puris.dtr.idp.enabled=true
 puris.dtr.idp.tokenurl=http://keycloak:8080/realms/Supplier/protocol/openid-connect/token
 # Note: Currently DTR only allows one client, thus manage client must be used for all.
-puris.dtr.idp.edc-client.id=${KC_MANAGE_CLIENT_ID}
-puris.dtr.idp.edc-client.secret.alias=${SUPPLIER_KC_DTR_PURIS_CLIENT_ALIAS}
-puris.dtr.idp.puris-client.id=${KC_MANAGE_CLIENT_ID}
-puris.dtr.idp.puris-client.secret=${SUPPLIER_KC_DTR_PURIS_CLIENT_SECRET}
+#puris.dtr.idp.edc-client.id=${KC_MANAGE_CLIENT_ID}
+#puris.dtr.idp.edc-client.secret.alias=${SUPPLIER_KC_DTR_PURIS_CLIENT_ALIAS}
+#puris.dtr.idp.puris-client.id=${KC_MANAGE_CLIENT_ID}
+#puris.dtr.idp.puris-client.secret=${SUPPLIER_KC_DTR_PURIS_CLIENT_SECRET}
 
 puris.erpadapter.enabled=false
 puris.erpadapter.url=http://host.docker.internal:5555/


### PR DESCRIPTION
## Description
- recent versions of [docker compose](https://github.com/docker/compose/issues/12123#issuecomment-2477247374) no longer support variable names containing hyphens in .properties or .env files 
- this fix removes the affected variables from those files and applies them via "environment" sections of services

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [ ] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
