### PR TITLE
feat: rework validation logic to return errors as strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,14 @@ The following Changelog lists the changes. Please refer to the [documentation](d
 
 The **need for configuration updates** is **marked bold**.
 
+### Added
+
+* Implement Excel imports through API ([#897](https://github.com/eclipse-tractusx/puris/pull/897/))
+
 ### Changed
 
 * Use the frontend's existing keycloak authentication to authorize backend calls ([#896](https://github.com/eclipse-tractusx/puris/pull/896)) (**moved IDP configuration and IDP no longer optional**)
-* Implement Excel imports through API ([#897](https://github.com/eclipse-tractusx/puris/pull/897/))
+* Rework validation logic to return detailed error messages ([#898](https://github.com/eclipse-tractusx/puris/pull/898))
 
 ## [v3.1.0](https://github.com/eclipse-tractusx/puris/releases/tag/3.1.0)
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/demand/logic/services/DemandService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/demand/logic/services/DemandService.java
@@ -19,10 +19,6 @@ SPDX-License-Identifier: Apache-2.0
 */
 package org.eclipse.tractusx.puris.backend.demand.logic.services;
 
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.ZoneOffset;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/production/logic/service/OwnProductionService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/production/logic/service/OwnProductionService.java
@@ -20,6 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 
 package org.eclipse.tractusx.puris.backend.production.logic.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
@@ -68,23 +69,42 @@ public class OwnProductionService extends ProductionService<OwnProduction> {
     }
 
     public boolean validate(OwnProduction production) {
+        return validateWithDetails(production).isEmpty();
+    }
+
+    public List<String> validateWithDetails(OwnProduction production) {
+        List<String> errors = new ArrayList<>();
         Partner ownPartnerEntity = partnerService.getOwnPartnerEntity();
-        return 
-            production.getQuantity() > 0 && 
-            production.getMeasurementUnit() != null && 
-            production.getEstimatedTimeOfCompletion() != null && 
-            production.getMaterial() != null &&
-            production.getPartner() != null &&
-            !production.getPartner().equals(ownPartnerEntity) &&
-            production.getProductionSiteBpns() != null &&
-            ownPartnerEntity.getSites().stream().anyMatch(site -> site.getBpns().equals(production.getProductionSiteBpns())) &&
-            ((
-                production.getCustomerOrderNumber() != null && 
-                production.getCustomerOrderPositionNumber() != null
-            ) || (
-                production.getCustomerOrderNumber() == null && 
-                production.getCustomerOrderPositionNumber() == null && 
-                production.getSupplierOrderNumber() == null
-            ));
+
+        if (production.getQuantity() <= 0) {
+            errors.add("Quantity must be greater than 0.");
+        }
+        if (production.getMeasurementUnit() == null) {
+            errors.add("Missing measurement unit.");
+        }
+        if (production.getEstimatedTimeOfCompletion() == null) {
+            errors.add("Missing estimated time of completion.");
+        }
+        if (production.getMaterial() == null) {
+            errors.add("Missing material.");
+        }
+        if (production.getPartner() == null) {
+            errors.add("Missing partner.");
+        }
+        if (production.getPartner().equals(ownPartnerEntity)) {
+            errors.add("Partner cannot be the same as own partner entity.");
+        }
+        if (production.getProductionSiteBpns() == null) {
+            errors.add("Missing production site BPNS.");
+        }
+        if (ownPartnerEntity.getSites().stream().noneMatch(site -> site.getBpns().equals(production.getProductionSiteBpns()))) {
+            errors.add("Production site BPNS must match one of the own partner entity's site BPNS.");
+        }
+        if (!((production.getCustomerOrderNumber() != null && production.getCustomerOrderPositionNumber() != null) || 
+            (production.getCustomerOrderNumber() == null && production.getCustomerOrderPositionNumber() == null && production.getSupplierOrderNumber() == null))) {
+            errors.add("Customer order number and position number must both be null or both be non-null, and supplier order number must be null if both are null.");
+        }
+
+        return errors;
     }
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/service/MaterialItemStockService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/service/MaterialItemStockService.java
@@ -21,6 +21,10 @@
 package org.eclipse.tractusx.puris.backend.stock.logic.service;
 
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.MaterialPartnerRelationService;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.PartnerService;
 import org.eclipse.tractusx.puris.backend.stock.domain.model.MaterialItemStock;
@@ -41,7 +45,15 @@ public class MaterialItemStockService extends ItemStockService<MaterialItemStock
 
     @Override
     public boolean validate(MaterialItemStock materialItemStock) {
-        return basicValidation(materialItemStock) && validateLocalStock(materialItemStock)
-            && validateMaterialItemStock(materialItemStock);
+        return basicValidation(materialItemStock).isEmpty() && validateLocalStock(materialItemStock).isEmpty()
+            && validateMaterialItemStock(materialItemStock).isEmpty();
+    }
+
+    public List<String> validateWithDetails(MaterialItemStock materialItemStock) {
+        List<String> errors = new ArrayList<>();
+        errors.addAll(basicValidation(materialItemStock));
+        errors.addAll(validateLocalStock(materialItemStock));
+        errors.addAll(validateMaterialItemStock(materialItemStock));
+        return errors;
     }
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/service/ProductItemStockService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/service/ProductItemStockService.java
@@ -22,8 +22,13 @@ package org.eclipse.tractusx.puris.backend.stock.logic.service;
 
 
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.MaterialPartnerRelationService;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.PartnerService;
+import org.eclipse.tractusx.puris.backend.stock.domain.model.MaterialItemStock;
 import org.eclipse.tractusx.puris.backend.stock.domain.model.ProductItemStock;
 import org.eclipse.tractusx.puris.backend.stock.domain.repository.ProductItemStockRepository;
 import org.springframework.stereotype.Service;
@@ -42,7 +47,15 @@ public class ProductItemStockService extends ItemStockService<ProductItemStock> 
 
     @Override
     public boolean validate(ProductItemStock productItemStock) {
-        return basicValidation(productItemStock) && validateLocalStock(productItemStock)
-            && validateProductItemStock(productItemStock);
+        return basicValidation(productItemStock).isEmpty() && validateLocalStock(productItemStock).isEmpty()
+            && validateProductItemStock(productItemStock).isEmpty();
+    }
+
+    public List<String> validateWithDetails(ProductItemStock productItemStock) {
+        List<String> errors = new ArrayList<>();
+        errors.addAll(basicValidation(productItemStock));
+        errors.addAll(validateLocalStock(productItemStock));
+        errors.addAll(validateProductItemStock(productItemStock));
+        return errors;
     }
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/service/ReportedMaterialItemStockService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/service/ReportedMaterialItemStockService.java
@@ -40,6 +40,6 @@ public class ReportedMaterialItemStockService extends ItemStockService<ReportedM
 
     @Override
     public boolean validate(ReportedMaterialItemStock itemStock) {
-        return basicValidation(itemStock) && validateMaterialItemStock(itemStock) && validateRemoteStock(itemStock);
+        return basicValidation(itemStock).isEmpty() && validateMaterialItemStock(itemStock).isEmpty() && validateRemoteStock(itemStock).isEmpty();
     }
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/service/ReportedProductItemStockService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/service/ReportedProductItemStockService.java
@@ -41,6 +41,6 @@ public class ReportedProductItemStockService extends ItemStockService<ReportedPr
 
     @Override
     public boolean validate(ReportedProductItemStock itemStock) {
-        return basicValidation(itemStock) && validateProductItemStock(itemStock) && validateRemoteStock(itemStock);
+        return basicValidation(itemStock).isEmpty() && validateProductItemStock(itemStock).isEmpty() && validateRemoteStock(itemStock).isEmpty();
     }
 }


### PR DESCRIPTION
## Description

- refactored validation for Demand, Production, Delivery and Stock to return detailed error messages
- the data import API now returns the detailed errors
- refined swagger annotations for data import

resolves #906 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [ ] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
