### PR TITLE
chore: bump dtr to version 0.9.0-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ The **need for configuration updates** is **marked bold**.
 * Updated dependencies to resolve high and critical security vulnerabilities ([#932](https://github.com/eclipse-tractusx/puris/pull/932))
 * Updated User guide with the updated notification view and the new import page ([#933](https://github.com/eclipse-tractusx/puris/pull/933))
 * Updated Arc42 documentation ([#937](https://github.com/eclipse-tractusx/puris/pull/937))
-* Bump helm test workfow to new kubernetes version and latest q-gates puris version ([#938](https://github.com/eclipse-tractusx/puris/pull/938))>>>>>>> main
+* Bump helm test workfow to new kubernetes version and latest q-gates puris version ([#938](https://github.com/eclipse-tractusx/puris/pull/938))
 
 ### Version Bumps
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The **need for configuration updates** is **marked bold**.
 ### Fixes
 
 * Drop further security capabilities and apply default seccomp in chart's deployments ([#938](https://github.com/eclipse-tractusx/puris/pull/938))
+* Fixed notification resolution validation issue ([#952](https://github.com/eclipse-tractusx/puris/pull/952))
+* Fixed notification resolution start date validation ([#954](https://github.com/eclipse-tractusx/puris/pull/954))
 
 ### Chore
 
@@ -36,14 +38,9 @@ The **need for configuration updates** is **marked bold**.
 * Updated Arc42 documentation ([#937](https://github.com/eclipse-tractusx/puris/pull/937))
 * Bump helm test workfow to new kubernetes version and latest q-gates puris version ([#938](https://github.com/eclipse-tractusx/puris/pull/938))>>>>>>> main
 
-### Fixes
+### Version Bumps
 
-* Fixed notification resolution validation issue ([#952](https://github.com/eclipse-tractusx/puris/pull/952))
-
-### Fixes
-
-* Fixed notification resolution validation issue ([#952](https://github.com/eclipse-tractusx/puris/pull/952))
-* Fixed notification resolution start date validation ([#954](https://github.com/eclipse-tractusx/puris/pull/954))
+* Digital Twin Registry to 0.9.0-RC1 ([#957](https://github.com/eclipse-tractusx/puris/pull/957))
 
 ## v3.2.0
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Beside the dependencies provided in the Helm Chart, the following dependencies h
 | Application                                                                                                       | App Version | Chart Version |
 | ----------------------------------------------------------------------------------------------------------------- | ----------- | ------------- |
 | [Tractus-X Connector](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector)       | 0.10.0      | 0.10.0        |
-| [Digital Twin Registry](https://github.com/eclipse-tractusx/sldt-digital-twin-registry/tree/main/charts/registry) | 0.8.0       | 0.8.0         |
+| [Digital Twin Registry](https://github.com/eclipse-tractusx/sldt-digital-twin-registry/tree/main/charts/registry) | 0.9.0       | 0.9.0         |
 
 ## Overview of Implemented Standards
 

--- a/local/docker-compose.yaml
+++ b/local/docker-compose.yaml
@@ -97,7 +97,7 @@ services:
       - "host.docker.internal:host-gateway" # Adjusts container's host file to allow for communication with docker-host machine
 
   dtr-customer:
-    image: tractusx/sldt-digital-twin-registry:0.8.0-RC1
+    image: tractusx/sldt-digital-twin-registry:0.9.0-RC1
     container_name: dtr-customer
     depends_on:
       postgres-all:
@@ -285,7 +285,7 @@ services:
       - "host.docker.internal:host-gateway" # Adjusts container's host file to allow for communication with docker-host machine
 
   dtr-supplier:
-    image: tractusx/sldt-digital-twin-registry:0.8.0-RC1
+    image: tractusx/sldt-digital-twin-registry:0.9.0-RC1
     container_name: dtr-supplier
     depends_on:
       postgres-all:


### PR DESCRIPTION
## Description

- bump DTR version to 0.9.0-RC1

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] ~If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).~
