### PR TITLE
fix: excel import validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The **need for configuration updates** is **marked bold**.
 * Drop further security capabilities and apply default seccomp in chart's deployments ([#938](https://github.com/eclipse-tractusx/puris/pull/938))
 * Fixed notification resolution validation issue ([#952](https://github.com/eclipse-tractusx/puris/pull/952))
 * Fixed notification resolution start date validation ([#954](https://github.com/eclipse-tractusx/puris/pull/954))
+* Fixed import bugs for empty rows and duplicate stocks ([#961](https://github.com/eclipse-tractusx/puris/pull/961))
 
 ### Chore
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,57 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v3.3.1
+
+The following Changelog lists the changes. Please refer to the [documentation](docs/README.md) for configuration needs and understanding the concept changes.
+
+The **need for configuration updates** is **marked bold**.
+
+### Fixes
+
+* Fixed import bugs for empty rows and duplicate stocks ([#961](https://github.com/eclipse-tractusx/puris/pull/961))
+
+### Known Knowns
+
+#### Upgradeability
+
+Data base migrations are performed but assets.
+
+#### Data Sovereignty
+
+For productive use the following enhancements are encouraged
+
+* User FrontEnd available: Role Company Admin is able to query catalogue and see negotiations and transfers But company rules / policies need to be configured upfront in backend (via postman) to enable automatic contract negotiations, responsibility lies with Company Admin role  
+  --> add section in the User Manual describing this and the (legal) importance and responsibility behind defining these rules
+* Currently only one standard policy per reg. connector / customer instance is supported (more precisely one for DTR, one for all submodels), negotiation happens automatically based on this  
+  --> enhance option to select partner and define specific policies (to be planned in context of BPDM Integration)  
+  --> UI for specific configuration by dedicated role (e.g. Comp Admin) and more flexible policy configuration (withoutv code changes) is needed
+* As a non-Admin user I do not have ability to view policies in detail  
+  --> transparency for users when interacting with and requesting / consuming data via dashboard / views on underlying usage policies to be enhanced
+* ContractReference Constraint or configuration of policies specific to one partner only has notnot implemented  
+  --> clarification of potential reference to "PURIS standard contract" and enabling of ContractReference for 24.08.
+* unclear meaning of different stati in negotations  
+  --> add view of successfull contract agreeements wrt which data have been closed
+* current logging only done on info level  
+  --> enhance logging of policies (currently only available at debug level)
+* in case of non-matching policies (tested in various scenarios) no negotiation takes place  
+  --> enhance visualization or specific Error message to user
+* no validation of the Schema "profile": "cx-policy:profile2405" (required to ensure interop with other PURIS apps)
+
+#### Styleguide
+
+##### Overall
+
+* Brief description at the top of each page describing content would be nice for better user experience.
+
+##### Catalog
+
+* No action possible -> unclear to user when and how user will consume an offer
+
+##### Negotiations
+
+* Add filters for transparency (bpnl, state)
+
 ## v3.3.0
 
 The following Changelog lists the changes. Please refer to the [documentation](docs/README.md) for configuration needs and understanding the concept changes.
@@ -30,7 +81,6 @@ The **need for configuration updates** is **marked bold**.
 * Fixed notification resolution validation issue ([#952](https://github.com/eclipse-tractusx/puris/pull/952))
 * Fixed notification resolution start date validation ([#954](https://github.com/eclipse-tractusx/puris/pull/954))
 * Fixed E2E test for sidebar ([#958](https://github.com/eclipse-tractusx/puris/pull/958))
-* Fixed import bugs for empty rows and duplicate stocks ([#961](https://github.com/eclipse-tractusx/puris/pull/961))
 
 ### Chore
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/file/logic/service/ExcelService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/file/logic/service/ExcelService.java
@@ -174,6 +174,9 @@ public class ExcelService {
             List<String> rowErrors = new ArrayList<>();
             Row row = rowIterator.next();
             rowIndex++;
+            if (isRowEmpty(row)) {
+                continue;
+            }
             try {
                 String ownMaterialNumber = getStringCellValue(row.getCell(0));
                 String partnerBpnl = getStringCellValue(row.getCell(1));
@@ -278,6 +281,9 @@ public class ExcelService {
             List<String> rowErrors = new ArrayList<>();
             Row row = rowIterator.next();
             rowIndex++;
+            if (isRowEmpty(row)) {
+                continue;
+            }
             try {
                 String ownMaterialNumber = getStringCellValue(row.getCell(0));
                 String partnerBpnl = getStringCellValue(row.getCell(1));
@@ -375,6 +381,9 @@ public class ExcelService {
             List<String> rowErrors = new ArrayList<>();
             Row row = rowIterator.next();
             rowIndex++;
+            if (isRowEmpty(row)) {
+                continue;
+            }
             try {
                 String ownMaterialNumber = getStringCellValue(row.getCell(0));
                 String partnerBpnl = getStringCellValue(row.getCell(1));
@@ -513,6 +522,9 @@ public class ExcelService {
             List<String> rowErrors = new ArrayList<>();
             Row row = rowIterator.next();
             rowIndex++;
+            if (isRowEmpty(row)) {
+                continue;
+            }
             try {
                 String ownMaterialNumber = getStringCellValue(row.getCell(0));
                 String partnerBpnl = getStringCellValue(row.getCell(1));
@@ -716,5 +728,23 @@ public class ExcelService {
             }
         }
         return errors;
+    }
+
+    /**
+     * Checks if a given row is empty (i.e. all cells are blank or null).
+     * @param row the row to check
+     * @return true if the row is empty, false otherwise
+     */
+    private boolean isRowEmpty(Row row) {
+        if (row == null) return true;
+        for (Cell cell : row) {
+            if (cell != null && cell.getCellType() != CellType.BLANK) {
+                String value = getStringCellValue(cell);
+                if (value != null && !value.trim().isEmpty()) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/ItemStock.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/ItemStock.java
@@ -117,6 +117,7 @@ public abstract class ItemStock {
                 this.getPartner().getUuid().equals(that.getPartner().getUuid()) &&
                 this.getLocationBpns().equals(that.getLocationBpns()) &&
                 this.getLocationBpna().equals(that.getLocationBpna()) &&
+                this.isBlocked == that.isBlocked &&
                 Objects.equals(this.getNonNullSupplierOrderId(), that.getNonNullSupplierOrderId()) &&
                 Objects.equals(this.getNonNullCustomerOrderId(), that.getNonNullCustomerOrderId()) &&
                 Objects.equals(this.getNonNullCustomerOrderPositionId(), that.getNonNullCustomerOrderPositionId());


### PR DESCRIPTION
## Description

- fixed a bug that prevents documents from being uploaded if a previously filled row is emptied (but not deleted)
- updated the `equals` method for item stock to consider stocks as inequal if the `isBlocked` value is different 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] ~~If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).~~
