### PR TITLE
Fix: expose and contract submodels following CX-0002

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,12 @@ Fixes
 
 * Expect dtr base url to include `api/v3` in asset ([#824](https://github.com/eclipse-tractusx/puris/pull/824)) (**updated default values and asset definition**)
 * Creating own partner entity does not run into exception ([#838](https://github.com/eclipse-tractusx/puris/pull/838))
-* Submodels are exposed via `submodel/$value` and not `$value` including the update of SubmodelDescriptors
-* use own bpnl as default tenant (`Edc-Bpn`) when updating own dtr and only use partner BPNL in externalSubjectId
+* Submodels are exposed via `submodel/$value` and not `$value` including the update of
+  SubmodelDescriptors ([#849](https://github.com/eclipse-tractusx/puris/pull/849))
+* use own bpnl as default tenant (`Edc-Bpn`) when updating own dtr and only use partner BPNL in
+  externalSubjectId ([#849](https://github.com/eclipse-tractusx/puris/pull/849))
+* use `assetId` instead of `semanticId` and `dct:type=submodel` during catalog request for submodel
+  assets ([#849](https://github.com/eclipse-tractusx/puris/pull/849))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ The **need for configuration updates** is **marked bold**.
 Fixes
 
 * Expect dtr base url to include `api/v3` in asset ([#824](https://github.com/eclipse-tractusx/puris/pull/824)) (**updated default values and asset definition**)
-* Creating own partner entity does not run into ([#838](https://github.com/eclipse-tractusx/puris/pull/838))
+* Creating own partner entity does not run into exception ([#838](https://github.com/eclipse-tractusx/puris/pull/838))
+* Submodels are exposed via `submodel/$value` and not `$value` including the update of SubmodelDescriptors
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Fixes
 * Expect dtr base url to include `api/v3` in asset ([#824](https://github.com/eclipse-tractusx/puris/pull/824)) (**updated default values and asset definition**)
 * Creating own partner entity does not run into exception ([#838](https://github.com/eclipse-tractusx/puris/pull/838))
 * Submodels are exposed via `submodel/$value` and not `$value` including the update of SubmodelDescriptors
+* use own bpnl as default tenant (`Edc-Bpn`) when updating own dtr and only use partner BPNL in externalSubjectId
 
 ### Removed
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/ddtr/logic/DtrAdapterService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/ddtr/logic/DtrAdapterService.java
@@ -78,6 +78,7 @@ public class DtrAdapterService {
             .post(body)
             .url(urlBuilder.build())
             .header("Content-Type", "application/json")
+            .header("Edc-Bpn", variablesService.getOwnBpnl())
             .build();
         return CLIENT.newCall(request).execute();
     }
@@ -92,6 +93,7 @@ public class DtrAdapterService {
             .put(body)
             .url(urlBuilder.build())
             .header("Content-Type", "application/json")
+            .header("Edc-Bpn", variablesService.getOwnBpnl())
             .build();
         return CLIENT.newCall(request).execute();
     }
@@ -108,6 +110,10 @@ public class DtrAdapterService {
         }
         var requestBuilder = new Request.Builder().url(urlBuilder.build());
         if (headerData != null) {
+            // ensure own tenant is set
+            if (!headerData.containsKey("Edc-Bpn")) {
+                headerData.put("Edc-Bpn", variablesService.getOwnBpnl());
+            }
             for (var header : headerData.entrySet()) {
                 requestBuilder.header(header.getKey(), header.getValue());
             }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/ddtr/logic/util/DtrRequestBodyBuilder.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/ddtr/logic/util/DtrRequestBodyBuilder.java
@@ -175,7 +175,6 @@ public class DtrRequestBodyBuilder {
         for (var refObject : refObjects) {
             keysArray.add(refObject);
         }
-        keysArray.add(createOwnReferenceObject());
         return idObject;
     }
 
@@ -200,10 +199,6 @@ public class DtrRequestBodyBuilder {
         refObject.put("type", "GlobalReference");
         refObject.put("value", bpnl);
         return refObject;
-    }
-
-    private ObjectNode createOwnReferenceObject() {
-        return createReferenceObject(variablesService.getOwnBpnl());
     }
 
     private JsonNode createSubmodelObject(String semanticId, String href, String assetId) {

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/ddtr/logic/util/DtrRequestBodyBuilder.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/ddtr/logic/util/DtrRequestBodyBuilder.java
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2024 Volkswagen AG
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -95,11 +97,15 @@ public class DtrRequestBodyBuilder {
         href = href.endsWith("/") ? href : href + "/";
         href += materialPartnerRelation.getPartnerCXNumber() + "/";
 
-        submodelDescriptorsArray.add(createSubmodelObject(AssetType.ITEM_STOCK_SUBMODEL.URN_SEMANTIC_ID, href + DirectionCharacteristic.INBOUND + "/", variablesService.getItemStockSubmodelApiAssetId()));
+        // all api definitions follow the same syntax, but some need to be direction specific
+        String directionHref = href + DirectionCharacteristic.INBOUND + "/submodel";
+        href += "submodel";
+
+        submodelDescriptorsArray.add(createSubmodelObject(AssetType.ITEM_STOCK_SUBMODEL.URN_SEMANTIC_ID, directionHref, variablesService.getItemStockSubmodelApiAssetId()));
         submodelDescriptorsArray.add(createSubmodelObject(AssetType.DEMAND_SUBMODEL.URN_SEMANTIC_ID, href, variablesService.getDemandSubmodelApiAssetId()));
         submodelDescriptorsArray.add(createSubmodelObject(AssetType.DELIVERY_SUBMODEL.URN_SEMANTIC_ID, href, variablesService.getDeliverySubmodelApiAssetId()));
-        submodelDescriptorsArray.add(createSubmodelObject(AssetType.DAYS_OF_SUPPLY.URN_SEMANTIC_ID, href  + DirectionCharacteristic.INBOUND + "/", variablesService.getDaysOfSupplySubmodelApiAssetId()));
-        log.debug("Created body for material " + material.getOwnMaterialNumber() + "\n" + body.toPrettyString());
+        submodelDescriptorsArray.add(createSubmodelObject(AssetType.DAYS_OF_SUPPLY.URN_SEMANTIC_ID, directionHref, variablesService.getDaysOfSupplySubmodelApiAssetId()));
+        log.debug("Created body for material {}\n{}", material.getOwnMaterialNumber(), body.toPrettyString());
         return body;
     }
 
@@ -131,7 +137,7 @@ public class DtrRequestBodyBuilder {
                 specificAssetIdsArray.add(customerPartIdObject);
             }
         } else {
-            log.error("Could not create request body: Missing product flag in material " + material.getOwnMaterialNumber());
+            log.error("Could not create request body: Missing product flag in material {}", material.getOwnMaterialNumber());
             return null;
         }
 
@@ -141,14 +147,18 @@ public class DtrRequestBodyBuilder {
         String href = variablesService.getEdcDataplanePublicUrl();
         href = href.endsWith("/") ? href : href + "/";
         href += material.getMaterialNumberCx() + "/";
-        
-        submodelDescriptorsArray.add(createSubmodelObject(AssetType.ITEM_STOCK_SUBMODEL.URN_SEMANTIC_ID, href + DirectionCharacteristic.OUTBOUND + "/", variablesService.getItemStockSubmodelApiAssetId()));
+
+        // all api definitions follow the same syntax, but some need to be direction specific
+        String directionHref = href + DirectionCharacteristic.OUTBOUND + "/submodel";
+        href += "submodel";
+
+        submodelDescriptorsArray.add(createSubmodelObject(AssetType.ITEM_STOCK_SUBMODEL.URN_SEMANTIC_ID, directionHref, variablesService.getItemStockSubmodelApiAssetId()));
         submodelDescriptorsArray.add(createSubmodelObject(AssetType.PRODUCTION_SUBMODEL.URN_SEMANTIC_ID, href, variablesService.getProductionSubmodelApiAssetId()));
         submodelDescriptorsArray.add(createSubmodelObject(AssetType.DELIVERY_SUBMODEL.URN_SEMANTIC_ID, href, variablesService.getDeliverySubmodelApiAssetId()));
-        submodelDescriptorsArray.add(createSubmodelObject(AssetType.DAYS_OF_SUPPLY.URN_SEMANTIC_ID, href  + DirectionCharacteristic.OUTBOUND + "/", variablesService.getDaysOfSupplySubmodelApiAssetId()));
+        submodelDescriptorsArray.add(createSubmodelObject(AssetType.DAYS_OF_SUPPLY.URN_SEMANTIC_ID, directionHref, variablesService.getDaysOfSupplySubmodelApiAssetId()));
         submodelDescriptorsArray.add(createPartTypeSubmodelObject(material.getOwnMaterialNumber()));
 
-        log.debug("Created body for product " + material.getOwnMaterialNumber() + "\n" + body.toPrettyString());
+        log.debug("Created body for product {}\n{}", material.getOwnMaterialNumber(), body.toPrettyString());
         return body;
     }
 
@@ -239,6 +249,7 @@ public class DtrRequestBodyBuilder {
         String href = variablesService.getEdcDataplanePublicUrl();
         href = href.endsWith("/") ? href : href + "/";
         href += Base64.getEncoder().encodeToString(materialId.getBytes(StandardCharsets.UTF_8));
+        href += "/submodel";
         return createSubmodelObject(AssetType.PART_TYPE_INFORMATION_SUBMODEL.URN_SEMANTIC_ID, href, variablesService.getPartTypeSubmodelApiAssetId());
     }
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/domain/model/AssetType.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/domain/model/AssetType.java
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2024 Volkswagen AG
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -33,12 +35,29 @@ public enum AssetType {
     public final String URN_SEMANTIC_ID;
     public final String REPRESENTATION;
     public final String ERP_KEYWORD;
-    public final String ERP_SAMMVERSION;
+    public final String ERP_SAMM_VERSION;
 
-    AssetType(String URN_SEMANTIC_ID, String REPRESENTATION, String ERP_KEYWORD, String ERP_SAMMVERSION) {
+    public static AssetType fromUrn(String urnSemanticId) {
+        return switch (urnSemanticId) {
+            case "urn:samm:io.catenax.item_stock:2.0.0#ItemStock" -> AssetType.ITEM_STOCK_SUBMODEL;
+            case "urn:samm:io.catenax.planned_production_output:2.0.0#PlannedProductionOutput" ->
+                AssetType.PRODUCTION_SUBMODEL;
+            case "urn:samm:io.catenax.short_term_material_demand:1.0.0#ShortTermMaterialDemand" ->
+                AssetType.DEMAND_SUBMODEL;
+            case "urn:samm:io.catenax.delivery_information:2.0.0#DeliveryInformation" -> AssetType.DELIVERY_SUBMODEL;
+            case "urn:samm:io.catenax.demand_and_capacity_notification:2.0.0#DemandAndCapacityNotification" ->
+                AssetType.NOTIFICATION;
+            case "urn:samm:io.catenax.days_of_supply:2.0.0#DaysOfSupply" -> AssetType.DAYS_OF_SUPPLY;
+            case "urn:samm:io.catenax.part_type_information:1.0.0#PartTypeInformation" ->
+                AssetType.PART_TYPE_INFORMATION_SUBMODEL;
+            default -> AssetType.DTR; // Handle unknown URN by returning a default enum value
+        };
+    }
+
+    AssetType(String URN_SEMANTIC_ID, String REPRESENTATION, String ERP_KEYWORD, String ERP_SAMM_VERSION) {
         this.URN_SEMANTIC_ID = URN_SEMANTIC_ID;
         this.REPRESENTATION = REPRESENTATION;
         this.ERP_KEYWORD = ERP_KEYWORD;
-        this.ERP_SAMMVERSION = ERP_SAMMVERSION;
+        this.ERP_SAMM_VERSION = ERP_SAMM_VERSION;
     }
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
@@ -1041,12 +1041,13 @@ public class EdcAdapterService {
             case PART_TYPE_INFORMATION_SUBMODEL -> fetchPartTypeSubmodelData(mpr);
         };
         Map<String, String> equalFilters = new HashMap<>();
+        // use only assetId and version (previously semanticId, submodel type, no assetId) to follow all conventions:
+        // - asset per asset type per material
+        // - asset per asset type
+        // - asset for submodel bundle
         equalFilters.put(EdcRequestBodyBuilder.CX_COMMON_NAMESPACE + "version", "3.0");
-        equalFilters.put(
-            "'" + EdcRequestBodyBuilder.DCT_NAMESPACE + "type'.'@id'",
-            EdcRequestBodyBuilder.CX_TAXO_NAMESPACE + "Submodel"
-        );
-        equalFilters.put("'" + EdcRequestBodyBuilder.AAS_SEMANTICS_NAMESPACE + "semanticId'.'@id'", type.URN_SEMANTIC_ID);
+        equalFilters.put(EdcRequestBodyBuilder.EDC_NAMESPACE + "id", submodelData.assetId);
+
         return negotiateContract(partner, submodelData.assetId(), type, submodelData.dspUrl(), equalFilters);
     }
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/delivery/controller/DeliveryRequestApiController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/delivery/controller/DeliveryRequestApiController.java
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2024 Volkswagen AG
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -34,12 +36,12 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.regex.Pattern;
 
-@RestController
-@RequestMapping("delivery-information")
-@Slf4j
 /**
  * This class offers the endpoint for requesting the PlannedProduction Submodel 2.0.0
  */
+@RestController
+@RequestMapping("delivery-information")
+@Slf4j
 public class DeliveryRequestApiController {
 
     @Autowired
@@ -58,7 +60,7 @@ public class DeliveryRequestApiController {
         @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content),
         @ApiResponse(responseCode = "501", description = "Unsupported representation", content = @Content)
     })
-    @GetMapping("request/{materialNumberCx}/{representation}")
+    @GetMapping("request/{materialNumberCx}/submodel/{representation}")
     public ResponseEntity<DeliveryInformation> getDeliveryMapping(
         @RequestHeader("edc-bpn") String bpnl,
         @PathVariable String materialNumberCx,

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/demand/controller/DemandRequestApiController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/demand/controller/DemandRequestApiController.java
@@ -1,6 +1,8 @@
 /*
- * Copyright (c) 2023, 2024 Volkswagen AG
- * Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023 Volkswagen AG
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -34,12 +36,12 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.regex.Pattern;
 
-@RestController
-@RequestMapping("material-demand")
-@Slf4j
 /**
  * This class offers the endpoint for requesting the ShortTermMaterialDemand Submodel 1.0.0
  */
+@RestController
+@RequestMapping("material-demand")
+@Slf4j
 public class DemandRequestApiController {
 
     @Autowired
@@ -58,7 +60,7 @@ public class DemandRequestApiController {
         @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content),
         @ApiResponse(responseCode = "501", description = "Unsupported representation", content = @Content)
     })
-    @GetMapping("request/{materialnumbercx}/{representation}")
+    @GetMapping("request/{materialnumbercx}/submodel/{representation}")
     public ResponseEntity<ShortTermMaterialDemand> getDemandMapping(
         @RequestHeader("edc-bpn") String bpnl,
         @PathVariable String materialnumbercx,
@@ -70,9 +72,6 @@ public class DemandRequestApiController {
         }
         if (!"$value".equals(representation)) {
             log.warn("Rejecting request at ShortTermMaterialDemand Submodel request 1.0.0 endpoint, missing '$value' in request");
-            if (!PatternStore.NON_EMPTY_NON_VERTICAL_WHITESPACE_PATTERN.matcher(representation).matches()) {
-                representation = "<REPLACED_INVALID_REPRESENTATION>";
-            }
             return ResponseEntity.status(501).build();
         }
         var samm = demandRequestApiService.handleDemandSubmodelRequest(bpnl, materialnumbercx);

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/erpadapter/logic/service/ErpAdapterTriggerService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/erpadapter/logic/service/ErpAdapterTriggerService.java
@@ -110,7 +110,7 @@ public class ErpAdapterTriggerService {
                             null : DirectionCharacteristic.valueOf(dataset.getDirectionCharacteristic());
                         request.setDirectionCharacteristic(directionCharacteristic);
                         request.setRequestType(dataset.getAssetType());
-                        request.setSammVersion(dataset.getAssetType().ERP_SAMMVERSION);
+                        request.setSammVersion(dataset.getAssetType().ERP_SAMM_VERSION);
                         executorService.submit(() -> erpAdapterRequestService.createAndSend(request));
 
                         // schedule next request
@@ -157,7 +157,7 @@ public class ErpAdapterTriggerService {
             erpAdapterRequest.setOwnMaterialNumber(ownMaterialNumber);
             erpAdapterRequest.setDirectionCharacteristic(direction);
             erpAdapterRequest.setRequestType(type);
-            erpAdapterRequest.setSammVersion(type.ERP_SAMMVERSION);
+            erpAdapterRequest.setSammVersion(type.ERP_SAMM_VERSION);
             executorService.submit(() -> erpAdapterRequestService.createAndSend(erpAdapterRequest));
 
             // create dataset for the daemon thread to schedule future erp adapter requests

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartTypeInformationController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartTypeInformationController.java
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2024 Volkswagen AG
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -69,7 +71,7 @@ public class PartTypeInformationController {
         @ApiResponse(responseCode = "404", description = "Product not found for given parameters. ", content = @Content),
         @ApiResponse(responseCode = "501", description = "Unsupported representation requested. ", content = @Content)
     })
-    @GetMapping("/{materialnumber}/{representation}")
+    @GetMapping("/{materialnumber}/submodel/{representation}")
     public ResponseEntity<PartTypeInformationSAMM> getMapping(@RequestHeader("edc-bpn") String bpnl,
                                                               @Parameter(description = "The material number that the request receiving party uses for the material in question")
                                         @PathVariable String materialnumber,

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/production/controller/ProductionRequestApiController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/production/controller/ProductionRequestApiController.java
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2024 Volkswagen AG
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -34,12 +36,12 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.regex.Pattern;
 
-@RestController
-@RequestMapping("planned-production")
-@Slf4j
 /**
  * This class offers the endpoint for requesting the PlannedProduction Submodel 2.0.0
  */
+@RestController
+@RequestMapping("planned-production")
+@Slf4j
 public class ProductionRequestApiController {
 
     @Autowired
@@ -58,7 +60,7 @@ public class ProductionRequestApiController {
         @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content),
         @ApiResponse(responseCode = "501", description = "Unsupported representation", content = @Content)
     })
-    @GetMapping("request/{materialnumbercx}/{representation}")
+    @GetMapping("request/{materialnumbercx}/submodel/{representation}")
     public ResponseEntity<PlannedProductionOutput> getProductionMapping(
         @RequestHeader("edc-bpn") String bpnl,
         @PathVariable String materialnumbercx,
@@ -70,9 +72,6 @@ public class ProductionRequestApiController {
         }
         if (!"$value".equals(representation)) {
             log.warn("Rejecting request at PlannedProduction Submodel request 2.0.0 endpoint, missing '$value' in request");
-            if (!PatternStore.NON_EMPTY_NON_VERTICAL_WHITESPACE_PATTERN.matcher(representation).matches()) {
-                representation = "<REPLACED_INVALID_REPRESENTATION>";
-            }
             return ResponseEntity.status(501).build();
         }
         var samm = productionRequestApiService.handleProductionSubmodelRequest(bpnl, materialnumbercx);

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/controller/ItemStockRequestApiController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/controller/ItemStockRequestApiController.java
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2023 Volkswagen AG
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
  * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -35,13 +37,13 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.regex.Pattern;
 
-@RestController
-@RequestMapping("item-stock")
-@Slf4j
 /**
  * This class offers endpoints for the ItemStock-request and
  * -status-request api assets.
  */
+@RestController
+@RequestMapping("item-stock")
+@Slf4j
 public class ItemStockRequestApiController {
 
     @Autowired
@@ -60,7 +62,7 @@ public class ItemStockRequestApiController {
         @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content),
         @ApiResponse(responseCode = "501", description = "Unsupported representation", content = @Content)
     })
-    @GetMapping("request/{materialnumber}/{direction}/{representation}")
+    @GetMapping("request/{materialnumber}/{direction}/submodel/{representation}")
     public ResponseEntity<ItemStockSamm> getMappingItemStock2(@RequestHeader("edc-bpn") String bpnl,
                                                               @PathVariable String materialnumber,
                                                               @PathVariable DirectionCharacteristic direction,
@@ -74,10 +76,10 @@ public class ItemStockRequestApiController {
             if (!PatternStore.NON_EMPTY_NON_VERTICAL_WHITESPACE_PATTERN.matcher(representation).matches()) {
                 representation = "<REPLACED_INVALID_REPRESENTATION>";
             }
-            log.warn("Received " + representation + " from " + bpnl + " with direction " + direction);
+            log.warn("Received {} from {} with direction {}", representation, bpnl, direction);
             return ResponseEntity.status(501).build();
         }
-        log.info("Received request for " + materialnumber + " with " + direction + " from " + bpnl);
+        log.info("Received request for {} with {} from {}", materialnumber, direction, bpnl);
         var samm = itemStockRequestApiService.handleItemStockSubmodelRequest(bpnl, materialnumber, direction);
         if (samm == null) {
             return ResponseEntity.status(500).build();

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/supply/controller/DaysOfSupplyRequestApiController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/supply/controller/DaysOfSupplyRequestApiController.java
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2024 Volkswagen AG
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
  * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -34,12 +36,12 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.regex.Pattern;
 
-@RestController
-@RequestMapping("days-of-supply")
-@Slf4j
 /**
  * This class offers the endpoint for requesting the DaysOfSupply Submodel 2.0.0
  */
+@RestController
+@RequestMapping("days-of-supply")
+@Slf4j
 public class DaysOfSupplyRequestApiController {
 
     @Autowired
@@ -56,7 +58,7 @@ public class DaysOfSupplyRequestApiController {
             @ApiResponse(responseCode = "500", description = "Internal Server Error"),
             @ApiResponse(responseCode = "501", description = "Unsupported representation")
     })
-    @GetMapping("request/{materialnumbercx}/{direction}/{representation}")
+    @GetMapping("request/{materialnumbercx}/{direction}/submodel/{representation}")
     public ResponseEntity<DaysOfSupply> getDaysOfSupplyMapping(
             @RequestHeader("edc-bpn") String bpnl,
             @PathVariable String materialnumbercx,
@@ -68,9 +70,6 @@ public class DaysOfSupplyRequestApiController {
         }
         if (!"$value".equals(representation)) {
             log.warn("Rejecting request at DaysOfSupply Submodel request 2.0.0 endpoint, missing '$value' in request");
-            if (!PatternStore.NON_EMPTY_NON_VERTICAL_WHITESPACE_PATTERN.matcher(representation).matches()) {
-                representation = "<REPLACED_INVALID_REPRESENTATION>";
-            }
             return ResponseEntity.status(501).build();
         }
         var samm = daysOfSupplyRequestApiService.handleDaysOfSupplySubmodelRequest(bpnl, materialnumbercx, direction);

--- a/backend/src/test/java/org/eclipse/tractusx/puris/backend/common/ddtr/logic/util/DtrRequestBodyBuilderTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/puris/backend/common/ddtr/logic/util/DtrRequestBodyBuilderTest.java
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+ * (represented by Fraunhofer ISST)
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.tractusx.puris.backend.common.ddtr.logic.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.tractusx.puris.backend.common.edc.domain.model.AssetType;
+import org.eclipse.tractusx.puris.backend.common.util.VariablesService;
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.MaterialPartnerRelation;
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
+import org.eclipse.tractusx.puris.backend.stock.logic.dto.itemstocksamm.DirectionCharacteristic;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static org.mockito.Mockito.when;
+
+class DtrRequestBodyBuilderTest {
+
+    @InjectMocks
+    DtrRequestBodyBuilder dtrRequestBodyBuilder;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    VariablesService variablesService;
+
+    private final static String TEST_CONST_DIGITAL_TWIN_TYPE = "digitalTwinType";
+    private final static String TEST_CONST_MANUFACTURER_PART_ID = "manufacturerPartId";
+    private final static String TEST_CONST_MANUFACTURER_ID = "manufacturerId";
+    private final static String TEST_CONST_CUSTOMER_PART_ID = "customerPartId";
+
+    private final static String ENV_VAR_EDC_DATA_PLANE_PUBLIC_URL = "https://data-plane.com/api/public/";
+    private final static String ENV_VAR_EDC_CONTROL_PLANE_PROTOCOL_URL = "https://control-plane:com/api/v1/dsp";
+    private final static String ENV_VAR_OWN_BPNL = "BPNL4444444444ZZ";
+
+    private Material MATERIAL;
+    private Partner PARTNER;
+    private Partner PARTNER2;
+    private MaterialPartnerRelation MPR;
+    private MaterialPartnerRelation MPR2;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+
+        // make variablesService mockable
+        Field field = DtrRequestBodyBuilder.class.getDeclaredField("variablesService");
+        field.setAccessible(true);
+        field.set(dtrRequestBodyBuilder, variablesService);
+
+        // make objectMapper a real object
+        Field objectMapperField = DtrRequestBodyBuilder.class.getDeclaredField("objectMapper");
+        objectMapperField.setAccessible(true);
+        objectMapperField.set(dtrRequestBodyBuilder, objectMapper);
+
+        MATERIAL = Material.builder()
+            .ownMaterialNumber("MNR-4711")
+            .materialFlag(true)
+            .productFlag(true)
+            .name("Test Material 1")
+            .materialNumberCx("urn:uuid:ccfffbba-cfa0-49c4-bc9c-4e13d7a4ac7a")
+            .build();
+
+        PARTNER = new Partner(
+            "Test Partner",
+            "https://edc-url.com/api/v1/dsp",
+            "BPNL1234567890ZZ",
+            "BPNS1234567890ZZ",
+            "Test Site",
+            "BPNA1234567890ZZ",
+            "Test Street 5",
+            "4711 Test City",
+            "Testonia"
+        );
+
+        PARTNER2 = new Partner(
+            "Test Partner",
+            "https://other-edc-url.com/api/v1/dsp",
+            "BPNL6666666666ZZ",
+            "BPNS6666666666ZZ",
+            "Test Site",
+            "BPNA6666666666ZZ",
+            "Test Street 5",
+            "4711 Test City",
+            "Testonia"
+        );
+
+        MPR = new MaterialPartnerRelation(
+            MATERIAL,
+            PARTNER,
+            "MNR-4711-S",
+            true,
+            true
+        );
+        MPR.setPartnerCXNumber("urn:uuid:ccfffbba-cfa0-49c4-bc9c-4e13d7a4ac88");
+
+        MPR2 = new MaterialPartnerRelation(
+            MATERIAL,
+            PARTNER2,
+            "MNR-4711-S2",
+            true,
+            true
+        );
+        MPR2.setPartnerCXNumber("urn:uuid:ccfffbba-cfa0-49c4-bc9c-4e13d7a4ac99");
+    }
+
+    /**
+     * Asserts the correct creation of a ShellDescriptor for a material (shared copy of the twin)
+     * <p>
+     * Performs the following CX-0002 compliance checks:
+     * <li>SubmodelDescriptor via {@linkplain #assertSubmodelDescriptor(JsonNode, AssetType, DirectionCharacteristic, String)} including semanticId</li>
+     * <li>SpecificAssetIds via {@linkplain #assertSpecificAssetIds(JsonNode, String, List)}</li>
+     * </p>
+     * Only checks for the customer side of information shared.
+     */
+    @Test
+    void createMaterialRegistrationRequestBody_givenOneMaterial_ReturnsCompliant() {
+
+        //given Material, Partner, MPR with MPR.partnerBuys=true
+
+        //when
+        when(variablesService.getEdcDataplanePublicUrl()).thenReturn(ENV_VAR_EDC_DATA_PLANE_PUBLIC_URL);
+        when(variablesService.getEdcProtocolUrl()).thenReturn(ENV_VAR_EDC_CONTROL_PLANE_PROTOCOL_URL);
+
+        JsonNode materialShellDescriptor = dtrRequestBodyBuilder.createMaterialRegistrationRequestBody(MPR);
+
+        Assertions.assertEquals(MPR.getPartnerCXNumber(), materialShellDescriptor.get("globalAssetId").asText());
+
+        JsonNode specificAssetIds = materialShellDescriptor.get("specificAssetIds");
+
+        for (JsonNode specificAssetId : specificAssetIds) {
+            switch (specificAssetId.get("name").asText()) {
+                case TEST_CONST_DIGITAL_TWIN_TYPE ->
+                    assertSpecificAssetIds(specificAssetId, "PartType", List.of(PARTNER.getBpnl()));
+                case TEST_CONST_CUSTOMER_PART_ID ->
+                    assertSpecificAssetIds(specificAssetId, MATERIAL.getOwnMaterialNumber(), List.of(PARTNER.getBpnl()));
+                case TEST_CONST_MANUFACTURER_ID ->
+                    assertSpecificAssetIds(specificAssetId, PARTNER.getBpnl(), List.of(PARTNER.getBpnl()));
+                case TEST_CONST_MANUFACTURER_PART_ID ->
+                    assertSpecificAssetIds(specificAssetId, MPR.getPartnerMaterialNumber(), List.of(PARTNER.getBpnl()));
+            }
+        }
+
+        JsonNode submodelDescriptors = materialShellDescriptor.get("submodelDescriptors");
+
+        for (JsonNode submodelDescriptor : submodelDescriptors) {
+
+            // assume that we only create one semanticId
+            JsonNode semanticId = submodelDescriptor.get("semanticId").get("keys").get(0);
+
+            switch (AssetType.fromUrn(semanticId.get("value").asText())) {
+                case AssetType.ITEM_STOCK_SUBMODEL ->
+                    assertSubmodelDescriptor(submodelDescriptor, AssetType.ITEM_STOCK_SUBMODEL, DirectionCharacteristic.INBOUND, MPR.getPartnerCXNumber());
+                case AssetType.PRODUCTION_SUBMODEL ->
+                    assertSubmodelDescriptor(submodelDescriptor, AssetType.PRODUCTION_SUBMODEL, DirectionCharacteristic.INBOUND, MPR.getPartnerCXNumber());
+                case AssetType.DAYS_OF_SUPPLY ->
+                    assertSubmodelDescriptor(submodelDescriptor, AssetType.DAYS_OF_SUPPLY, DirectionCharacteristic.INBOUND, MPR.getPartnerCXNumber());
+                case AssetType.DELIVERY_SUBMODEL ->
+                    assertSubmodelDescriptor(submodelDescriptor, AssetType.DELIVERY_SUBMODEL, DirectionCharacteristic.INBOUND, MPR.getPartnerCXNumber());
+            }
+        }
+    }
+
+    /**
+     * Asserts that the SubmodelDescriptor matches CX-0002 and the endpoint definitions in this application
+     * <p>
+     * Performs the following checks regarding CX-0002 ONLY on DSP, submodel-3.0 endpoints (assumes there is only one)
+     * <li><code>ProtocolInformation.subprotocolBodyEncoding</code> is set following CX-0002</li>
+     * <li><code>ProtocolInformation.href</code> is set to the data plane cut-off with parametrization following CX-0002 conventions(see EDC Asset dataAddress.baseUrl in registration of submodel assets in {@linkplain org.eclipse.tractusx.puris.backend.common.edc.logic.service.EdcAdapterService})</li>
+     * <li><code>ProtocolInformation.subprotocolBody</code> is in form of "assetId=\<id\>;dspEndpoint=\<dsp api endpoint of edc\>"</li>
+     * </p>
+     * <b>ATTENTION:</b> The application currently only handles one SemanticId.
+     *
+     * @param submodelDescriptor to perform assertions on, must not be null
+     * @param submodel           that is represented by this submodel descriptor, must not be null
+     * @param direction          that is associated with the submodel type and may be used in the <code>href</code> field, must not be null
+     * @param materialNumberCx   that is used for exposure in the <code>href</code> field, must not be null
+     */
+    private void assertSubmodelDescriptor(JsonNode submodelDescriptor, AssetType submodel, DirectionCharacteristic direction, String materialNumberCx) {
+
+        JsonNode endpoints = submodelDescriptor.get("endpoints");
+
+        // Convert the JsonNode array to a Stream
+        Stream<JsonNode> endpointStream = StreamSupport.stream(endpoints.spliterator(), false);
+
+        List<JsonNode> dspEndpoints = endpointStream.filter(
+            endpoint -> "SUBMODEL-3.0".equals(endpoint.path("interface").asText()) &&
+                "DSP".equals(endpoint.path("protocolInformation").path("subprotocol").asText())
+        ).toList();
+
+        Assertions.assertEquals(1, dspEndpoints.size());
+        JsonNode protocolInformation = dspEndpoints.getFirst().get("protocolInformation");
+        Assertions.assertEquals("plain", protocolInformation.get("subprotocolBodyEncoding").asText());
+
+        String subprotocolBody = protocolInformation.get("subprotocolBody").asText();
+
+        // format: id=<asset_id>;dspEndpoint=<control plan url dsp url>
+        String[] bodyParts = subprotocolBody.split(";");
+
+        String idEquation = bodyParts[0];
+        String dspEndpointEquation = bodyParts[1];
+
+        Assertions.assertTrue(idEquation.startsWith("id="));
+
+        Assertions.assertTrue(dspEndpointEquation.startsWith("dspEndpoint="));
+        Assertions.assertEquals(ENV_VAR_EDC_CONTROL_PLANE_PROTOCOL_URL, dspEndpointEquation.split("=")[1]);
+
+        // href
+        // format=<data plane public url>/<your information for the endpoint>/<direction for specific submodel>/submodel
+        String href = protocolInformation.path("href").asText();
+
+        boolean needsDirection = submodel.URN_SEMANTIC_ID.equals(AssetType.ITEM_STOCK_SUBMODEL.URN_SEMANTIC_ID)
+            || submodel.URN_SEMANTIC_ID.equals(AssetType.DAYS_OF_SUPPLY.URN_SEMANTIC_ID);
+
+        if (needsDirection && direction == DirectionCharacteristic.INBOUND) {
+            Assertions.assertEquals(href, ENV_VAR_EDC_DATA_PLANE_PUBLIC_URL + materialNumberCx + "/INBOUND/submodel");
+        } else if (needsDirection && direction == DirectionCharacteristic.OUTBOUND) {
+            Assertions.assertEquals(href, ENV_VAR_EDC_DATA_PLANE_PUBLIC_URL + materialNumberCx + "/OUTBOUND/submodel");
+        } else if (!needsDirection) {
+            System.out.println("href: " + href);
+            Assertions.assertEquals(href, ENV_VAR_EDC_DATA_PLANE_PUBLIC_URL + materialNumberCx + "/submodel");
+        }
+    }
+
+    /**
+     * asserts that the specificAssetId exactly matches the definition of CX-0002
+     * <p>
+     * It's assumed, that the specificAssetId Type has already been checked.
+     * </p>
+     * Performs the following checks:
+     * <li><code>ExternalSubjectId</code> is set to CX-0002</li>
+     * <li>The expected BPNLs must all be present in the <code>ExternalSubjectId.keys[].value</code></li>
+     * <li>The expected BPNLs size must match the size of <code>ExternalSubjectId.keys</code></li>
+     *
+     * @param specificAssetId             node of the specificAssetId to check, must not be null
+     * @param expectedValue               value to be expected in the value field, must not be null
+     * @param expectedToBeVisibleForBpnls list of BPNLs that must EXACTLY match the keys, may not be null
+     */
+    private void assertSpecificAssetIds(JsonNode specificAssetId, String expectedValue, List<String> expectedToBeVisibleForBpnls) {
+        Assertions.assertEquals(expectedValue, specificAssetId.get("value").asText());
+
+        JsonNode externalSubjectId = specificAssetId.get("externalSubjectId");
+        Assertions.assertEquals("ExternalReference", externalSubjectId.get("type").asText());
+        JsonNode keys = externalSubjectId.get("keys");
+        Assertions.assertEquals(expectedToBeVisibleForBpnls.size(), keys.size());
+
+        for (String expectedBpnl : expectedToBeVisibleForBpnls) {
+            // Convert the JsonNode array to a Stream
+            Stream<JsonNode> keysStream = StreamSupport.stream(keys.spliterator(), false);
+            Optional<JsonNode> keyOpt = keysStream.filter(
+                keyInStream -> expectedBpnl.equals(keyInStream.get("value").asText())
+            ).findFirst();
+            Assertions.assertTrue(keyOpt.isPresent());
+            JsonNode key = keyOpt.get();
+            Assertions.assertEquals("GlobalReference", key.get("type").asText());
+            Assertions.assertEquals(expectedBpnl, key.get("value").asText());
+        }
+    }
+
+    /**
+     * asserts the correct creation of a ShellDescriptor for a product with two customers (you create the twin)
+     * <p>
+     * Performs the following CX-0002 compliance checks:
+     * <li>SubmodelDescriptor via {@linkplain #assertSubmodelDescriptor(JsonNode, AssetType, DirectionCharacteristic, String)} including semanticId</li>
+     * <li>SpecificAssetIds via {@linkplain #assertSpecificAssetIds(JsonNode, String, List)} considering multiple partners to see a specificAssetId or not</li>
+     * </p>
+     * Only checks for the supplier side of information shared.
+     */
+    @Test
+    void createProductRegistrationRequestBody() {
+        // given Material
+        // Partner, MPR with MPR.partnerSupplies=true
+        // Partner2, MPR2 with MPR.partnerSupplies=true
+
+        // when
+        when(variablesService.getEdcDataplanePublicUrl()).thenReturn(ENV_VAR_EDC_DATA_PLANE_PUBLIC_URL);
+        when(variablesService.getEdcProtocolUrl()).thenReturn(ENV_VAR_EDC_CONTROL_PLANE_PROTOCOL_URL);
+        when(variablesService.getOwnBpnl()).thenReturn(ENV_VAR_OWN_BPNL);
+
+        // operation
+        JsonNode materialShellDescriptor = dtrRequestBodyBuilder.createProductRegistrationRequestBody(
+            MATERIAL,
+            MATERIAL.getMaterialNumberCx(),
+            List.of(MPR, MPR2)
+        );
+
+        // then
+        Assertions.assertEquals(MATERIAL.getMaterialNumberCx(), materialShellDescriptor.get("globalAssetId").asText());
+
+        JsonNode specificAssetIds = materialShellDescriptor.get("specificAssetIds");
+
+        for (JsonNode specificAssetId : specificAssetIds) {
+            switch (specificAssetId.get("name").asText()) {
+                case TEST_CONST_DIGITAL_TWIN_TYPE:
+                    assertSpecificAssetIds(specificAssetId, "PartType", List.of(PARTNER.getBpnl(), PARTNER2.getBpnl()));
+                    break;
+                case TEST_CONST_CUSTOMER_PART_ID:
+                    // customer part ID may only be visible to one partner. Thus, we need to check them separately
+                    // and ensure it's only used for one partner
+                    if (MPR.getPartnerMaterialNumber().equals(specificAssetId.get("value").asText())) {
+                        assertSpecificAssetIds(specificAssetId, MPR.getPartnerMaterialNumber(), List.of(PARTNER.getBpnl()));
+                    } else if (MPR2.getPartnerMaterialNumber().equals(specificAssetId.get("value").asText())) {
+                        assertSpecificAssetIds(specificAssetId, MPR2.getPartnerMaterialNumber(), List.of(PARTNER2.getBpnl()));
+                    }
+                    break;
+                case TEST_CONST_MANUFACTURER_ID:
+                    assertSpecificAssetIds(specificAssetId, ENV_VAR_OWN_BPNL, List.of(PARTNER.getBpnl(), PARTNER2.getBpnl()));
+                    break;
+                case TEST_CONST_MANUFACTURER_PART_ID:
+                    assertSpecificAssetIds(specificAssetId, MATERIAL.getOwnMaterialNumber(), List.of(PARTNER.getBpnl(), PARTNER2.getBpnl()));
+                    break;
+            }
+        }
+
+        JsonNode submodelDescriptors = materialShellDescriptor.get("submodelDescriptors");
+
+        for (JsonNode submodelDescriptor : submodelDescriptors) {
+            // assume that we only create one semanticId
+            JsonNode semanticId = submodelDescriptor.get("semanticId").get("keys").get(0);
+
+            switch (AssetType.fromUrn(semanticId.get("value").asText())) {
+                case AssetType.ITEM_STOCK_SUBMODEL ->
+                    assertSubmodelDescriptor(submodelDescriptor, AssetType.ITEM_STOCK_SUBMODEL, DirectionCharacteristic.OUTBOUND, MATERIAL.getMaterialNumberCx());
+                case AssetType.DEMAND_SUBMODEL ->
+                    assertSubmodelDescriptor(submodelDescriptor, AssetType.DEMAND_SUBMODEL, DirectionCharacteristic.OUTBOUND, MATERIAL.getMaterialNumberCx());
+                case AssetType.DELIVERY_SUBMODEL ->
+                    assertSubmodelDescriptor(submodelDescriptor, AssetType.DELIVERY_SUBMODEL, DirectionCharacteristic.OUTBOUND, MATERIAL.getMaterialNumberCx());
+                case AssetType.DAYS_OF_SUPPLY ->
+                    assertSubmodelDescriptor(submodelDescriptor, AssetType.DAYS_OF_SUPPLY, DirectionCharacteristic.OUTBOUND, MATERIAL.getMaterialNumberCx());
+                case AssetType.PART_TYPE_INFORMATION_SUBMODEL ->
+                    assertSubmodelDescriptor(submodelDescriptor, AssetType.PART_TYPE_INFORMATION_SUBMODEL, DirectionCharacteristic.OUTBOUND, Base64.getEncoder().encodeToString(MATERIAL.getOwnMaterialNumber().getBytes(StandardCharsets.UTF_8)));
+            }
+        }
+    }
+}

--- a/backend/src/test/java/org/eclipse/tractusx/puris/backend/erpadapter/logic/service/ErpAdapterRequestValidationTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/puris/backend/erpadapter/logic/service/ErpAdapterRequestValidationTest.java
@@ -64,7 +64,7 @@ public class ErpAdapterRequestValidationTest {
             .partnerBpnl(supplierPartnerBpnl)
             .ownMaterialNumber(matNbrCustomer)
             .requestType(type)
-            .sammVersion(type.ERP_SAMMVERSION)
+            .sammVersion(type.ERP_SAMM_VERSION)
             .build();
 
         // when
@@ -87,7 +87,7 @@ public class ErpAdapterRequestValidationTest {
             .partnerBpnl("wrong-bpnl") // should fail regex check
             .ownMaterialNumber("illegal-material-number\n") // should fail regex check
             .requestType(AssetType.ITEM_STOCK_SUBMODEL)
-            .sammVersion(AssetType.ITEM_STOCK_SUBMODEL.ERP_SAMMVERSION)
+            .sammVersion(AssetType.ITEM_STOCK_SUBMODEL.ERP_SAMM_VERSION)
             .build();
 
         // when

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -16,6 +16,52 @@ docker compose -f docker-compose-dev-postgres.yaml down
 _NOTE: For testing purposes HyperSql is still used but excluded for spring run._
 ll
 
+## Cleaning the vault
+
+Sometimes it may be helpful to remove old transfers or edr tokens if you resetup your edc but not your vault.
+
+As per version `0.9.0` (started with a `0.5.0` or `0.4.0` version), the edc creates in the root of the vault secrets:
+
+- transfers in form of <uuid>
+- edrs for uuids in form of edr--<uuid>
+
+Download & install the vault CLI
+
+> The vault deletion process is to
+> - remove the versions. If you remove them, they remain on the system.
+> - destroy the versions. Now they're gone, too but the path still remains.
+> - remove metatdata from secret path. Now the whole secret has been removed.
+    > Note: only do this in a controlled environment
+
+```shell
+export VAULT_ADDR=TODO
+export VAULT_TOKEN=TODO
+
+export KV_PATH=your-puris-kv-path
+
+# select uuids and edr--uuid
+secrets=$(vault kv list -format=json $KV_PATH | jq -r '.[] | select(test("^(edr--[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$"))')
+
+# Count the number of UUID-like secrets
+count=$(echo "$secrets" | wc -l)
+
+# Print the number of secrets found
+echo "Number of UUID-like secrets found: $count"
+
+for secret in $secrets; do
+    
+    # Remove the 'data/' prefix if it exists
+    secret_name=$(echo "$secret" | sed 's/^data\///')
+    
+    echo "Deleting secret: $secret"
+    vault kv delete "$KV_PATH/$secret"
+    echo "Destroy version 1 permanently: $secret"
+    vault kv destroy -versions=1 "$KV_PATH/$secret"
+    echo "Remove path by removing metadata: $secret"
+    vault kv metadata delete "$KV_PATH/$secret"
+done
+```
+
 ## Keeping dependencies-files up to date
 
 ### Backend


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

solves #844 #846 #841 

Adds a test for the shell and submodel composure.

I also noticed that we created to ExternalSubjectIds, but not the tenantId when creating / updating ShellDescriptors in our DTR. Thus, I changed that behavior.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
