### PR TITLE
fix helm chart: not working frontend and backend nameOverride

### DIFF
--- a/charts/puris/Chart.yaml
+++ b/charts/puris/Chart.yaml
@@ -35,7 +35,7 @@ dependencies:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.9.1
+version: 2.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/puris/Chart.yaml
+++ b/charts/puris/Chart.yaml
@@ -35,7 +35,7 @@ dependencies:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.9.0
+version: 2.9.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/puris/templates/_helpers.tpl
+++ b/charts/puris/templates/_helpers.tpl
@@ -22,7 +22,8 @@
 Expand the name of the chart.
 */}}
 {{- define "puris.backend.name" -}}
-{{- default .Chart.Name "backend" .Values.backend.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- $nameOverride := .Values.backend.nameOverride | default "" }}
+{{- printf "%s-%sbackend" .Release.Name (ternary "" ($nameOverride | printf "%s-") (eq $nameOverride "")) | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -86,7 +87,8 @@ FRONTEND
 Expand the name of the chart.
 */}}
 {{- define "puris.frontend.name" -}}
-{{- default .Chart.Name "frontend" .Values.frontend.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- $nameOverride := .Values.frontend.nameOverride | default "" }}
+{{- printf "%s-%sfrontend" .Release.Name (ternary "" ($nameOverride | printf "%s-") (eq $nameOverride "")) | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
## Description

### What does this PR introduce?
This PR introduces the ability to change the pod names via the frontend.nameOverride and backend.nameOverride values.

Changes to logic behind the backend.name and frontend.name values to fix the nameOverride (if release name is puris):
- `--set frontend.nameOverride=newFrontendName` results in `puris-newFrontendName-frontend`
- `--set backend.nameOverride=newBackendName` results in `puris-newBackendName-frontend`

Note: changes also the default pods names from
- `backend` to `puris-backend`
    - `--set backend.nameOverride=""` results in `puris-backend`
- `frontend` to `puris-frontend`
    - `--set frontend.nameOverride=""` results in  `puris-frontend`

### Does it fix a bug?
Yes, the nameOverride was mentioned in the values.yml file but didn't result in a name change.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
