### PR TITLE
fix: changed the material refresh logic to request the correct stock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Fixes
   externalSubjectId ([#849](https://github.com/eclipse-tractusx/puris/pull/849))
 * use `assetId` instead of `semanticId` and `dct:type=submodel` during catalog request for submodel
   assets ([#849](https://github.com/eclipse-tractusx/puris/pull/849))
+* use the correct request when refreshing material data from customers ([#879](https://github.com/eclipse-tractusx/puris/pull/879))
 
 Version Bumps
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/MaterialRefreshService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/logic/service/MaterialRefreshService.java
@@ -81,7 +81,7 @@ public class MaterialRefreshService {
             futures.add(
                     CompletableFuture.runAsync(
                             () -> itemStockRequestApiService
-                                    .doItemStockSubmodelReportedMaterialItemStockRequest(
+                                    .doItemStockSubmodelReportedProductItemStockRequest(
                                             customer, material),
                             executorService));
             futures.add(


### PR DESCRIPTION
## Description

- fixed a mistake in the material refresh logic that resulted in sending the wrong refresh request to customers

fixes #879 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
