### PR TITLE
fix: sidebar tests

### DIFF
--- a/frontend/src/components/layout/SideBar.tsx
+++ b/frontend/src/components/layout/SideBar.tsx
@@ -40,6 +40,7 @@ import {
     HandshakeOutlined,
     HelpOutlineOutlined,
     HomeOutlined,
+    InfoOutlined,
     LogoutOutlined,
     MenuOutlined,
     NotificationsOutlined,
@@ -119,6 +120,7 @@ const sideBarItems: SideBarItemProps[] = [
     { name: 'Negotiations', icon: <HandshakeOutlined />, path: '/negotiations', requiredRoles: ['PURIS_ADMIN'] },
     { name: 'Transfers', icon: <SyncAltOutlined />, path: '/transfers', requiredRoles: ['PURIS_ADMIN'] },
     { name: 'User Guide', icon: <HelpOutlineOutlined />, path: '/user-guide' },
+    { name: 'About License', icon: <InfoOutlined/>, path: '/about-license'},
     { name: 'Logout', icon: <LogoutOutlined />, action: AuthenticationService.logout, variant: 'button' },
 ];
 

--- a/local/testing/e2e/cypress.config.js
+++ b/local/testing/e2e/cypress.config.js
@@ -41,5 +41,6 @@ module.exports = defineConfig({
         viewportHeight: 720,
         experimentalWebKitSupport: true
     },
+    defaultCommandTimeout: 6000,
     video: true,
 });

--- a/local/testing/e2e/cypress/e2e/customer/material-details-view-data-operations.spec.cy.js
+++ b/local/testing/e2e/cypress/e2e/customer/material-details-view-data-operations.spec.cy.js
@@ -134,7 +134,7 @@ describe('material data operations', () => {
             cy.getByTestId('toast-success').should('be.visible');
 
             // expand the appropriate calendar week if necessary and open the delivery modal for the day after tomorrow
-            const targetWeekIndex = new Date().getDay() + 2 > 6 ? 1 : 0;
+            const targetWeekIndex = (new Date().getDay() + 2) > 7 ? 1 : 0;
             cy.getByTestIdContains('cw-summary').eq(targetWeekIndex).then(($cw) => {
                 if (!$cw.attr('aria-expanded')) {
                   cy.wrap($cw).find('h4 + button').click();

--- a/local/testing/e2e/cypress/e2e/general/sidebar.spec.cy.js
+++ b/local/testing/e2e/cypress/e2e/general/sidebar.spec.cy.js
@@ -42,18 +42,11 @@ describe("sidebar", () => {
 
             for (let i = 0; i < menuLinks.length; i++) {
                 cy.get('[data-testid*="sidebar-menu-item"] a')
-                    .should("have.length", 6)
+                    .should("have.length", 7)
                     .eq(i)
                     .click();
                 cy.url().should("match", new RegExp(menuLinks[i].target));
             }
-
-            cy.get('[data-testid="sidebar-item-license"]').should("exist");
-            cy.get('[data-testid="sidebar-item-license"] a').click();
-            cy.url().should("match", /\/aboutLicense$/);
-            cy.get(
-                '[data-testid*="sidebar-menu-item"][aria-selected="true"]'
-            ).should("not.exist");
         });
     });
 });

--- a/local/testing/e2e/cypress/fixtures/menu.json
+++ b/local/testing/e2e/cypress/fixtures/menu.json
@@ -30,6 +30,11 @@
     "iconid": "HelpOutlineOutlinedIcon"
   },
   {
+    "target": "/about-license",
+    "name": "About License",
+    "iconid": "InfoOutlinedIcon"
+  },
+  {
     "name": "Logout",
     "iconid": "LogoutOutlinedIcon"
   }


### PR DESCRIPTION
## Description

- fix sidebar tests for the newly moved license menu item
- fixed an error with the calendar week panel expansion logic

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [ ] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
