### PR TITLE
feat: implemented login logic for cypress tests

### DIFF
--- a/local/testing/TESTING.md
+++ b/local/testing/TESTING.md
@@ -7,6 +7,12 @@ End-to-end testing for the PURIS FOSS application is done using Cypress. The Cyp
 * PURIS FOSS application is running locally in docker compose
 * the app was seeded with integration test data using the `-i` flag
 
+## Configuring the tests
+
+Before running the tests make sure to configure the `baseUrl` in `cypress.config.json` and `supplierUrl` in `cypress.env.json`. `baseUrl` is expected to match the customer frontend url.
+
+In order to run the tests with login, the environment file `cypress.env.json` needs to be configured with the appropriate information. Set `idp_enabled` to true and fill in your login information for the IDP. Make sure that the company names match the configured names in the IDP.
+
 ## Running the tests
 
 The tests can be run using the command:
@@ -33,7 +39,7 @@ sh run-e2e.sh --browser webkit
 
 ## Developing tests
 
-When developing tests, the `run-e2e.sh` command can simply be re-run whenever specs, fixtures or support files change. Only changes to the cypress config should require re-building the docker image.
+When developing tests, it should not be necessary to rebuild the docker image.
 
 ## Test structure
 

--- a/local/testing/e2e/cypress.config.js
+++ b/local/testing/e2e/cypress.config.js
@@ -41,8 +41,5 @@ module.exports = defineConfig({
         viewportHeight: 720,
         experimentalWebKitSupport: true
     },
-    env: {
-      supplierUrl: 'http://localhost:3001'
-    },
     video: true,
 });

--- a/local/testing/e2e/cypress.env.json
+++ b/local/testing/e2e/cypress.env.json
@@ -1,0 +1,15 @@
+{
+    "idp_enabled": false,
+    "central_idp_url": "https://centralidp.int.catena-x.net",
+    "shared_idp_url": "https://sharedidp.int.catena-x.net",
+    "customer": {
+        "company_name": "Control Unit Creator Incorp.",
+        "username": "your_username",
+        "password": "your_password"
+    },
+    "supplier": {
+        "company_name": "Semiconductor Supplier Incorp.",
+        "username": "your_username",
+        "password": "your_password"
+    }
+}

--- a/local/testing/e2e/cypress.env.json
+++ b/local/testing/e2e/cypress.env.json
@@ -2,6 +2,7 @@
     "idp_enabled": false,
     "central_idp_url": "https://centralidp.int.catena-x.net",
     "shared_idp_url": "https://sharedidp.int.catena-x.net",
+    "supplierUrl": "http://localhost:3001/",
     "customer": {
         "company_name": "Control Unit Creator Incorp.",
         "username": "your_username",

--- a/local/testing/e2e/cypress/e2e/general/navigation.spec.cy.js
+++ b/local/testing/e2e/cypress/e2e/general/navigation.spec.cy.js
@@ -19,6 +19,11 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 describe("navigation", () => {
+    beforeEach(() => {
+        cy.visit('/')
+        cy.login('customer');
+    })
+
     it("allows navigating to all sidebar menu pages", () => {
         cy.fixture("menu.json").then((menu) => {
             menu.forEach((item) => {

--- a/local/testing/e2e/cypress/e2e/general/sidebar.spec.cy.js
+++ b/local/testing/e2e/cypress/e2e/general/sidebar.spec.cy.js
@@ -21,7 +21,7 @@ SPDX-License-Identifier: Apache-2.0
 describe("sidebar", () => {
     beforeEach(() => {
         cy.visit("/");
-        cy.login();
+        cy.login('customer');
     });
 
     it("shows 7 menu items and one is selected", () => {

--- a/local/testing/e2e/cypress/support/commands.js
+++ b/local/testing/e2e/cypress/support/commands.js
@@ -35,8 +35,15 @@ Cypress.Commands.add('getByTestIdContains', (testid) => {
   return cy.get(`[data-testid*="${testid}"]`);
 })
 
-Cypress.Commands.add('login', () => {
-  if (Cypress.env('IDP_ENABLED')) {
-    // TODO: conditionally handle login for local and int environments
+Cypress.Commands.add('login', (role) => {
+  if (Cypress.env('idp_enabled')) {
+    cy.origin(Cypress.env('central_idp_url'), { args: { role }}, ({ role }) => {
+      cy.contains(Cypress.env(role).company_name).click();
+    });
+    cy.origin(Cypress.env('shared_idp_url'), { args: { role }}, ({ role }) => {
+      cy.get('#username').should('exist').type(Cypress.env(role).username);
+      cy.get('#password').should('exist').type(Cypress.env(role).password);
+      cy.get('#kc-login').should('exist').click();
+    });
   }
 })

--- a/local/testing/e2e/docker-compose-e2e.yaml
+++ b/local/testing/e2e/docker-compose-e2e.yaml
@@ -28,4 +28,6 @@ services:
     command: "--browser ${BROWSER:-chrome}"
     volumes:
       - ./cypress:/testing/cypress
+      - ./cypress.config.js:/testing/cypress.config.js
+      - ./cypress.env.json:/testing/cypress.env.json
     network_mode: "host"


### PR DESCRIPTION
## Description
<!-- 
Please describe your PR: 

- implements the logic to login using the tractus-x portal
- the login can be enabled by setting environment variables

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
