### PR TITLE
fix: add appropriate http protocol to default allowed origins

### DIFF
--- a/charts/puris/templates/backend-deployment.yaml
+++ b/charts/puris/templates/backend-deployment.yaml
@@ -134,7 +134,18 @@ spec:
               value: "http://{{ $baseUrl }}/"
                 {{- end}}
             - name: PURIS_ALLOWED-ORIGINS
-              value: "{{ .Values.backend.puris.allowedOrigins | default .Values.frontend.puris.baseUrl }}"
+                # remove backslash if given
+                {{- $baseUrl := trimSuffix "/" .Values.frontend.puris.baseUrl }}
+                {{- $allowedOrigins := .Values.backend.puris.allowedOrigins }}
+                {{- if not $allowedOrigins }}
+                  {{- if .Values.frontend.ingress.tls }}
+              value: "https://{{ $baseUrl }}"
+                  {{- else }}
+              value: "http://{{ $baseUrl }}"
+                  {{- end }}
+                {{- else }}
+              value: "{{ $allowedOrigins }}"
+                {{- end }}
             - name: PURIS_ITEMSTOCKSUBMODEL_APIASSETID
               value: "{{ .Values.backend.puris.itemstocksubmodel.apiassetid }}"
             - name: PURIS_PRODUCTIONSUBMODEL_APIASSETID


### PR DESCRIPTION
## Description

- added logic to add the appropriate http protocol to the deaulft value for allowed origin

resolves #887 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [ ] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
