### PR TITLE
feat: extended days of supply unit tests with edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The **need for configuration updates** is **marked bold**.
 * Switch to spring actuator helm endpoint including enhancement of health, liveness and startup probe ([#469](https://github.com/eclipse-tractusx/puris/pull/469))
 * Company name and BPNL display in the sidebar for easier distinguishing between applications ([#837](https://github.com/eclipse-tractusx/puris/pull/837))
 * Updated partner data request flow to automatically update the UI when the data is received ([#847](https://github.com/eclipse-tractusx/puris/pull/847))
+* Extended Days of Supply unit tests in the backend to include some additional edge cases ([#870](https://github.com/eclipse-tractusx/puris/pull/870))
 
 Fixes
 


### PR DESCRIPTION
## Description

- extended days of supply unit tests:
    - test for insufficient number of days
    - initial stock of 0
    - mixed own and reported deliveries 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
