### PR TITLE
fix: mandatory indicator for estimated completion time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,11 @@ Fixes
 * Change log message for already existing edc assets on startup ([547](https://github.com/eclipse-tractusx/puris/pull/547))
 * Don't return own partner entity from partner/all endpoint ([#563](https://github.com/eclipse-tractusx/puris/pull/563))
 * Fix material number issues and partner/all endpoint in integration test suite ([#689](https://github.com/eclipse-tractusx/puris/pull/689))
-
 * improve demand and capacity notification (accept material number correctly, added test, role specific differentiation) ([#576](https://github.com/eclipse-tractusx/puris/pull/576))
+* Can't create select a partner when creating deliveries ([#800](https://github.com/eclipse-tractusx/puris/pull/800))
+* Missing indicators for mandatory fields ([#800](https://github.com/eclipse-tractusx/puris/pull/800))
+* Update "Supplier Site" label on add demand dialog to "Expected Supplier Site" ([#800](https://github.com/eclipse-tractusx/puris/pull/800))
+* fixed translation of weekdays to english language ([#800](https://github.com/eclipse-tractusx/puris/pull/800))
 
 UI enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Fixes
 * Missing indicators for mandatory fields ([#800](https://github.com/eclipse-tractusx/puris/pull/800))
 * Update "Supplier Site" label on add demand dialog to "Expected Supplier Site" ([#800](https://github.com/eclipse-tractusx/puris/pull/800))
 * fixed translation of weekdays to english language ([#800](https://github.com/eclipse-tractusx/puris/pull/800))
+* fixed missing mandatory indicator for Estimated Completion Time ([#801](https://github.com/eclipse-tractusx/puris/pull/801))
 
 UI enhancements
 

--- a/frontend/src/features/material-details/components/PlannedProductionModal.tsx
+++ b/frontend/src/features/material-details/components/PlannedProductionModal.tsx
@@ -210,7 +210,7 @@ export const PlannedProductionModal = ({ open, mode, onClose, onSave, production
                                 </Grid>
                                 <Grid item xs={6} display="flex" alignItems="end">
                                     <DateTime
-                                        label="Estimated Completion Time"
+                                        label="Estimated Completion Time*"
                                         placeholder="Pick Production Date"
                                         locale="de"
                                         error={formError}


### PR DESCRIPTION
## Description

- added missing mandatory indicator on Estimated Completion Time

resolves #799

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
