### PR TITLE
chore: upgrade edc and dtr to new versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ Fixes
 
 Version Bumps
 
+* Infrastructure Components
+  * Tractus-X Connector to 0.10.0-rc2 ([#872](https://github.com/eclipse-tractusx/puris/pull/872))
+  * Digital Twin Registry to 0.8.0-RC1 ([#872](https://github.com/eclipse-tractusx/puris/pull/872))
 * Backend Dependencies
   * spring-boot from 3.4.3 to 3.4.5 in /backend ([#871](https://github.com/eclipse-tractusx/puris/pull/871))
 

--- a/local/docker-compose.yaml
+++ b/local/docker-compose.yaml
@@ -94,7 +94,7 @@ services:
       - "host.docker.internal:host-gateway" # Adjusts container's host file to allow for communication with docker-host machine
 
   dtr-customer:
-    image: tractusx/sldt-digital-twin-registry:0.7.0
+    image: tractusx/sldt-digital-twin-registry:0.8.0-RC1
     container_name: dtr-customer
     depends_on:
       postgres-all:
@@ -279,7 +279,7 @@ services:
       - "host.docker.internal:host-gateway" # Adjusts container's host file to allow for communication with docker-host machine
 
   dtr-supplier:
-    image: tractusx/sldt-digital-twin-registry:0.7.0
+    image: tractusx/sldt-digital-twin-registry:0.8.0-RC1
     container_name: dtr-supplier
     depends_on:
       postgres-all:

--- a/local/tractus-x-edc/config/customer/control-plane.properties
+++ b/local/tractus-x-edc/config/customer/control-plane.properties
@@ -4,6 +4,7 @@ web.http.path=/api
 # MANAGEMENT (replaced data in 0.3.0)
 web.http.management.port=8181
 web.http.management.path=/management
+web.http.management.auth.key=${EDC_API_PW}
 # CONTROL (replaced validation in 0.3.0)
 web.http.control.port=8183
 web.http.control.path=/api/controlplane/control
@@ -16,12 +17,14 @@ web.http.catalog.path=/catalog
 web.http.catalog.auth.type=tokenbased
 web.http.catalog.auth.key=${EDC_API_PW}
 
+edc.catalog.cache.execution.enabled=false
+edc.dcp.v08.forced=true
+
 # TX EDC 0.9.0, Upstream 0.11.0, enable with https://github.com/eclipse-tractusx/puris/issues/783
 #edc.policy.validation.enabled=true
 
 edc.participant.id=BPNL4444444444XX
 edc.component.id=customer-controlplane-component-id
-edc.api.auth.key=${EDC_API_PW}
 edc.dsp.callback.address=http://customer-control-plane:8184/api/v1/dsp
 edc.hostname=customer-control-plane
 # IATP

--- a/local/tractus-x-edc/config/supplier/control-plane.properties
+++ b/local/tractus-x-edc/config/supplier/control-plane.properties
@@ -4,6 +4,7 @@ web.http.path=/api
 # MANAGEMENT (replaced data in 0.3.0)
 web.http.management.port=9181
 web.http.management.path=/management
+web.http.management.auth.key=${EDC_API_PW}
 # CONTROL (replaced validation in 0.3.0)
 web.http.control.port=9183
 web.http.control.path=/api/controlplane/control
@@ -16,13 +17,15 @@ web.http.catalog.path=/catalog
 web.http.catalog.auth.type=tokenbased
 web.http.catalog.auth.key=${EDC_API_PW}
 
+edc.catalog.cache.execution.enabled=false
+edc.dcp.v08.forced=true
+
 # TX EDC 0.9.0, Upstream 0.11.0, enable with https://github.com/eclipse-tractusx/puris/issues/783
 edc.policy.validation.enabled=false
 
 JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:1044
 edc.participant.id=BPNL1234567890ZZ
 edc.component.id=supplier-controlplane-component-id
-edc.api.auth.key=${EDC_API_PW}
 edc.dsp.callback.address=http://supplier-control-plane:9184/api/v1/dsp
 edc.hostname=supplier-control-plane
 # IATP

--- a/local/tractus-x-edc/docker-compose.yaml
+++ b/local/tractus-x-edc/docker-compose.yaml
@@ -21,13 +21,13 @@
 
 services:
   control-plane:
-    image: tractusx/edc-controlplane-postgresql-hashicorp-vault:0.9.0-rc2
+    image: tractusx/edc-controlplane-postgresql-hashicorp-vault:0.10.0-rc2
     volumes:
       - ./config/default/opentelemetry.properties:/app/opentelemetry.properties
       - ./config/default/logging.properties:/app/logging.properties
 
   data-plane:
-    image: tractusx/edc-dataplane-hashicorp-vault:0.9.0-rc2
+    image: tractusx/edc-dataplane-hashicorp-vault:0.10.0-rc2
     volumes:
       - ./config/default/opentelemetry.properties:/app/opentelemetry.properties
       - ./config/default/logging.properties:/app/logging.properties


### PR DESCRIPTION
## Description

- upgrade EDC to 0.10.0-rc2
- upgrade DTR to 0.8.0-RC1

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [ ] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
