### PR TITLE
fix: added import to sidebar test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The **need for configuration updates** is **marked bold**.
 * Drop further security capabilities and apply default seccomp in chart's deployments ([#938](https://github.com/eclipse-tractusx/puris/pull/938))
 * Fixed notification resolution validation issue ([#952](https://github.com/eclipse-tractusx/puris/pull/952))
 * Fixed notification resolution start date validation ([#954](https://github.com/eclipse-tractusx/puris/pull/954))
+* Fixed E2E test for sidebar ([#958](https://github.com/eclipse-tractusx/puris/pull/958))
 
 ### Chore
 

--- a/local/testing/e2e/cypress/e2e/general/sidebar.spec.cy.js
+++ b/local/testing/e2e/cypress/e2e/general/sidebar.spec.cy.js
@@ -26,7 +26,7 @@ describe("sidebar", () => {
         cy.wait(1000);
     });
 
-    it("shows 7 menu items and one is selected", () => {
+    it("shows 9 menu items and one is selected", () => {
         cy.fixture("menu.json").then((menu) => {
             cy.getByTestId("sidebar").should("exist");
             cy.getByTestIdContains("sidebar-menu-item").should(

--- a/local/testing/e2e/cypress/fixtures/menu.json
+++ b/local/testing/e2e/cypress/fixtures/menu.json
@@ -10,6 +10,11 @@
     "iconid": "NotificationsOutlinedIcon"
   },
   {
+    "target": "/import",
+    "name": "Import",
+    "iconid": "ExitToAppOutlinedIcon"
+  },
+  {
     "target": "/catalog",
     "name": "Catalog",
     "iconid": "AutoStoriesOutlinedIcon"


### PR DESCRIPTION
## Description

- fixed sidebar test to include "import" menu item

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [ ] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
