### PR TITLE
docs: prepare release 25.03

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -26,14 +26,14 @@ on:
         inputs:
             node_image:
                 description: 'kindest/node image for k8s kind cluster'
-                # k8s version from 3.1 release as default
-                default: 'kindest/node:v1.27.3'
+                # k8s version from 25.03 release as default
+                default: 'kindest/node:v1.32.2'
                 required: false
                 type: string
             upgrade_from:
                 description: 'chart version to upgrade from'
-                # chart version from 1.0.0 (R24.03) release as default
-                default: '1.0.0'
+                # chart version from 2.7.0 (R24.08) release as default
+                default: '2.7.0'
                 required: false
                 type: string
             helm_version:

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -63,7 +63,7 @@ jobs:
                     # upgrade version, default (v0.17.0) uses node image v1.21.1 and doesn't work with more recent node image versions
                     version: v0.20.0
                     # default value for event_name != workflow_dispatch
-                    node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.27.3' }}
+                    node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.32.2' }}
 
             -   name: Build Frontend image
                 uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -28,6 +28,7 @@ on:
 
 jobs:
   analyze-frontend:
+    if: github.repository == 'eclipse-tractusx/puris'
     name: Analyze frontend
     runs-on: ubuntu-latest
     permissions:
@@ -57,6 +58,7 @@ jobs:
           sarif_file: "trivy-results-1.sarif"
 
   analyze-backend:
+    if: github.repository == 'eclipse-tractusx/puris'
     name: Analyze backend
     runs-on: ubuntu-latest
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,135 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v3.0.0](https://github.com/eclipse-tractusx/puris/releases/tag/3.0.0)
+
+The following Changelog lists the changes. Please refer to the [documentation](docs/README.md) for configuration needs and understanding the concept changes.
+
+The **need for configuration updates** is **marked bold**.
+
+### Added
+
+* Added banner for puris backend ([#556](https://github.com/eclipse-tractusx/puris/pull/556))
+* Add bruno integration test collection ([#546](https://github.com/eclipse-tractusx/puris/pull/546))
+
+### Changed
+
+Fixes
+
+* Encode material numbers in frontend parameters with base64 ([#512](https://github.com/eclipse-tractusx/puris/pull/512), [#580](https://github.com/eclipse-tractusx/puris/pull/580))(*breaking change*)
+* Change log message for already existing edc assets on startup ([547](https://github.com/eclipse-tractusx/puris/pull/547))
+* Don't return own partner entity from partner/all endpoint ([#563](https://github.com/eclipse-tractusx/puris/pull/563))
+* Fix material number issues and partner/all endpoint in integration test suite ([#689](https://github.com/eclipse-tractusx/puris/pull/689))
+
+* improve demand and capacity notification (accept material number correctly, added test, role specific differentiation) ([#576](https://github.com/eclipse-tractusx/puris/pull/576))
+
+UI enhancements
+
+* Reworked UI theme ([#709](https://github.com/eclipse-tractusx/puris/pull/709), [#701](https://github.com/eclipse-tractusx/puris/issues/701), [#769](https://github.com/eclipse-tractusx/puris/pull/769))
+* Added Material List View ([#702](https://github.com/eclipse-tractusx/puris/issues/702))
+* Added Material Details View ([#737](https://github.com/eclipse-tractusx/puris/issues/737), [#747](https://github.com/eclipse-tractusx/puris/pull/747), [#750](https://github.com/eclipse-tractusx/puris/pull/750))
+* Integrated Stock View into Material Details View ([#742](https://github.com/eclipse-tractusx/puris/pull/742), [#427](https://github.com/eclipse-tractusx/puris/issues/427), [#778](https://github.com/eclipse-tractusx/puris/pull/778))
+
+Days of Supply Information implementation
+
+* Added Days of Supply EDC integration ([#694](https://github.com/eclipse-tractusx/puris/pull/694))
+* Added Days of Supply to the frontend ([#776](https://github.com/eclipse-tractusx/puris/pull/776))
+* Added unit tests for Days of Supply to the backend ([#454](https://github.com/eclipse-tractusx/puris/issues/454), [#694](https://github.com/eclipse-tractusx/puris/pull/694))
+* Add integration test cases for bruno for days of supply ([#752](https://github.com/eclipse-tractusx/puris/pull/752))
+* Fix days of supply calculation by only relying on the projected stocks without the addedValue ([#773](https://github.com/eclipse-tractusx/puris/pull/773))
+
+CI
+
+* Added workflow for backend unit tests ([#616](https://github.com/eclipse-tractusx/puris/pull/616))
+* Added trufflehog secret scanning tool ([#531](https://github.com/eclipse-tractusx/puris/pull/531), [#555](https://github.com/eclipse-tractusx/puris/pull/555))
+* Updated Triviy version and workflow failure ([#452](https://github.com/eclipse-tractusx/puris/pull/452))
+* Changed Helm Test workflow to only check for version bump in the end so that version bumps are not enforced anymore ([#450](https://github.com/eclipse-tractusx/puris/pull/450))
+
+Chore
+
+* edited license headers to follow TRG 7.02 ([#562](https://github.com/eclipse-tractusx/puris/pull/562))
+* cleanup erp adapter request feature ([issue#584](https://github.com/eclipse-tractusx/puris/issues/584)) ([#578](https://github.com/eclipse-tractusx/puris/pull/578))
+
+* Update of swagger documentation (TBD)
+
+Version Bumps
+
+* Infrastructure Components
+    * Tractus-X Connector to 0.8.0 ([#705](https://github.com/eclipse-tractusx/puris/pull/705)) and 0.9.0-rc2 ([#781](https://github.com/eclipse-tractusx/puris/pull/781))
+    * Digital Twin Registry to 0.7.0 ([#781](https://github.com/eclipse-tractusx/puris/pull/781))
+* Backend Dependencies
+    * edc-connector-version from 0.7.0 to 0.11.1 in /backend ([#781](https://github.com/eclipse-tractusx/puris/pull/781))
+    * org.springdoc:springdoc-openapi-starter-webmvc-ui in /backend ([#790](https://github.com/eclipse-tractusx/puris/pull/790))
+    * org.springframework.boot:spring-boot-starter-parent in /backend ([#790](https://github.com/eclipse-tractusx/puris/pull/790))
+* IAM Mock (Local Deployment)
+    * jinja2 from 3.1.4 to 3.1.5 ([#784](https://github.com/eclipse-tractusx/puris/pull/784))
+    * python-multipart from 0.0.7 to 0.0.18 ([#784](https://github.com/eclipse-tractusx/puris/pull/784))
+    * starlette from 0.37.2 to 0.40.0 ([#784](https://github.com/eclipse-tractusx/puris/pull/784))
+    * cryptography from 42.0.5 to 44.0.1 ([#784](https://github.com/eclipse-tractusx/puris/pull/784))
+* CI
+    * peter-evans/dockerhub-description from 3.4.2 to 4.0.0 ([#460](https://github.com/eclipse-tractusx/puris/pull/460))
+    * actions/checkout from 4.1.6 to 4.2.3 ([#461](https://github.com/eclipse-tractusx/puris/pull/461), [#629](https://github.com/eclipse-tractusx/puris/pull/629), [#607](https://github.com/eclipse-tractusx/puris/pull/607), [#646](https://github.com/eclipse-tractusx/puris/pull/646))
+    * actions/setup-node from 4.0.2 to 4.1.0 ([#552](https://github.com/eclipse-tractusx/puris/pull/552), [#594](https://github.com/eclipse-tractusx/puris/pull/594), [#650](https://github.com/eclipse-tractusx/puris/pull/650))
+    * trufflesecurity/trufflehog from 3.80.2 to 3.82.13 ([#544](https://github.com/eclipse-tractusx/puris/pull/544), [#557](https://github.com/eclipse-tractusx/puris/pull/557), [#571](https://github.com/eclipse-tractusx/puris/pull/571), [#588](https://github.com/eclipse-tractusx/puris/pull/588), [#603](https://github.com/eclipse-tractusx/puris/pull/603), [#608](https://github.com/eclipse-tractusx/puris/pull/608), [#610](https://github.com/eclipse-tractusx/puris/pull/610), [#630](https://github.com/eclipse-tractusx/puris/pull/630), [#636](https://github.com/eclipse-tractusx/puris/pull/636), [#639](https://github.com/eclipse-tractusx/puris/pull/639), [#651](https://github.com/eclipse-tractusx/puris/pull/651))
+    * docker/setup-buildx-action from 3.3.0 to 3.7.1 ([#553](https://github.com/eclipse-tractusx/puris/pull/553), [#618](https://github.com/eclipse-tractusx/puris/pull/618))
+    * docker/login-action from 3.1.0 to 3.3.0 ([#548](https://github.com/eclipse-tractusx/puris/pull/548))
+    * docker/setup-qemu-action from 3.0.0 to 3.2.0 ([#549](https://github.com/eclipse-tractusx/puris/pull/549))
+    * github/codeql-action from 3.25.10 to 3.26.13 ([#545](https://github.com/eclipse-tractusx/puris/pull/545), [#558](https://github.com/eclipse-tractusx/puris/pull/558), [#567](https://github.com/eclipse-tractusx/puris/pull/567), [#569](https://github.com/eclipse-tractusx/puris/pull/569), [#589](https://github.com/eclipse-tractusx/puris/pull/589), [#593](https://github.com/eclipse-tractusx/puris/pull/593), [#604](https://github.com/eclipse-tractusx/puris/pull/604), [#614](https://github.com/eclipse-tractusx/puris/pull/614), [#624](https://github.com/eclipse-tractusx/puris/pull/624), [#632](https://github.com/eclipse-tractusx/puris/pull/632), [#645](https://github.com/eclipse-tractusx/puris/pull/645))
+    * actions/setup-java from 3.13.0 to 4.5.0 ([#535](https://github.com/eclipse-tractusx/puris/pull/535), [#605](https://github.com/eclipse-tractusx/puris/pull/605), [#628](https://github.com/eclipse-tractusx/puris/pull/628), [#649](https://github.com/eclipse-tractusx/puris/pull/649))
+    * docker/build-push-action from 5.3.0 to 6.9.0 ([#543](https://github.com/eclipse-tractusx/puris/pull/543), [#612](https://github.com/eclipse-tractusx/puris/pull/612))
+    * actions/setup-python from 5.1.1 to 5.2.0 ([#570](https://github.com/eclipse-tractusx/puris/pull/570)) to 5.3.0 ([#648](https://github.com/eclipse-tractusx/puris/pull/648))
+    * checkmarx/kics-github-action from 2.1.0 to 2.1.3 ([#560](https://github.com/eclipse-tractusx/puris/pull/560), [#619](https://github.com/eclipse-tractusx/puris/pull/619))
+    * aquasecurity/trivy-action from 0.22.0 to 0.24.0 ([#559](https://github.com/eclipse-tractusx/puris/pull/559),[#627](https://github.com/eclipse-tractusx/puris/pull/627), [#635](https://github.com/eclipse-tractusx/puris/pull/635))
+    * keycloak-js from 23.0.5 to 25.0.6 in /frontend ([#595](https://github.com/eclipse-tractusx/puris/pull/595))
+
+### Removed
+
+N.A.
+
+### Known Knowns
+
+#### Security
+
+The Backend is currently secured via API Key while the Frontend already uses a Keycloak integration.
+See [Admin Guide](./docs/admin/Admin_Guide.md) for further information.
+
+#### Upgradeability
+
+As currently no active user was known migrations of data are not yet supported. The chart technically is upgradeable.
+
+#### Data Sovereignty
+
+For productive use the following enhancements are encouraged
+
+* User FrontEnd available: Role Company Admin is able to query catalogue and see negotiations and transfers
+  But company rules / policies need to be configured upfront in backend (via postman) to enable automatic contract
+  negotiations, responsibility lies with Company Admin role
+  --> add section in the User Manual describing this and the (legal) importance and responsibility behind defining these rules
+* Currently only one standard policy per reg. connector / customer instance is supported (more precisely one for DTR,
+  one for all submodels), negotiation happens automatically based on this
+  --> enhance option to select partner and define specific policies (to be planned in context of BPDM Integration)
+  --> UI for specific configuration by dedicated role (e.g. Comp Admin) and more flexible policy configuration (withoutv code changes) is needed
+* As a non-Admin user I do not have ability to view policies in detail --> transparency for users when interacting with and requesting / consuming data via dashboard / views on underlying usage policies to be enhanced
+* ContractReference Constraint or configuration of policies specific to one partner only has notnot implemented --> clarification of potential reference to "PURIS standard contract" and enabling of ContractReference for 24.08.
+* unclear meaning of different stati in negotations --> add view of successfull contract agreeements wrt which data have been closed
+* current logging only done on info level --> enhance logging of policies (currently only available at debug level)
+* in case of non-matching policies (tested in various scenarios) no negotiation takes place --> **enhance visualization or specific Error message to user**
+* no validation of the Schema "profile": "cx-policy:profile2405" (required to ensure interop with other PURIS apps)
+
+#### Styleguide
+
+Overall
+
+* Brief description at the top of each page describing content would be nice for better user experience.
+
+Catalog
+
+* No action possible -> unclear to user when and how user will consume an offer
+
+Negotiations
+
+* Add filters for transparency (bpnl, state)
+
 ## [v2.1.0](https://github.com/eclipse-tractusx/puris/releases/tag/2.1.0)
 
 The following Changelog lists the changes. Please refer to the [documentation](docs/README.md) for configuration needs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,10 @@ Fixes
 
 UI enhancements
 
-* Reworked UI theme ([#709](https://github.com/eclipse-tractusx/puris/pull/709), [#701](https://github.com/eclipse-tractusx/puris/issues/701), [#769](https://github.com/eclipse-tractusx/puris/pull/769))
-* Added Material List View ([#702](https://github.com/eclipse-tractusx/puris/issues/702))
-* Added Material Details View ([#737](https://github.com/eclipse-tractusx/puris/issues/737), [#747](https://github.com/eclipse-tractusx/puris/pull/747), [#750](https://github.com/eclipse-tractusx/puris/pull/750))
-* Integrated Stock View into Material Details View ([#742](https://github.com/eclipse-tractusx/puris/pull/742), [#427](https://github.com/eclipse-tractusx/puris/issues/427), [#778](https://github.com/eclipse-tractusx/puris/pull/778))
+* Reworked UI theme ([#709](https://github.com/eclipse-tractusx/puris/pull/709))
+* Added Material List View ([#732](https://github.com/eclipse-tractusx/puris/pull/732))
+* Added Material Details View ([#747](https://github.com/eclipse-tractusx/puris/pull/747), [#750](https://github.com/eclipse-tractusx/puris/pull/750))
+* Integrated Stock View into Material Details View ([#778](https://github.com/eclipse-tractusx/puris/pull/778))
 
 Days of Supply Information implementation
 
@@ -51,10 +51,10 @@ CI
 
 Chore
 
-* edited license headers to follow TRG 7.02 ([#562](https://github.com/eclipse-tractusx/puris/pull/562))
-* cleanup erp adapter request feature ([issue#584](https://github.com/eclipse-tractusx/puris/issues/584)) ([#578](https://github.com/eclipse-tractusx/puris/pull/578))
-
-* Update of swagger documentation (TBD)
+* Changed license headers to follow TRG 7.02 ([#562](https://github.com/eclipse-tractusx/puris/pull/562))
+* Cleaned up erp adapter request feature ([#578](https://github.com/eclipse-tractusx/puris/pull/578))
+* Updated User Guide ([#780](https://github.com/eclipse-tractusx/puris/pull/780))
+* Update of swagger documentation ([#794](https://github.com/eclipse-tractusx/puris/pull/794))
 
 Version Bumps
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The application follows the following Catena-X standards (business-wise) to the 
 | [CX-0120 Short-Term Material Demand Exchange 2.0.0](https://catenax-ev.github.io/docs/next/standards/CX-0120-ShortTermMaterialDemandExchange)      | Compliant.                                | 
 | [CX-0121 Planned Production Output Exchange 1.0.0](https://catenax-ev.github.io/docs/next/standards/CX-0121-PlannedProductionOutputExchange)       | Compliant.                                |
 | [CX-0122 Item Stock Exchange 2.0.0](https://catenax-ev.github.io/docs/next/standards/CX-0122-ItemStockExchange)                                    | Compliant.                                |                                                                                         
-| [CX-0145 Days of Supply Exchange 1.0.0](https://catenax-ev.github.io/docs/next/standards/CX-0145-DaysofsupplyExchange)                             | Missing EDC and Frontend integration.     |                                                                           
+| [CX-0145 Days of Supply Exchange 1.0.0](https://catenax-ev.github.io/docs/next/standards/CX-0145-DaysofsupplyExchange)                             | Compliant.                                |                                                                           
 | [CX-0146 Supply Chain Disruption Notifications 1.0.0](https://catenax-ev.github.io/docs/next/standards/CX-0146-SupplyChainDisruptionNotifications) | Missing functionality to react and close. |                                                             
 
 ## Known Knows

--- a/backend/DOCKER_NOTICE.md
+++ b/backend/DOCKER_NOTICE.md
@@ -16,6 +16,8 @@ Eclipse Tractus-X product(s) installed within the image:
 
 - DockerHub: https://hub.docker.com/_/eclipse-temurin
 - GitHub project: https://github.com/adoptium/containers
+- Eclipse Temurin project: https://projects.eclipse.org/projects/adoptium.temurin
+- Additional information about the Eclipse Temurin images: https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin
 
 As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc
 from the base distribution, along with any direct or indirect dependencies of the primary software being contained).

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <groupId>org.eclipse.tractusx.puris</groupId>
     <artifactId>puris-backend</artifactId>
-    <version>2.1.0</version>
+    <version>3.0.0</version>
     <name>puris-backend</name>
     <description>PURIS Backend</description>
     <properties>

--- a/charts/puris/Chart.yaml
+++ b/charts/puris/Chart.yaml
@@ -35,10 +35,10 @@ dependencies:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.7.0
+version: 2.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.1.0"
+appVersion: "3.0.0"

--- a/charts/puris/README.md
+++ b/charts/puris/README.md
@@ -1,6 +1,6 @@
 # puris
 
-![Version: 2.7.0](https://img.shields.io/badge/Version-2.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+![Version: 2.8.0](https://img.shields.io/badge/Version-2.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
 A helm chart for Kubernetes deployment of PURIS
 

--- a/charts/puris/README.md
+++ b/charts/puris/README.md
@@ -102,7 +102,7 @@ dependencies:
 | backend.puris.erpadapter.timelimit | int | `7` | Period since last received partner request after which no more new update requests to the erp adapter will be sent (days) |
 | backend.puris.erpadapter.url | string | `"http://my-erpadapter:8080"` | The url of your ERP adapter's request api |
 | backend.puris.existingSecret | string | `"secret-puris-backend"` | Secret for backend passwords. For more information look into 'backend-secrets.yaml' file. |
-| backend.puris.frameworkagreement.credential | string | `"Puris"` | The name of the framework agreement. Starting with Uppercase and using CamelCase. |
+| backend.puris.frameworkagreement.credential | string | `"DataExchangeGovernance"` | The name of the framework agreement. Starting with Uppercase and using CamelCase. |
 | backend.puris.frameworkagreement.version | string | `"1.0"` | The version of the framework agreement, NEEDS TO BE PUT AS "STRING"! |
 | backend.puris.generatematerialcatenaxid | bool | `true` | Flag that decides whether the auto-generation feature of the puris backend is enabled. Since all Material entities are required to have a CatenaX-Id, you must enter any pre-existing CatenaX-Id via the materials-API of the backend, when you are inserting a new Material entity to the backend's database. If a CatenaX-Id was not assigned to your Material so far, then this feature can auto-generate one randomly. In a real-world-scenario, you must then use this randomly generated CatenaX-Id for the lifetime of that Material entity. |
 | backend.puris.itemstocksubmodel.apiassetid | string | `"itemstocksubmodel-api-asset"` | Asset ID for ItemStockSubmodel API |

--- a/charts/puris/values.yaml
+++ b/charts/puris/values.yaml
@@ -441,7 +441,7 @@ backend:
       apiassetid: notification-api-asset
     frameworkagreement:
       # -- The name of the framework agreement. Starting with Uppercase and using CamelCase.
-      credential: Puris
+      credential: DataExchangeGovernance
       # -- The version of the framework agreement, NEEDS TO BE PUT AS "STRING"!
       version: "1.0"
     purpose:

--- a/docs/admin/Admin_Guide.md
+++ b/docs/admin/Admin_Guide.md
@@ -113,6 +113,10 @@ TLDR; you define the definition of the policy you want to use and that you'll ac
 that is templated. You can only configure the name and version of the Framework Agreement Credential and the Usage
 Purpose.
 
+> NOTE:
+> 
+> The odrl:profile of Catena-X is currently hard-coded to `cx-policy:profile2405`.
+
 ### Framework Agreement
 
 To configure the Framework Agreement credential, that is automatically enforced by the EDC during contracting
@@ -121,10 +125,10 @@ configured.
 The table contains
 the puris defaults for release R24.05.
 
-| Helm                                        | Docker                              | Configuration |
-|---------------------------------------------|-------------------------------------|---------------|
-| backend.puris.frameworkagreement.credential | PURIS_FRAMEWORKAGREEMENT_CREDENTIAL | Puris         |
-| backend.puris.frameworkagreement.version    | PURIS_FRAMEWORKAGREEMENT_VERSION    | 1.0           |
+| Helm                                        | Docker                              | Configuration          |
+|---------------------------------------------|-------------------------------------|------------------------|
+| backend.puris.frameworkagreement.credential | PURIS_FRAMEWORKAGREEMENT_CREDENTIAL | DataExchangeGovernance |
+| backend.puris.frameworkagreement.version    | PURIS_FRAMEWORKAGREEMENT_VERSION    | 1.0                    |
 
 _**ATTENTION**: If the credential is NOT listed in
 the [odrl profile](https://github.com/catenax-eV/cx-odrl-profile/blob/main/profile.md)

--- a/docs/api/openAPI.yaml
+++ b/docs/api/openAPI.yaml
@@ -20,6 +20,32 @@ components:
           pattern: ^[^\n\x0B\f\r\x85\u2028\u2029]+$
           type: string
       type: object
+    AllocatedDaysOfSupply:
+      additionalProperties: false
+      properties:
+        amountOfAllocatedDaysOfSupply:
+          items:
+            $ref: '#/components/schemas/QuantityOfDaysOfSupply'
+          maxItems: 50
+          type: array
+        lastUpdatedOnDateTime:
+          format: date-time
+          maxItems: 50
+          type: string
+        stockLocationBPNA:
+          maxItems: 50
+          pattern: ^BPNA[0-9a-zA-Z]{12}$
+          type: string
+        stockLocationBPNS:
+          maxItems: 50
+          pattern: ^BPNS[0-9a-zA-Z]{12}$
+          type: string
+      required:
+      - amountOfAllocatedDaysOfSupply
+      - lastUpdatedOnDateTime
+      - stockLocationBPNA
+      - stockLocationBPNS
+      type: object
     AllocatedPlannedProductionOutput:
       additionalProperties: false
       properties:
@@ -42,6 +68,49 @@ components:
       - lastUpdatedOnDateTime
       - plannedProductionQuantity
       - productionSiteBpns
+      type: object
+    Classification:
+      additionalProperties: false
+      properties:
+        classificationDescription:
+          maxItems: 50
+          pattern: ^[^\n\x0B\f\r\x85\u2028\u2029]+$
+          type: string
+        classificationID:
+          maxItems: 50
+          pattern: ^[^\n\x0B\f\r\x85\u2028\u2029]+$
+          type: string
+        classificationStandard:
+          maxItems: 50
+          pattern: ^[^\n\x0B\f\r\x85\u2028\u2029]+$
+          type: string
+      required:
+      - classificationID
+      - classificationStandard
+      type: object
+    DaysOfSupply:
+      additionalProperties: false
+      properties:
+        allocatedDaysOfSupply:
+          items:
+            $ref: '#/components/schemas/AllocatedDaysOfSupply'
+          maxItems: 50
+          type: array
+          uniqueItems: true
+        direction:
+          enum:
+          - INBOUND
+          - OUTBOUND
+          maxItems: 50
+          type: string
+        materialGlobalAssetId:
+          maxItems: 50
+          pattern: (^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)
+          type: string
+      required:
+      - allocatedDaysOfSupply
+      - direction
+      - materialGlobalAssetId
       type: object
     DeliveryDto:
       additionalProperties: false
@@ -288,104 +357,6 @@ components:
           maxItems: 50
           type: string
       type: object
-    DemandAndCapacityNotificationSamm:
-      additionalProperties: false
-      properties:
-        affectedSitesRecipient:
-          items:
-            maxItems: 50
-            pattern: ^BPNS[0-9a-zA-Z]{12}$
-            type: string
-          maxItems: 50
-          type: array
-        affectedSitesSender:
-          items:
-            maxItems: 50
-            pattern: ^BPNS[0-9a-zA-Z]{12}$
-            type: string
-          maxItems: 50
-          type: array
-        contentChangedAt:
-          format: date-time
-          maxItems: 50
-          type: string
-        effect:
-          enum:
-          - demand-reduction
-          - demand-increase
-          - capacity-reduction
-          - capacity-increase
-          maxItems: 50
-          type: string
-        expectedEndDateOfEffect:
-          format: date-time
-          maxItems: 50
-          type: string
-        leadingRootCause:
-          enum:
-          - strike
-          - natural-disaster
-          - production-incident
-          - pandemic-or-epidemic
-          - logistics-disruption
-          - war
-          - other
-          maxItems: 50
-          type: string
-        materialGlobalAssetId:
-          items:
-            maxItems: 50
-            pattern: (^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)
-            type: string
-          maxItems: 50
-          type: array
-        materialNumberCustomer:
-          items:
-            maxItems: 50
-            pattern: ^[^\n\x0B\f\r\x85\u2028\u2029]+$
-            type: string
-          maxItems: 50
-          type: array
-        materialNumberSupplier:
-          items:
-            maxItems: 50
-            pattern: ^[^\n\x0B\f\r\x85\u2028\u2029]+$
-            type: string
-          maxItems: 50
-          type: array
-        notificationId:
-          maxItems: 50
-          pattern: (^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)
-          type: string
-        relatedNotificationId:
-          maxItems: 50
-          pattern: (^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)
-          type: string
-        sourceNotificationId:
-          maxItems: 50
-          pattern: (^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)
-          type: string
-        startDateOfEffect:
-          format: date-time
-          maxItems: 50
-          type: string
-        status:
-          enum:
-          - resolved
-          - open
-          maxItems: 50
-          type: string
-        text:
-          maxItems: 50
-          type: string
-      required:
-      - contentChangedAt
-      - effect
-      - leadingRootCause
-      - notificationId
-      - startDateOfEffect
-      - status
-      type: object
     DemandDto:
       additionalProperties: false
       properties:
@@ -514,9 +485,16 @@ components:
     FrontendMaterialDto:
       additionalProperties: false
       properties:
+        daysOfSupply:
+          format: double
+          type: number
         description:
           maxItems: 50
           pattern: ^[^\n\x0B\f\r\x85\u2028\u2029]+$
+          type: string
+        lastUpdatedOn:
+          format: date-time
+          maxItems: 50
           type: string
         ownMaterialNumber:
           maxItems: 50
@@ -600,6 +578,10 @@ components:
     Material:
       additionalProperties: false
       properties:
+        lastUpdatedOn:
+          format: date-time
+          maxItems: 50
+          type: string
         materialFlag:
           type: boolean
         materialNumberCx:
@@ -763,6 +745,69 @@ components:
       required:
       - customerOrderId
       - customerOrderPositionId
+      type: object
+    PartSitesInformationAsPlanned:
+      additionalProperties: false
+      properties:
+        catenaXsiteId:
+          maxItems: 50
+          pattern: ^BPNS[0-9a-zA-Z]{12}$
+          type: string
+        function:
+          enum:
+          - production
+          - warehouse
+          - spare part warehouse
+          maxItems: 50
+          type: string
+        functionValidFrom:
+          maxItems: 50
+          pattern: ^(?:[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:[.][0-9]+)?Z|[0-9]{4}-[0-9]{2}-[0-9]{2}(?:T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:[.][0-9]+)?(?:Z|[+-][0-9]{2}:[0-9]{2}))?)$
+          type: string
+        functionValidUntil:
+          maxItems: 50
+          pattern: ^(?:[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:[.][0-9]+)?Z|[0-9]{4}-[0-9]{2}-[0-9]{2}(?:T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:[.][0-9]+)?(?:Z|[+-][0-9]{2}:[0-9]{2}))?)$
+          type: string
+      required:
+      - catenaXsiteId
+      - function
+      type: object
+    PartTypeInformationBody:
+      additionalProperties: false
+      properties:
+        manufacturerPartId:
+          maxItems: 50
+          type: string
+        nameAtManufacturer:
+          maxItems: 50
+          type: string
+        partClassification:
+          items:
+            $ref: '#/components/schemas/Classification'
+          maxItems: 50
+          type: array
+      required:
+      - manufacturerPartId
+      - nameAtManufacturer
+      type: object
+    PartTypeInformationSAMM:
+      additionalProperties: false
+      properties:
+        catenaXId:
+          maxItems: 50
+          pattern: (^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)
+          type: string
+        partSitesInformationAsPlanned:
+          items:
+            $ref: '#/components/schemas/PartSitesInformationAsPlanned'
+          maxItems: 50
+          type: array
+          uniqueItems: true
+        partTypeInformation:
+          $ref: '#/components/schemas/PartTypeInformationBody'
+      required:
+      - catenaXId
+      - partTypeInformation
       type: object
     PartnerDto:
       additionalProperties: false
@@ -985,6 +1030,20 @@ components:
           maxItems: 50
           type: string
       type: object
+    QuantityOfDaysOfSupply:
+      additionalProperties: false
+      properties:
+        date:
+          format: date-time
+          maxItems: 50
+          type: string
+        daysOfSupply:
+          format: double
+          type: number
+      required:
+      - date
+      - daysOfSupply
+      type: object
     ReportedMaterialStockDto:
       additionalProperties: false
       properties:
@@ -1197,13 +1256,14 @@ components:
       type: apiKey
 info:
   title: PURIS FOSS Open API
-  version: 2.1.0
+  version: 3.0.0
 openapi: 3.0.1
 paths:
   /days-of-supply/customer:
     get:
       description: Calculate days of supply for customer for given number of days.
-        Filtered by given material number, partner bpnl and site bpns.
+        Filtered by given material number, partner bpnl and site bpns. materialNumber
+        is expected to be base64 encoded
       operationId: calculateCustomerDaysOfSupply
       parameters:
       - in: query
@@ -1215,14 +1275,14 @@ paths:
           type: string
       - in: query
         name: bpnl
-        required: true
+        required: false
         schema:
           additionalProperties: false
           maxItems: 50
           type: string
       - in: query
         name: siteBpns
-        required: true
+        required: false
         schema:
           additionalProperties: false
           maxItems: 50
@@ -1251,7 +1311,7 @@ paths:
   /days-of-supply/customer/reported:
     get:
       description: Get days of supply for customer for given material number and partner
-        bpnl.
+        bpnl. materialNumber is expected to be base64 encoded
       operationId: getCustomerDaysOfSupply
       parameters:
       - in: query
@@ -1264,6 +1324,13 @@ paths:
       - in: query
         name: bpnl
         required: true
+        schema:
+          additionalProperties: false
+          maxItems: 50
+          type: string
+      - in: query
+        name: siteBpns
+        required: false
         schema:
           additionalProperties: false
           maxItems: 50
@@ -1282,10 +1349,106 @@ paths:
       summary: Get days of supply for customer.
       tags:
       - supply-controller
+  /days-of-supply/customer/reported/refresh:
+    get:
+      description: Refreshes all reported customer Days of Supply for the specified
+        Material from the days of supply request API.
+      operationId: refreshReportedCustomerSupply
+      parameters:
+      - description: base64 encoded
+        in: query
+        name: ownMaterialNumber
+        required: true
+        schema:
+          additionalProperties: false
+          maxItems: 50
+          type: string
+      responses:
+        '200':
+          content:
+            '*/*':
+              schema:
+                additionalProperties: false
+                items:
+                  $ref: '#/components/schemas/PartnerDto'
+                maxItems: 50
+                type: array
+          description: OK
+      summary: Refreshes all reported customer days of supply
+      tags:
+      - supply-controller
+  /days-of-supply/request/{materialnumbercx}/{direction}/{representation}:
+    get:
+      operationId: getDaysOfSupplyMapping
+      parameters:
+      - in: header
+        name: edc-bpn
+        required: true
+        schema:
+          additionalProperties: false
+          maxItems: 50
+          type: string
+      - in: path
+        name: materialnumbercx
+        required: true
+        schema:
+          additionalProperties: false
+          maxItems: 50
+          type: string
+      - in: path
+        name: direction
+        required: true
+        schema:
+          additionalProperties: false
+          enum:
+          - INBOUND
+          - OUTBOUND
+          maxItems: 50
+          type: string
+      - in: path
+        name: representation
+        required: true
+        schema:
+          additionalProperties: false
+          maxItems: 50
+          type: string
+      responses:
+        '200':
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/DaysOfSupply'
+                additionalProperties: false
+          description: Ok
+        '400':
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/DaysOfSupply'
+                additionalProperties: false
+          description: Bad Request
+        '500':
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/DaysOfSupply'
+                additionalProperties: false
+          description: Internal Server Error
+        '501':
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/DaysOfSupply'
+                additionalProperties: false
+          description: Unsupported representation
+      summary: This endpoint receives the DaysOfSupply Submodel 2.0.0 requests
+      tags:
+      - days-of-supply-request-api-controller
   /days-of-supply/supplier:
     get:
       description: Calculate days of supply for supplier for given number of days.
-        Filtered by given material number, partner bpnl and site bpns.
+        Filtered by given material number, partner bpnl and site bpns. materialNumber
+        is expected to be base64 encoded
       operationId: calculateSupplierDaysOfSupply
       parameters:
       - in: query
@@ -1297,14 +1460,14 @@ paths:
           type: string
       - in: query
         name: bpnl
-        required: true
+        required: false
         schema:
           additionalProperties: false
           maxItems: 50
           type: string
       - in: query
         name: siteBpns
-        required: true
+        required: false
         schema:
           additionalProperties: false
           maxItems: 50
@@ -1333,7 +1496,7 @@ paths:
   /days-of-supply/supplier/reported:
     get:
       description: Get days of supply for supplier for given material number and partner
-        bpnl.
+        bpnl. materialNumber is expected to be base64 encoded
       operationId: getSupplierDaysOfSupply
       parameters:
       - in: query
@@ -1346,6 +1509,13 @@ paths:
       - in: query
         name: bpnl
         required: true
+        schema:
+          additionalProperties: false
+          maxItems: 50
+          type: string
+      - in: query
+        name: siteBpns
+        required: false
         schema:
           additionalProperties: false
           maxItems: 50
@@ -1364,13 +1534,42 @@ paths:
       summary: Get days of supply for supplier.
       tags:
       - supply-controller
+  /days-of-supply/supplier/reported/refresh:
+    get:
+      description: Refreshes all reported supplier Days of Supply for the specified
+        Material from the days of supply request API.
+      operationId: refreshReportedSupplierSupply
+      parameters:
+      - description: base64 encoded
+        in: query
+        name: ownMaterialNumber
+        required: true
+        schema:
+          additionalProperties: false
+          maxItems: 50
+          type: string
+      responses:
+        '200':
+          content:
+            '*/*':
+              schema:
+                additionalProperties: false
+                items:
+                  $ref: '#/components/schemas/PartnerDto'
+                maxItems: 50
+                type: array
+          description: OK
+      summary: Refreshes all reported supplier days of supply
+      tags:
+      - supply-controller
   /delivery:
     get:
       description: Get all planned deliveries for the given material number. Optionally
         a bpns and partner bpnl can be provided to filter the deliveries further.
       operationId: getAllDeliveries
       parameters:
-      - in: query
+      - description: encoded in base64
+        in: query
         name: ownMaterialNumber
         required: true
         schema:
@@ -1415,40 +1614,18 @@ paths:
               additionalProperties: false
         required: true
       responses:
-        '200':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DeliveryDto'
-                additionalProperties: false
-          description: Delivery was created.
         '201':
           content:
             '*/*':
               schema:
                 $ref: '#/components/schemas/DeliveryDto'
                 additionalProperties: false
-          description: Created
+          description: Delivery was created.
         '400':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DeliveryDto'
-                additionalProperties: false
           description: Malformed or invalid request body.
         '409':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DeliveryDto'
-                additionalProperties: false
           description: Delivery already exists.
         '500':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DeliveryDto'
-                additionalProperties: false
           description: Internal Server Error.
       summary: Creates a new delivery
       tags:
@@ -1463,14 +1640,7 @@ paths:
               additionalProperties: false
         required: true
       responses:
-        '200':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DeliveryDto'
-                additionalProperties: false
-          description: OK
-        '204':
+        '202':
           content:
             '*/*':
               schema:
@@ -1478,25 +1648,10 @@ paths:
                 additionalProperties: false
           description: Delivery was updated.
         '400':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DeliveryDto'
-                additionalProperties: false
           description: Malformed or invalid request body.
         '404':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DeliveryDto'
-                additionalProperties: false
           description: Delivery does not exist.
         '500':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DeliveryDto'
-                additionalProperties: false
           description: Internal Server Error.
       summary: Updates a delivery by its UUID
       tags:
@@ -1535,27 +1690,13 @@ paths:
                 additionalProperties: false
           description: Ok
         '400':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DeliveryInformation'
-                additionalProperties: false
           description: Bad Request
         '500':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DeliveryInformation'
-                additionalProperties: false
           description: Internal Server Error
         '501':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DeliveryInformation'
-                additionalProperties: false
           description: Unsupported representation
-      summary: This endpoint receives the Delivery Information Submodel 2.0.0 requests
+      summary: 'This endpoint receives the Delivery Information Submodel 2.0.0 requests.
+        This endpoint is meant to be accessed by partners via EDC only. '
       tags:
       - delivery-request-api-controller
   /delivery/reported/refresh:
@@ -1563,7 +1704,8 @@ paths:
       description: Refreshes all reported deliveries from the delivery request API.
       operationId: refreshReportedDeliveries
       parameters:
-      - in: query
+      - description: encoded in base64
+        in: query
         name: ownMaterialNumber
         required: true
         schema:
@@ -1614,7 +1756,8 @@ paths:
         demanding site can be filtered by its bpns.
       operationId: getAllDemands
       parameters:
-      - in: query
+      - description: encoded in base64
+        in: query
         name: ownMaterialNumber
         required: true
         schema:
@@ -1660,25 +1803,10 @@ paths:
                 additionalProperties: false
           description: Demand was created.
         '400':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DemandDto'
-                additionalProperties: false
           description: Malformed or invalid request body.
         '409':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DemandDto'
-                additionalProperties: false
           description: Demand already exists. Use PUT instead.
         '500':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DemandDto'
-                additionalProperties: false
           description: Internal Server Error.
       summary: Creates a new demand
       tags:
@@ -1701,25 +1829,10 @@ paths:
                 additionalProperties: false
           description: Demand was updated.
         '400':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DemandDto'
-                additionalProperties: false
           description: Malformed or invalid request body.
         '404':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DemandDto'
-                additionalProperties: false
           description: Demand does not exist.
         '500':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DemandDto'
-                additionalProperties: false
           description: Internal Server Error.
       summary: Updates a demand by its UUID
       tags:
@@ -1769,25 +1882,10 @@ paths:
                 additionalProperties: false
           description: Notification was created.
         '400':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DemandAndCapacityNotificationDto'
-                additionalProperties: false
           description: Malformed or invalid request body.
         '409':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DemandAndCapacityNotificationDto'
-                additionalProperties: false
           description: Notification already exists. Use PUT instead.
         '500':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DemandAndCapacityNotificationDto'
-                additionalProperties: false
           description: Internal Server Error.
       summary: Creates a new notification
       tags:
@@ -1810,25 +1908,10 @@ paths:
                 additionalProperties: false
           description: Notification was updated.
         '400':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DemandAndCapacityNotificationDto'
-                additionalProperties: false
           description: Malformed or invalid request body.
         '404':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DemandAndCapacityNotificationDto'
-                additionalProperties: false
           description: Notification does not exist.
         '500':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DemandAndCapacityNotificationDto'
-                additionalProperties: false
           description: Internal Server Error.
       summary: Updates a notification by its UUID
       tags:
@@ -1874,34 +1957,49 @@ paths:
       requestBody:
         content:
           application/json:
+            example:
+              content:
+                demandAndCapacityNotification:
+                  affectedSitesRecipient:
+                  - BPNS6666787765VQ
+                  affectedSitesSender:
+                  - BPNS7588787849VQ
+                  contentChangedAt: '2023-12-13T15:00:00+01:00'
+                  effect: demand-reduction
+                  expectedEndDateOfEffect: '2023-12-17T08:00:00+01:00'
+                  leadingRootCause: strike
+                  materialGlobalAssetId:
+                  - urn:uuid:48878d48-6f1d-47f5-8ded-a441d0d879df
+                  materialNumberCustomer:
+                  - MNR-7307-AU340474.002
+                  materialNumberSupplier:
+                  - MNR-8101-ID146955.001
+                  notificationId: urn:uuid:d9452f24-3bf3-4134-b3eb-68858f1b2362
+                  relatedNotificationId: urn:uuid:d05cef4a-b692-45bf-87cc-eda2d84e4c04
+                  sourceNotificationId: urn:uuid:c69cb3e4-16ad-43c3-82b9-0deac75ecf9e
+                  startDateOfEffect: '2023-12-13T15:00:00+01:00'
+                  status: resolved
+                  text: Capacity reduction due to ongoing strike.
+              header:
+                context: CX-DemandAndCapacityNotification:2.0
+                messageId: 3b4edc05-e214-47a1-b0c2-1d831cdd9ba9
+                receiverBpn: BPNL6666787765VQ
+                senderBpn: BPNL7588787849VQ
+                sentDateTime: '2023-06-19T21:24:00+07:00'
+                version: 3.0.0
             schema:
+              $ref: '#/components/schemas/JsonNode'
               additionalProperties: false
-              maxItems: 50
-              type: string
         required: true
       responses:
         '200':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DemandAndCapacityNotificationSamm'
-                additionalProperties: false
           description: Ok
         '400':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DemandAndCapacityNotificationSamm'
-                additionalProperties: false
           description: Bad Request
         '500':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/DemandAndCapacityNotificationSamm'
-                additionalProperties: false
           description: Internal Server Error
-      summary: This endpoint receives the DemandAndCapacityNotification 2.0.0 requests
+      summary: 'This endpoint receives the DemandAndCapacityNotification 2.0.0 requests.
+        This endpoint is meant to be accessed by partners via EDC only. '
       tags:
       - demand-and-capacity-notification-request-api-controller
   /demand-and-capacity-notification/{id}:
@@ -1935,7 +2033,8 @@ paths:
         by its bpns.
       operationId: getAllDemandsForPartner
       parameters:
-      - in: query
+      - description: encoded in base64
+        in: query
         name: ownMaterialNumber
         required: true
         schema:
@@ -1975,7 +2074,8 @@ paths:
       description: Refreshes all reported demands from the demand request API.
       operationId: refreshReportedProductions_1
       parameters:
-      - in: query
+      - description: encoded in base64
+        in: query
         name: ownMaterialNumber
         required: true
         schema:
@@ -2258,7 +2358,8 @@ paths:
           additionalProperties: false
           maxItems: 50
           type: string
-      - in: query
+      - description: encoded in base64
+        in: query
         name: own-materialnumber
         required: true
         schema:
@@ -2277,6 +2378,7 @@ paths:
           - DEMAND_SUBMODEL
           - DELIVERY_SUBMODEL
           - NOTIFICATION
+          - DAYS_OF_SUPPLY
           - PART_TYPE_INFORMATION_SUBMODEL
           maxItems: 50
           type: string
@@ -2364,27 +2466,13 @@ paths:
                 additionalProperties: false
           description: Ok
         '400':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ItemStockSamm'
-                additionalProperties: false
           description: Bad Request
         '500':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ItemStockSamm'
-                additionalProperties: false
           description: Internal Server Error
         '501':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ItemStockSamm'
-                additionalProperties: false
           description: Unsupported representation
-      summary: This endpoint receives the ItemStock Submodel 2.0.0 requests
+      summary: 'This endpoint receives the ItemStock Submodel 2.0.0 requests. This
+        endpoint is meant to be accessed by partners via EDC only. '
       tags:
       - item-stock-request-api-controller
   /material-demand/request/{materialnumbercx}/{representation}:
@@ -2421,27 +2509,13 @@ paths:
                 additionalProperties: false
           description: Ok
         '400':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ShortTermMaterialDemand'
-                additionalProperties: false
           description: Bad Request
         '500':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ShortTermMaterialDemand'
-                additionalProperties: false
           description: Internal Server Error
         '501':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ShortTermMaterialDemand'
-                additionalProperties: false
           description: Unsupported representation
-      summary: This endpoint receives the ShortTermMaterialDemand Submodel 1.0.0 requests
+      summary: 'This endpoint receives the ShortTermMaterialDemand Submodel 1.0.0
+        requests. This endpoint is meant to be accessed by partners via EDC only. '
       tags:
       - demand-request-api-controller
   /materialpartnerrelations:
@@ -2452,8 +2526,7 @@ paths:
       operationId: createMaterialPartnerRelation
       parameters:
       - description: The Material Number that is used in your own company to identify
-          the Material.
-        example: MNR-7307-AU340474.002
+          the Material, encoded in base64
         in: query
         name: ownMaterialNumber
         required: true
@@ -2471,8 +2544,7 @@ paths:
           maxItems: 50
           type: string
       - description: The Material Number that this Partner is using in his own company
-          to identify the Material.
-        example: MNR-8101-ID146955.001
+          to identify the Material, encoded in base64
         in: query
         name: partnerMaterialNumber
         required: true
@@ -2554,8 +2626,7 @@ paths:
       operationId: updateMaterialPartnerRelation
       parameters:
       - description: The Material Number that is used in your own company to identify
-          the Material.
-        example: MNR-7307-AU340474.002
+          the Material, encoded in base64
         in: query
         name: ownMaterialNumber
         required: true
@@ -2573,8 +2644,7 @@ paths:
           maxItems: 50
           type: string
       - description: The Material Number that this Partner is using in his own company
-          to identify the Material.
-        example: MNR-8101-ID146955.001
+          to identify the Material, encoded in base64
         in: query
         name: partnerMaterialNumber
         required: false
@@ -2655,8 +2725,7 @@ paths:
       operationId: getMaterial
       parameters:
       - description: The Material Number that is used in your own company to identify
-          the Material.
-        example: MNR-7307-AU340474.002
+          the Material, encoded in base64
         in: query
         name: ownMaterialNumber
         required: true
@@ -2673,18 +2742,8 @@ paths:
                 additionalProperties: false
           description: Returns the requested Material.
         '400':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/MaterialEntityDto'
-                additionalProperties: false
           description: Invalid parameter
         '404':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/MaterialEntityDto'
-                additionalProperties: false
           description: Requested Material was not found.
       tags:
       - material-controller
@@ -2812,25 +2871,10 @@ paths:
                 additionalProperties: false
           description: Found Partner, returning it in response body.
         '400':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/PartnerDto'
-                additionalProperties: false
           description: Invalid parameter.
         '404':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/PartnerDto'
-                additionalProperties: false
           description: Requested Partner not found.
         '500':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/PartnerDto'
-                additionalProperties: false
           description: Internal Server Error.
       tags:
       - partner-controller
@@ -3040,9 +3084,11 @@ paths:
       - partner-controller
   /parttypeinformation/{materialnumber}/{representation}:
     get:
-      description: Endpoint that delivers PartTypeInformation of own products to customer
-        partners. 'materialnumber' must be set to the ownMaterialNumber of the party,
-        that receives the request
+      description: 'Endpoint that delivers PartTypeInformation of own products to
+        customer partners. ''materialnumber'' must be set to the ownMaterialNumber
+        of the party, that receives the request. Please note that the SAMMs delivered
+        by this endpoint don''t provide partClassification and partSitesInformationAsPlanned
+        data. This endpoint is meant to be accessed by partners via EDC only. '
       operationId: getMapping
       parameters:
       - in: header
@@ -3074,36 +3120,16 @@ paths:
           content:
             '*/*':
               schema:
+                $ref: '#/components/schemas/PartTypeInformationSAMM'
                 additionalProperties: false
-                type: object
           description: Ok
         '400':
-          content:
-            '*/*':
-              schema:
-                additionalProperties: false
-                type: object
           description: 'Invalid request parameters. '
         '401':
-          content:
-            '*/*':
-              schema:
-                additionalProperties: false
-                type: object
           description: 'Access forbidden. '
         '404':
-          content:
-            '*/*':
-              schema:
-                additionalProperties: false
-                type: object
           description: 'Product not found for given parameters. '
         '501':
-          content:
-            '*/*':
-              schema:
-                additionalProperties: false
-                type: object
           description: 'Unsupported representation requested. '
       tags:
       - part-type-information-controller
@@ -3141,27 +3167,13 @@ paths:
                 additionalProperties: false
           description: Ok
         '400':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/PlannedProductionOutput'
-                additionalProperties: false
           description: Bad Request
         '500':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/PlannedProductionOutput'
-                additionalProperties: false
           description: Internal Server Error
         '501':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/PlannedProductionOutput'
-                additionalProperties: false
           description: Unsupported representation
-      summary: This endpoint receives the PlannedProduction Submodel 2.0.0 requests
+      summary: 'This endpoint receives the PlannedProduction Submodel 2.0.0 requests.
+        This endpoint is meant to be accessed by partners via EDC only. '
       tags:
       - production-request-api-controller
   /production:
@@ -3170,7 +3182,8 @@ paths:
         the production site can be filtered by its bpns.
       operationId: getAllProductions
       parameters:
-      - in: query
+      - description: encoded in base64
+        in: query
         name: ownMaterialNumber
         required: true
         schema:
@@ -3216,25 +3229,10 @@ paths:
                 additionalProperties: false
           description: Planned Production was created.
         '400':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ProductionDto'
-                additionalProperties: false
           description: Malformed or invalid request body.
         '409':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ProductionDto'
-                additionalProperties: false
           description: Planned Production already exists.
         '500':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ProductionDto'
-                additionalProperties: false
           description: Internal Server Error.
       summary: Creates a new planned production
       tags:
@@ -3257,25 +3255,10 @@ paths:
                 additionalProperties: false
           description: Planned Productions was updated.
         '400':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ProductionDto'
-                additionalProperties: false
           description: Malformed or invalid request body.
         '404':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ProductionDto'
-                additionalProperties: false
           description: Planned Production does not exist.
         '500':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ProductionDto'
-                additionalProperties: false
           description: Internal Server Error.
       summary: Updates a planned production by its UUID
       tags:
@@ -3305,34 +3288,10 @@ paths:
                 type: array
           description: Planned Productions were created.
         '400':
-          content:
-            '*/*':
-              schema:
-                additionalProperties: false
-                items:
-                  $ref: '#/components/schemas/ProductionDto'
-                maxItems: 50
-                type: array
           description: Malformed or invalid request body.
         '409':
-          content:
-            '*/*':
-              schema:
-                additionalProperties: false
-                items:
-                  $ref: '#/components/schemas/ProductionDto'
-                maxItems: 50
-                type: array
           description: Planned Productions already exist.
         '500':
-          content:
-            '*/*':
-              schema:
-                additionalProperties: false
-                items:
-                  $ref: '#/components/schemas/ProductionDto'
-                maxItems: 50
-                type: array
           description: Internal Server Error.
       summary: Creates a range of planned productions
       tags:
@@ -3344,7 +3303,8 @@ paths:
         filtered by its bpns.
       operationId: getAllProductionsForPartner
       parameters:
-      - in: query
+      - description: encoded in base64
+        in: query
         name: ownMaterialNumber
         required: true
         schema:
@@ -3385,7 +3345,8 @@ paths:
         API.
       operationId: refreshReportedProductions
       parameters:
-      - in: query
+      - description: encoded in base64
+        in: query
         name: ownMaterialNumber
         required: true
         schema:
@@ -3435,7 +3396,8 @@ paths:
       description: Returns a list of all Partners that are ordering the given material
       operationId: getCustomerPartnersOrderingMaterial
       parameters:
-      - in: query
+      - description: encoded in base64
+        in: query
         name: ownMaterialNumber
         required: true
         schema:
@@ -3454,14 +3416,6 @@ paths:
                 type: array
           description: OK
         '400':
-          content:
-            '*/*':
-              schema:
-                additionalProperties: false
-                items:
-                  $ref: '#/components/schemas/PartnerDto'
-                maxItems: 50
-                type: array
           description: Invalid parameter
       tags:
       - stock-view-controller
@@ -3501,25 +3455,10 @@ paths:
                 additionalProperties: false
           description: Material Stock was created.
         '400':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/MaterialStockDto'
-                additionalProperties: false
           description: Malformed or invalid request body.
         '409':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/MaterialStockDto'
-                additionalProperties: false
           description: Material Stock does already exist.
         '500':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/MaterialStockDto'
-                additionalProperties: false
           description: Internal Server Error.
       tags:
       - stock-view-controller
@@ -3542,18 +3481,30 @@ paths:
                 additionalProperties: false
           description: Material Stock was updated.
         '400':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/MaterialStockDto'
-                additionalProperties: false
           description: Malformed request body.
         '500':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/MaterialStockDto'
-                additionalProperties: false
+          description: Internal Server Error.
+      tags:
+      - stock-view-controller
+  /stockView/material-stocks/{id}:
+    delete:
+      description: Deletes an existing material-stock
+      operationId: deleteMaterialStock
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          additionalProperties: false
+          format: uuid
+          maxItems: 50
+          type: string
+      responses:
+        '204':
+          description: Material Stock was deleted.
+        '404':
+          description: Material Stock not found.
+        '500':
           description: Internal Server Error.
       tags:
       - stock-view-controller
@@ -3563,7 +3514,8 @@ paths:
         are usingfor the material given in the request parameter.
       operationId: getMaterialNumbers
       parameters:
-      - in: query
+      - description: encoded in base64
+        in: query
         name: ownMaterialNumber
         required: true
         schema:
@@ -3582,13 +3534,6 @@ paths:
                     BPNL4444444444XX: MNR-7307-AU340474.002
           description: OK
         '400':
-          content:
-            '*/*':
-              schema:
-                additionalProperties:
-                  maxItems: 50
-                  type: string
-                type: object
           description: Invalid parameter
       tags:
       - stock-view-controller
@@ -3596,6 +3541,13 @@ paths:
     get:
       description: Returns a list of all materials (excluding products)
       operationId: getMaterials
+      parameters:
+      - in: query
+        name: includeDaysOfSupply
+        required: false
+        schema:
+          additionalProperties: false
+          type: boolean
       responses:
         '200':
           content:
@@ -3645,25 +3597,10 @@ paths:
                 additionalProperties: false
           description: Product Stock was created.
         '400':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ProductStockDto'
-                additionalProperties: false
           description: Malformed or invalid request body.
         '409':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ProductStockDto'
-                additionalProperties: false
           description: Product Stock does already exist.
         '500':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ProductStockDto'
-                additionalProperties: false
           description: Internal Server Error.
       tags:
       - stock-view-controller
@@ -3686,18 +3623,30 @@ paths:
                 additionalProperties: false
           description: Product Stock was updated.
         '400':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ProductStockDto'
-                additionalProperties: false
           description: Malformed request body.
         '500':
-          content:
-            '*/*':
-              schema:
-                $ref: '#/components/schemas/ProductStockDto'
-                additionalProperties: false
+          description: Internal Server Error.
+      tags:
+      - stock-view-controller
+  /stockView/product-stocks/{id}:
+    delete:
+      description: Deletes an existing material-stock
+      operationId: deleteProductStock
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          additionalProperties: false
+          format: uuid
+          maxItems: 50
+          type: string
+      responses:
+        '204':
+          description: Product Stock was deleted.
+        '404':
+          description: Product Stock not found.
+        '500':
           description: Internal Server Error.
       tags:
       - stock-view-controller
@@ -3705,6 +3654,13 @@ paths:
     get:
       description: Returns a list of all products (excluding materials)
       operationId: getProducts
+      parameters:
+      - in: query
+        name: includeDaysOfSupply
+        required: false
+        schema:
+          additionalProperties: false
+          type: boolean
       responses:
         '200':
           content:
@@ -3724,7 +3680,8 @@ paths:
         he has at his site. Only stocks for the given material number are returned.
       operationId: getSupplierMaterialStocks
       parameters:
-      - in: query
+      - description: encoded in base64
+        in: query
         name: ownMaterialNumber
         required: true
         schema:
@@ -3743,14 +3700,6 @@ paths:
                 type: array
           description: OK
         '400':
-          content:
-            '*/*':
-              schema:
-                additionalProperties: false
-                items:
-                  $ref: '#/components/schemas/ReportedMaterialStockDto'
-                maxItems: 50
-                type: array
           description: Invalid parameter
       tags:
       - stock-view-controller
@@ -3760,7 +3709,8 @@ paths:
         he has at his site. Only stocks for the given material number are returned.
       operationId: getCustomerProductStocks
       parameters:
-      - in: query
+      - description: encoded in base64
+        in: query
         name: ownMaterialNumber
         required: true
         schema:
@@ -3779,14 +3729,6 @@ paths:
                 type: array
           description: OK
         '400':
-          content:
-            '*/*':
-              schema:
-                additionalProperties: false
-                items:
-                  $ref: '#/components/schemas/ReportedProductStockDto'
-                maxItems: 50
-                type: array
           description: Invalid parameter
       tags:
       - stock-view-controller
@@ -3795,7 +3737,8 @@ paths:
       description: Returns a list of all Partners that are supplying the given material
       operationId: getSupplierPartnersSupplyingMaterial
       parameters:
-      - in: query
+      - description: encoded in base64
+        in: query
         name: ownMaterialNumber
         required: true
         schema:
@@ -3814,14 +3757,6 @@ paths:
                 type: array
           description: OK
         '400':
-          content:
-            '*/*':
-              schema:
-                additionalProperties: false
-                items:
-                  $ref: '#/components/schemas/PartnerDto'
-                maxItems: 50
-                type: array
           description: Invalid parameter
       tags:
       - stock-view-controller
@@ -3836,7 +3771,8 @@ paths:
         endpoint.
       operationId: triggerReportedMaterialStockUpdateForMaterialNumber
       parameters:
-      - in: query
+      - description: encoded in base64
+        in: query
         name: ownMaterialNumber
         required: true
         schema:
@@ -3855,14 +3791,6 @@ paths:
                 type: array
           description: OK
         '400':
-          content:
-            '*/*':
-              schema:
-                additionalProperties: false
-                items:
-                  $ref: '#/components/schemas/PartnerDto'
-                maxItems: 50
-                type: array
           description: Invalid parameter
       tags:
       - stock-view-controller
@@ -3877,7 +3805,8 @@ paths:
         endpoint.
       operationId: triggerReportedProductStockUpdateForMaterialNumber
       parameters:
-      - in: query
+      - description: encoded in base64
+        in: query
         name: ownMaterialNumber
         required: true
         schema:
@@ -3896,19 +3825,8 @@ paths:
                 type: array
           description: OK
         '400':
-          content:
-            '*/*':
-              schema:
-                additionalProperties: false
-                items:
-                  $ref: '#/components/schemas/PartnerDto'
-                maxItems: 50
-                type: array
           description: Invalid parameter
       tags:
       - stock-view-controller
 security:
 - X-API-KEY: []
-servers:
-- description: Generated server url
-  url: http://localhost:8081/catena

--- a/frontend/DOCKER_NOTICE.md
+++ b/frontend/DOCKER_NOTICE.md
@@ -14,6 +14,7 @@ Eclipse Tractus-X product(s) installed within the image:
 **Used Base Image [Frontend]**
 `nginxinc/nginx-unprivileged:alpine`
 
+- [Dockerfile (alpine)](https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/Dockerfile-alpine.template)
 - DockerHub: https://hub.docker.com/r/nginxinc/nginx-unprivileged
 - GitHub project: https://github.com/nginxinc/docker-nginx-unprivileged
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
     "name": "puris-frontend",
     "description": "Puris frontend",
     "license": "Apache-2.0",
-    "version": "2.1.0",
+    "version": "3.0.0",
     "type": "module",
     "scripts": {
         "dev": "vite --host --mode customer --port 5173",


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

This PR is meant to cover last changes needed for R25.03 as noticed during Quality Gate Check #785.

Changes:

- wrote changelog for app version 3.0.0
- set versions in frontend, backend, charts and associated documentation
- exported openApi updates for [TRG 1.08](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-08)
- updated documentation for administration and standard values in chart
- updated docker_notice files to include more information as mentioned in [TRG 4.06](https://eclipse-tractusx.github.io/docs/release/trg-4/trg-4-06)
- CI
  - bump standard versions in helm-test
  - fix trivy to only run on eclipse-tractusx/puris

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
