### PR TITLE
fix(helm): passthrough jpa.hibernate.ddl-auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ The **need for configuration updates** is **marked bold**.
 
 Fixes
 
-* Expect dtr base url to include `api/v3` in asset ([#844](https://github.com/eclipse-tractusx/puris/pull/824)) (**updated default values and asset definition**)
+* Expect dtr base url to include `api/v3` in asset ([#824](https://github.com/eclipse-tractusx/puris/pull/824)) (**updated default values and asset definition**)
+* Creating own partner entity does not run into ([#838](https://github.com/eclipse-tractusx/puris/pull/838))
 
 ### Removed
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/DataInjectionCommandLineRunner.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/DataInjectionCommandLineRunner.java
@@ -133,9 +133,10 @@ public class DataInjectionCommandLineRunner implements CommandLineRunner {
             );
         }
         mySelf = partnerService.create(mySelf);
-        log.info("Successfully created own Partner Entity: " + (partnerService.findByBpnl(mySelf.getBpnl()) != null));
+        log.info("Successfully created own Partner Entity: " + (mySelf != null));
+        mySelf = partnerService.findByBpnl(variablesService.getOwnBpnl());
         if (mySelf != null) {
-            log.info(mySelf.toString());
+            log.info("Following partner has been configured for yourself (and not been changed): " + mySelf.toString());
         }
     }
 

--- a/charts/puris/README.md
+++ b/charts/puris/README.md
@@ -52,7 +52,7 @@ dependencies:
 | backend.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey | string | `"kubernetes.io/hostname"` | Topology key of the Kubernetes cluster |
 | backend.autoscaling.enabled | bool | `false` | Enable or disable the autoscaling of pods |
 | backend.env | object | `{}` | Extra environment variables that will be passed onto the backend deployment pods |
-| backend.image.pullPolicy | string | `"Always"` | THe policy for the image pull process |
+| backend.image.pullPolicy | string | `"IfNotPresent"` | THe policy for the image pull process |
 | backend.image.repository | string | `"tractusx/app-puris-backend"` | Repository of the docker image |
 | backend.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | backend.imagePullSecrets | list | `[]` | List of used secrets |
@@ -108,7 +108,7 @@ dependencies:
 | backend.puris.frameworkagreement.version | string | `"1.0"` | The version of the framework agreement, NEEDS TO BE PUT AS "STRING"! |
 | backend.puris.generatematerialcatenaxid | bool | `true` | Flag that decides whether the auto-generation feature of the puris backend is enabled. Since all Material entities are required to have a CatenaX-Id, you must enter any pre-existing CatenaX-Id via the materials-API of the backend, when you are inserting a new Material entity to the backend's database. If a CatenaX-Id was not assigned to your Material so far, then this feature can auto-generate one randomly. In a real-world-scenario, you must then use this randomly generated CatenaX-Id for the lifetime of that Material entity. |
 | backend.puris.itemstocksubmodel.apiassetid | string | `"itemstocksubmodel-api-asset"` | Asset ID for ItemStockSubmodel API |
-| backend.puris.jpa.hibernate.ddl-auto | string | `"create"` | Initialises SQL database with Hibernate property "create" to allow Hibernate to first drop all tables and then create new ones |
+| backend.puris.jpa.hibernate.ddl-auto | string | `"update"` | Initialises SQL database with Hibernate property "update" to allow Hibernate to add things to schema so that it doesn't drop tables |
 | backend.puris.jpa.properties.hibernate.enable_lazy_load_no_trans | bool | `true` | Enables "Lazy load no trans" property to fetch of each lazy entity to open a temporary session and run inside a separate transaction |
 | backend.puris.notification.apiassetid | string | `"notification-api-asset"` | Asset ID for Notification API |
 | backend.puris.own.bpna | string | `"BPNA4444444444ZZ"` | Own BPNA of the EDC |
@@ -155,7 +155,7 @@ dependencies:
 | frontend.autoscaling.minReplicas | int | `1` | Number of minimum replica pods for autoscaling |
 | frontend.autoscaling.targetCPUUtilizationPercentage | int | `80` | Value of CPU usage in percentage for autoscaling decisions |
 | frontend.env | object | `{}` | Extra environment variables that will be passed onto the frontend deployment pods |
-| frontend.image.pullPolicy | string | `"Always"` | THe policy for the image pull process |
+| frontend.image.pullPolicy | string | `"IfNotPresent"` | THe policy for the image pull process |
 | frontend.image.repository | string | `"tractusx/app-puris-frontend"` | Repository of the docker image |
 | frontend.image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | frontend.imagePullSecrets | list | `[]` | List of used secrets |

--- a/charts/puris/templates/backend-deployment.yaml
+++ b/charts/puris/templates/backend-deployment.yaml
@@ -114,7 +114,7 @@ spec:
               value: "{{ .Values.backend.puris.own.streetnumber }}"
             - name: OWN_ZIPCODEANDCITY
               value: "{{ .Values.backend.puris.own.zipcodeandcity }}"
-            - name: JPA_HIBERNATE_DDL-AUTO
+            - name: SPRING_JPA_HIBERNATE_DDL-AUTO
               value: {{ index .Values.backend "puris" "jpa" "hibernate" "ddl-auto" }} #Need to do workaround because of '-' in ddl-auto
             - name: JPA_PROPERTIES_HIBERNATE_ENABLE.LAZY.LOAD.NO.TRANS
               value: "{{ .Values.backend.puris.jpa.properties.hibernate.enable_lazy_load_no_trans }}"

--- a/charts/puris/values.yaml
+++ b/charts/puris/values.yaml
@@ -32,7 +32,7 @@ frontend:
     # -- Repository of the docker image
     repository: tractusx/app-puris-frontend
     # -- THe policy for the image pull process
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion.
     tag: ""
 
@@ -232,7 +232,7 @@ backend:
     # -- Repository of the docker image
     repository: tractusx/app-puris-backend
     # -- THe policy for the image pull process
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion.
     tag: ""
 
@@ -427,8 +427,8 @@ backend:
       role:
     jpa:
       hibernate:
-        # -- Initialises SQL database with Hibernate property "create" to allow Hibernate to first drop all tables and then create new ones
-        ddl-auto: create
+        # -- Initialises SQL database with Hibernate property "update" to allow Hibernate to add things to schema so that it doesn't drop tables
+        ddl-auto: update
       properties:
         hibernate:
           # -- Enables "Lazy load no trans" property to fetch of each lazy entity to open a temporary session and run inside a separate transaction


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

The ddl-auto setting has not been passed through correctly. In combination with the default value a helm upgrade or a pod restart wiped all data in the database.

Changes:

- passthrough full property (`spring.jpa.hibernate.ddl-auto` - spring has been missing)
- update ddl-auto standard value
- updated changelog
- updated creation of own partner entity which caused in an exception when partner with own bpnl already existed. 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).

> Note: helm chart has not been bumped because a minor change has been entered but not been released.
