### PR TITLE
Fix/days of supply calculation

### DIFF
--- a/DEPENDENCIES_BACKEND
+++ b/DEPENDENCIES_BACKEND
@@ -38,8 +38,8 @@ maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/4.0.2, BSD-3-Clause, ap
 maven/mavencentral/junit/junit/4.13.2, EPL-2.0, approved, CQ23636
 maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.17, Apache-2.0, approved, #7164
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.17, Apache-2.0 AND BSD-3-Clause, approved, #7163
-maven/mavencentral/net.minidev/accessors-smart/2.5.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/net.minidev/json-smart/2.5.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/net.minidev/accessors-smart/2.5.1, Apache-2.0, approved, #19432
+maven/mavencentral/net.minidev/json-smart/2.5.1, Apache-2.0, approved, #19431
 maven/mavencentral/org.antlr/antlr4-runtime/4.13.0, BSD-3-Clause, approved, #10767
 maven/mavencentral/org.apache.commons/commons-lang3/3.14.0, Apache-2.0, approved, #11677
 maven/mavencentral/org.apache.logging.log4j/log4j-api/2.23.1, Apache-2.0, approved, #13368

--- a/DEPENDENCIES_FRONTEND
+++ b/DEPENDENCIES_FRONTEND
@@ -129,7 +129,7 @@ npm/npmjs/@types/hast/2.3.10, MIT, approved, clearlydefined
 npm/npmjs/@types/mdast/3.0.15, MIT, approved, clearlydefined
 npm/npmjs/@types/ms/0.7.34, MIT, approved, #10811
 npm/npmjs/@types/node/20.8.3, MIT, approved, #10804
-npm/npmjs/@types/parse-json/4.0.2, MIT, approved, clearlydefined
+npm/npmjs/@types/parse-json/4.0.2, MIT, approved, #19199
 npm/npmjs/@types/unist/2.0.10, MIT, approved, clearlydefined
 npm/npmjs/@typescript-eslint/eslint-plugin/7.18.0, BSD-2-Clause AND MIT AND (BSD-2-Clause AND ISC AND MIT), approved, #15825
 npm/npmjs/@typescript-eslint/parser/7.0.0, BSD-2-Clause AND (BSD-2-Clause AND ISC AND MIT) AND MIT, approved, #13312

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/supply/logic/service/CustomerSupplyService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/supply/logic/service/CustomerSupplyService.java
@@ -36,20 +36,21 @@ import org.eclipse.tractusx.puris.backend.stock.logic.service.MaterialItemStockS
 import org.eclipse.tractusx.puris.backend.supply.domain.model.OwnCustomerSupply;
 import org.eclipse.tractusx.puris.backend.supply.domain.model.ReportedCustomerSupply;
 import org.eclipse.tractusx.puris.backend.supply.domain.repository.ReportedCustomerSupplyRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class CustomerSupplyService extends SupplyService<OwnCustomerSupply, ReportedCustomerSupply, ReportedCustomerSupplyRepository, MaterialItemStock, MaterialItemStockService> {
-    @Autowired
+    
     private OwnDeliveryService ownDeliveryService;
-    @Autowired
     private ReportedDeliveryService reportedDeliveryService;
-    @Autowired
     private OwnDemandService demandService;
-
-    public CustomerSupplyService(ReportedCustomerSupplyRepository repository, PartnerService partnerService, MaterialService materialService) {
-        super(repository, partnerService, materialService);
+    
+    public CustomerSupplyService(MaterialItemStockService stockService, MaterialService materialService,
+            PartnerService partnerService, ReportedCustomerSupplyRepository repository, OwnDeliveryService ownDeliveryService, ReportedDeliveryService reportedDeliveryService, OwnDemandService demandService) {
+        super(stockService, materialService, partnerService, repository);
+        this.ownDeliveryService = ownDeliveryService;
+        this.reportedDeliveryService = reportedDeliveryService;
+        this.demandService = demandService;
     }
 
     @Override
@@ -81,7 +82,7 @@ public class CustomerSupplyService extends SupplyService<OwnCustomerSupply, Repo
      * @param numberOfDays the number of days over which the forecast should be calculated.
      * @return a list of {@link OwnCustomerSupply} objects, each containing the calculated days of supply for a specific date.
      */
-    public final List<OwnCustomerSupply> calculateCustomerDaysOfSupply(String material, Optional<String> partnerBpnl, Optional<String> siteBpns, int numberOfDays) {
+    public List<OwnCustomerSupply> calculateCustomerDaysOfSupply(String material, Optional<String> partnerBpnl, Optional<String> siteBpns, int numberOfDays) {
         return calculateDaysOfSupply(material, partnerBpnl, siteBpns, numberOfDays);
     }
     

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/supply/logic/service/SupplierSupplyService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/supply/logic/service/SupplierSupplyService.java
@@ -36,20 +36,21 @@ import org.eclipse.tractusx.puris.backend.stock.logic.service.ProductItemStockSe
 import org.eclipse.tractusx.puris.backend.supply.domain.model.OwnSupplierSupply;
 import org.eclipse.tractusx.puris.backend.supply.domain.model.ReportedSupplierSupply;
 import org.eclipse.tractusx.puris.backend.supply.domain.repository.ReportedSupplierSupplyRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class SupplierSupplyService extends SupplyService<OwnSupplierSupply, ReportedSupplierSupply, ReportedSupplierSupplyRepository, ProductItemStock, ProductItemStockService> {
-    @Autowired
+
     private OwnDeliveryService ownDeliveryService;
-    @Autowired
     private ReportedDeliveryService reportedDeliveryService;
-    @Autowired
     private OwnProductionService productionService;
 
-    public SupplierSupplyService(ReportedSupplierSupplyRepository repository, PartnerService partnerService, MaterialService materialService) {
-        super(repository, partnerService, materialService);
+    public SupplierSupplyService(ProductItemStockService stockService, MaterialService materialService,
+            PartnerService partnerService, ReportedSupplierSupplyRepository repository, OwnDeliveryService ownDeliveryService, ReportedDeliveryService reportedDeliveryService, OwnProductionService productionService) {
+        super(stockService, materialService, partnerService, repository);
+        this.ownDeliveryService = ownDeliveryService;
+        this.reportedDeliveryService = reportedDeliveryService;
+        this.productionService = productionService;
     }
 
     @Override

--- a/backend/src/test/java/org/eclipse/tractusx/puris/backend/delivery/controller/DeliveryRequestApiServiceTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/puris/backend/delivery/controller/DeliveryRequestApiServiceTest.java
@@ -203,7 +203,7 @@ public class DeliveryRequestApiServiceTest {
         // verfy that samm mapper has been called correctly (our concern)
         verify(sammMapper)
             .ownDeliveryToSamm(
-                eq(Arrays.asList(delivery, delivery2)),
+                eq(deliveries),
                 eq(SUPPLIER_PARTNER),
                 eq(mpr.getMaterial())
             );

--- a/backend/src/test/java/org/eclipse/tractusx/puris/backend/delivery/controller/DeliveryRequestApiServiceTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/puris/backend/delivery/controller/DeliveryRequestApiServiceTest.java
@@ -20,7 +20,6 @@
 
 package org.eclipse.tractusx.puris.backend.delivery.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.tractusx.puris.backend.common.domain.model.measurement.ItemUnitEnumeration;
 import org.eclipse.tractusx.puris.backend.common.edc.logic.service.EdcAdapterService;
@@ -73,8 +72,6 @@ public class DeliveryRequestApiServiceTest {
     @Mock
     private DeliveryInformationSammMapper sammMapper;
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
-
     private static final String MATERIAL_NUMBER_CX_CUSTOMER = UUID.randomUUID().toString();
     private static final String BPNL_CUSTOMER = "BPNL4444444444XX";
     private static final String BPNS_CUSTOMER = "BPNS4444444444XX";
@@ -97,14 +94,6 @@ public class DeliveryRequestApiServiceTest {
         new Date()
     );
 
-    private static final Material TEST_MATERIAL_SUPPLIER = new Material(
-        true,
-        true,
-        "Own-Mnr",
-        MATERIAL_NUMBER_CX_SUPPLIER,
-        "Test Material",
-        new Date()
-    );
 
     @BeforeEach
     void setUp() {
@@ -155,12 +144,7 @@ public class DeliveryRequestApiServiceTest {
         OwnDelivery delivery2 = getDelivery();
         delivery2.setIncoterm(IncotermEnumeration.FCA);
 
-        // Delivery with incoterm with SUPPLIER responsibility
-        // TODO rene: for some reason the third delivery has been found, too.
-        OwnDelivery delivery3 = getDelivery();
-        delivery3.setIncoterm(IncotermEnumeration.DAP);
-
-        List<OwnDelivery> deliveries = Arrays.asList(delivery, delivery2, delivery3);
+        List<OwnDelivery> deliveries = Arrays.asList(delivery, delivery2);
 
         // partner supplies only
         MaterialPartnerRelation mpr = getMpr(SUPPLIER_PARTNER, true, false);
@@ -181,7 +165,6 @@ public class DeliveryRequestApiServiceTest {
         }).when(mprService).triggerPartTypeRetrievalTask(SUPPLIER_PARTNER);
 
         // return all deliveries defined above
-        // predicate for customer case will return delivery, delivery2
         when(ownDeliveryService.findAllByFilters(
             Optional.of(mpr.getMaterial().getOwnMaterialNumber()),
             Optional.empty(),

--- a/backend/src/test/java/org/eclipse/tractusx/puris/backend/stock/controller/StockViewControllerTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/puris/backend/stock/controller/StockViewControllerTest.java
@@ -31,6 +31,8 @@ import org.eclipse.tractusx.puris.backend.masterdata.logic.service.MaterialServi
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.PartnerService;
 import org.eclipse.tractusx.puris.backend.stock.logic.dto.FrontendMaterialDto;
 import org.eclipse.tractusx.puris.backend.stock.logic.service.*;
+import org.eclipse.tractusx.puris.backend.supply.logic.service.CustomerSupplyService;
+import org.eclipse.tractusx.puris.backend.supply.logic.service.SupplierSupplyService;
 import org.junit.jupiter.api.Test;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -74,6 +76,12 @@ class StockViewControllerTest {
 
     @MockBean
     private ReportedProductItemStockService reportedProductItemStockService;
+
+    @MockBean
+    private CustomerSupplyService customerSupplyService;
+
+    @MockBean
+    private SupplierSupplyService supplierSupplyService;
 
     @MockBean
     private PartnerService partnerService;

--- a/backend/src/test/java/org/eclipse/tractusx/puris/backend/supply/logic/SupplyServiceTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/puris/backend/supply/logic/SupplyServiceTest.java
@@ -1,0 +1,155 @@
+package org.eclipse.tractusx.puris.backend.supply.logic;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.tractusx.puris.backend.delivery.logic.service.OwnDeliveryService;
+import org.eclipse.tractusx.puris.backend.delivery.logic.service.ReportedDeliveryService;
+import org.eclipse.tractusx.puris.backend.demand.logic.services.OwnDemandService;
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
+import org.eclipse.tractusx.puris.backend.masterdata.logic.service.MaterialPartnerRelationService;
+import org.eclipse.tractusx.puris.backend.masterdata.logic.service.MaterialService;
+import org.eclipse.tractusx.puris.backend.masterdata.logic.service.PartnerService;
+import org.eclipse.tractusx.puris.backend.stock.domain.repository.MaterialItemStockRepository;
+import org.eclipse.tractusx.puris.backend.stock.logic.dto.itemstocksamm.DirectionCharacteristic;
+import org.eclipse.tractusx.puris.backend.stock.logic.service.MaterialItemStockService;
+import org.eclipse.tractusx.puris.backend.supply.domain.model.OwnCustomerSupply;
+import org.eclipse.tractusx.puris.backend.supply.domain.repository.ReportedCustomerSupplyRepository;
+import org.eclipse.tractusx.puris.backend.supply.logic.service.CustomerSupplyService;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SupplyServiceTest {
+    @InjectMocks
+    CustomerSupplyService customerSupplyService;
+
+    @Mock
+    MaterialService materialService;
+
+    @Mock
+    PartnerService partnerService;
+
+    @Mock
+    MaterialItemStockService stockService;
+
+    @Mock
+    MaterialPartnerRelationService mprService;
+
+    @Mock 
+    MaterialItemStockRepository itemStockRepository;
+
+    @Mock
+    OwnDeliveryService ownDeliveryService;
+
+    @Mock
+    ReportedDeliveryService reportedDeliveryService;
+
+    @Mock
+    OwnDemandService ownDemandService;
+
+    @Mock
+    ReportedCustomerSupplyRepository repository;
+
+    private static final String MATERIAL_NUMBER_CX_CUSTOMER = UUID.randomUUID().toString();
+    private static final String BPNL_CUSTOMER = "BPNL4444444444XX";
+    private static final String BPNS_CUSTOMER = "BPNS4444444444XX";
+    private static final String BPNA_CUSTOMER = "BPNA4444444444AA";
+
+    private static final String BPNL_SUPPLIER = "BPNL1234567890ZZ";
+    private static final String BPNS_SUPPLIER = "BPNS1234567890ZZ";
+    private static final String BPNA_SUPPLIER = "BPNA1234567890AA";
+
+    private Partner CUSTOMER_PARTNER;
+    private Partner SUPPLIER_PARTNER;
+
+    private static final Material TEST_MATERIAL = new Material(
+            true,
+            true,
+            "Own-Mnr",
+            MATERIAL_NUMBER_CX_CUSTOMER,
+            "Test Material",
+            new Date());
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        CUSTOMER_PARTNER = new Partner(
+            "Test Customer",
+            "http://some-edc.com",
+            BPNL_CUSTOMER,
+            BPNS_CUSTOMER,
+            "Site Name",
+            BPNA_CUSTOMER,
+            "Street 10",
+            "40468 Testdorf",
+            "DE"
+        );
+        CUSTOMER_PARTNER.setUuid(UUID.randomUUID());
+
+        SUPPLIER_PARTNER = new Partner(
+            "Test Supplier",
+            "http://some-edc.com",
+            BPNL_SUPPLIER,
+            BPNS_SUPPLIER,
+            "Site Name",
+            BPNA_SUPPLIER,
+            "Street 10",
+            "40468 Testdorf",
+            "DE"
+        );
+        SUPPLIER_PARTNER.setUuid(UUID.randomUUID());
+    }
+
+    @Test
+    void testCalculateCustomerDaysOfSupply() {
+        List<Double> demandQuantities = List.of(40.0, 60.0, 50.0, 50.0, 60.0, 50.0);
+        List<Double> deliveryQuantities = List.of(0.0, 60.0, 100.0, 0.0, 0.0, 40.0);
+        List<Double> daysOfSupply = List.of(1.0, 1.2, 2.0, 1.0, 0.0);
+
+        when(ownDemandService.getQuantityForDays(
+            TEST_MATERIAL.getOwnMaterialNumber(),
+            Optional.of(BPNL_SUPPLIER),
+            Optional.empty(),
+            6
+        )).thenReturn(demandQuantities);
+
+        when(ownDeliveryService.getQuantityForDays(
+            TEST_MATERIAL.getOwnMaterialNumber(),
+            Optional.of(BPNL_SUPPLIER),
+            Optional.empty(),
+            DirectionCharacteristic.INBOUND,
+            6
+        )).thenReturn(deliveryQuantities);
+
+        when(reportedDeliveryService.getQuantityForDays(
+            TEST_MATERIAL.getOwnMaterialNumber(),
+            Optional.of(BPNL_SUPPLIER),
+            Optional.empty(),
+            DirectionCharacteristic.INBOUND,
+            6
+        )).thenReturn(List.of(0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+
+        Optional<String> partnerBpnl = Optional.of(BPNL_SUPPLIER);
+        when(partnerService.findByBpnl(partnerBpnl.get())).thenReturn(SUPPLIER_PARTNER);
+
+        when(stockService.getInitialStockQuantity(TEST_MATERIAL.getOwnMaterialNumber(), partnerBpnl)).thenReturn(100.0);
+        when(materialService.findByOwnMaterialNumber(TEST_MATERIAL.getOwnMaterialNumber())).thenReturn(TEST_MATERIAL);
+
+        List<OwnCustomerSupply> customerSupplies = customerSupplyService.calculateDaysOfSupply(TEST_MATERIAL.getOwnMaterialNumber(), partnerBpnl, Optional.empty(), 6);
+
+        assertEquals(5, customerSupplies.size());
+        assertEquals(daysOfSupply, customerSupplies.stream().map(supply -> supply.getDaysOfSupply()).toList());
+    }
+
+}

--- a/frontend/src/contexts/calendarWeekContext.tsx
+++ b/frontend/src/contexts/calendarWeekContext.tsx
@@ -19,13 +19,13 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { createContext, ReactNode, useContext, useState } from 'react';
 import { Expandable } from '@features/material-details/models/expandable';
-import { CalendarWeek, getCalendarWeek, incrementCalendarWeek } from '@util/date-helpers';
+import { CalendarWeek, getCalendarWeek, incrementCalendarWeek, incrementDate } from '@util/date-helpers';
 
 function initializeCalendarWeeks(): Expandable<CalendarWeek>[] {
-    const today = new Date();
-    const numberOfWeeks = today.getUTCDay() === 1 ? 4 : 5;
+    const yesterday = incrementDate(new Date(), -1);
+    const numberOfWeeks = yesterday.getUTCDay() === 1 ? 4 : 5;
     const weeks: Expandable<CalendarWeek>[] = [];
-    const currentCalendarWeek = getCalendarWeek(today);
+    const currentCalendarWeek = getCalendarWeek(yesterday);
     for (let i = 0; i < numberOfWeeks; i++) {
         weeks.push({
             ...incrementCalendarWeek(currentCalendarWeek, i),

--- a/frontend/src/features/material-details/components/CalendarWeekSummary.tsx
+++ b/frontend/src/features/material-details/components/CalendarWeekSummary.tsx
@@ -122,9 +122,9 @@ export function CalendarWeekSummary<TType extends SummaryType>({ cw, summary, is
                                     <Box flex={1} display="flex" justifyContent="center" alignItems="center">
                                         <Typography
                                             variant="body2"
-                                            color={ summary.dailySummaries[date.toLocaleDateString()]?.stockTotal < 0 ? '#f44336bb' : 'inherit' }
+                                            color={ summary.dailySummaries[incrementDate(date, 1).toLocaleDateString()]?.stockTotal < 0 ? '#f44336bb' : 'inherit' }
                                         >
-                                            {summary.dailySummaries[date.toLocaleDateString()]?.stockTotal}
+                                            {summary.dailySummaries[incrementDate(date, 1).toLocaleDateString()]?.stockTotal}
                                         </Typography>
                                     </Box>
                                 </Stack>
@@ -175,7 +175,7 @@ export function CalendarWeekSummary<TType extends SummaryType>({ cw, summary, is
                                 {
                                     [...weekDates]
                                         .reverse()
-                                        .map((date) => summary.dailySummaries[date.toLocaleDateString()])
+                                        .map((date) => summary.dailySummaries[incrementDate(date, 1).toLocaleDateString()])
                                         .find((sum) => sum)?.stockTotal
                                 }
                             </Typography>


### PR DESCRIPTION
## Description

- adjusted the calculation of days of supply to be in line with the standard
- notable differences are:
    - actual item stock is displayed on the previous day
    - days of supply compares the current stock in a day to demands/outgoing shipments of the upcoming days
    - incoming deliveries/production are not included in the calculation for a single day
-  a unit test for the calculation was provided
    - the test uses the sample data provided in the [standard document](https://catenax-ev.github.io/docs/next/standards/CX-0145-DaysofsupplyExchange#522-process-representation)
    - **note:** There seems to be a mistake in the standard data. the days of supply for day 5 should be 0

resolves #771 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
