### PR TITLE
Notification resolution bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ The **need for configuration updates** is **marked bold**.
 * Updated open API ([#929](https://github.com/eclipse-tractusx/puris/pull/929))
 * Updated dependencies to resolve high and critical security vulnerabilities ([#932](https://github.com/eclipse-tractusx/puris/pull/932))
 
+### Fixes
+
+* Fixed notification resolution validation issue ([#952](https://github.com/eclipse-tractusx/puris/pull/952))
+
 ## v3.2.0
 
 The following Changelog lists the changes. Please refer to the [documentation](docs/README.md) for configuration needs and understanding the concept changes.

--- a/frontend/src/features/notifications/components/NotificationInformationModal.tsx
+++ b/frontend/src/features/notifications/components/NotificationInformationModal.tsx
@@ -179,7 +179,8 @@ export const DemandCapacityNotificationInformationModal = ({
     }, [open, demandCapacityNotification, forwardData]);
 
     const handleSaveClick = () => {
-        if (!isValidDemandCapacityNotification(temporaryDemandCapacityNotification)) {
+        if (!isValidDemandCapacityNotification(temporaryDemandCapacityNotification) ||
+        !temporaryDemandCapacityNotification.text?.trim()) {
             setFormError(true);
             return;
         }
@@ -436,8 +437,8 @@ export const DemandCapacityNotificationInformationModal = ({
                                                 text: event.target.value,
                                             })
                                         }
-                                        error={formError && !temporaryDemandCapacityNotification?.text}
-                                        className={formError && !temporaryDemandCapacityNotification?.text ? 'error-textarea' : ''}
+                                        error={formError && !temporaryDemandCapacityNotification?.text?.trim()}
+                                        className={formError && !temporaryDemandCapacityNotification?.text?.trim() ? 'error-textarea' : ''}
                                     />
                                 </Grid>
                                 <Typography  variant="body3" sx={{color: theme.palette.warning.main, py: 1}} ><ReportProblem></ReportProblem> These notes will be shared with the selected partner. Please do not include sensitive data of third parties.</Typography>

--- a/frontend/src/features/notifications/components/NotificationResolutionMessageModal.tsx
+++ b/frontend/src/features/notifications/components/NotificationResolutionMessageModal.tsx
@@ -55,7 +55,7 @@ export const DemandCapacityNotificationResolutionModal = ({
     }, [open]);
 
     const handleSaveClick = () => {
-        if (resolutionMessage === '') {
+        if (resolutionMessage === '' || !resolutionMessage?.trim()) {
             setFormError(true);
             return;
         }
@@ -69,7 +69,7 @@ export const DemandCapacityNotificationResolutionModal = ({
             affectedSitesBpnsRecipient: [],
             affectedSitesBpnsSender: [],
             affectedMaterialNumbers: [],
-            text: ''
+            text: null
         };
 
         putDemandAndCapacityNotification(updatedNotification)
@@ -115,8 +115,8 @@ export const DemandCapacityNotificationResolutionModal = ({
                                         id="resolvingMeasureDescription"
                                         value={resolutionMessage}
                                         onChange={(event) => setResolutionMessage(event.target.value)}
-                                        error={formError && !resolutionMessage}
-                                        className={formError && !resolutionMessage ? 'error-textarea' : ''}
+                                        error={formError && !resolutionMessage?.trim()}
+                                        className={formError && !resolutionMessage?.trim() ? 'error-textarea' : ''}
                                         placeholder="Your message"
                                     />
                                 </Grid>

--- a/frontend/src/models/types/data/demand-capacity-notification.ts
+++ b/frontend/src/models/types/data/demand-capacity-notification.ts
@@ -28,7 +28,7 @@ export type DemandCapacityNotification = {
     uuid: string,
     notificationId: string,
     sourceDisruptionId: string,
-    text: string,
+    text: string | null,
     partnerBpnl: BPNL,
     affectedMaterialNumbers: string[],
     leadingRootCause: LeadingRootCauseType,


### PR DESCRIPTION
## Description

- Fixed issue of not being able to resolve notification due to an empty text
- Added validation checks against only white spaces in both text and resolution message

Solves issue: #950 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
