### PR TITLE
fix: stocks always including values for all materials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v3.4.1
+## v3.5.0
 
 The following Changelog lists the changes. Please refer to the [documentation](docs/README.md) for configuration needs and understanding the concept changes.
 
@@ -24,6 +24,7 @@ The **need for configuration updates** is **marked bold**.
 - Fixed invalid framework policy in the bruno DTR setup ([#967](https://github.com/eclipse-tractusx/puris/pull/967))
 - Fixed Modal dialogs not updating when deleting entries for materials ([#984](https://github.com/eclipse-tractusx/puris/pull/984))
 - Allow 0 values in all reported and most own data to improve application resiliency ([#991](https://github.com/eclipse-tractusx/puris/pull/991))
+- Fixed product and material stocks always including values for all materials ([#994](https://github.com/eclipse-tractusx/puris/pull/994))
 
 ## v3.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v3.5.0
+## v4.0.0
 
 The following Changelog lists the changes. Please refer to the [documentation](docs/README.md) for configuration needs and understanding the concept changes.
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <groupId>org.eclipse.tractusx.puris</groupId>
     <artifactId>puris-backend</artifactId>
-    <version>3.5.0</version>
+    <version>4.0.0</version>
     <name>puris-backend</name>
     <description>PURIS Backend</description>
     <properties>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <groupId>org.eclipse.tractusx.puris</groupId>
     <artifactId>puris-backend</artifactId>
-    <version>3.4.1</version>
+    <version>3.5.0</version>
     <name>puris-backend</name>
     <description>PURIS Backend</description>
     <properties>

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/controller/StockViewController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/controller/StockViewController.java
@@ -168,9 +168,10 @@ public class StockViewController {
 
     @GetMapping("product-stocks")
     @ResponseBody
-    @Operation(description = "Returns a list of all product-stocks")
-    public List<ProductStockDto> getProductStocks() {
-        return productItemStockService.findAll().stream()
+    @Operation(summary = "Get all material stocks for the given Material", description = "Get all material stocks for the given material number.")
+    public List<ProductStockDto> getProductStocks(@Parameter(description = "encoded in base64") String ownMaterialNumber) {
+        ownMaterialNumber = new String(Base64.getDecoder().decode(ownMaterialNumber));
+        return productItemStockService.findByOwnMaterialNumber(ownMaterialNumber).stream()
             .map(this::convertToDto)
             .collect(Collectors.toList());
     }
@@ -342,9 +343,10 @@ public class StockViewController {
 
     @GetMapping("material-stocks")
     @ResponseBody
-    @Operation(description = "Returns a list of all material-stocks")
-    public List<MaterialStockDto> getMaterialStocks() {
-        List<MaterialStockDto> allMaterialStocks = materialItemStockService.findAll().stream()
+    @Operation(summary = "Get all material stocks for the given Material", description = "Get all material stocks for the given material number.")
+    public List<MaterialStockDto> getMaterialStocks(@Parameter(description = "encoded in base64") String ownMaterialNumber) {
+        ownMaterialNumber = new String(Base64.getDecoder().decode(ownMaterialNumber));
+        List<MaterialStockDto> allMaterialStocks = materialItemStockService.findByOwnMaterialNumber(ownMaterialNumber).stream()
             .map(this::convertToDto)
             .collect(Collectors.toList());
         return allMaterialStocks;

--- a/charts/puris/Chart.yaml
+++ b/charts/puris/Chart.yaml
@@ -41,4 +41,4 @@ version: 4.2.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.4.1"
+appVersion: "3.5.0"

--- a/charts/puris/Chart.yaml
+++ b/charts/puris/Chart.yaml
@@ -35,10 +35,10 @@ dependencies:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.2.1
+version: 5.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.5.0"
+appVersion: "4.0.0"

--- a/charts/puris/README.md
+++ b/charts/puris/README.md
@@ -1,6 +1,6 @@
 # puris
 
-![Version: 4.2.1](https://img.shields.io/badge/Version-4.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.4.1](https://img.shields.io/badge/AppVersion-3.4.1-informational?style=flat-square)
+![Version: 5.0.0](https://img.shields.io/badge/Version-4.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.0](https://img.shields.io/badge/AppVersion-3.4.1-informational?style=flat-square)
 
 A helm chart for Kubernetes deployment of PURIS
 

--- a/docs/admin/Migration_Guide.md
+++ b/docs/admin/Migration_Guide.md
@@ -4,6 +4,10 @@ This migration guide is based on the `chartVersion` of the chart that also bumps
 
 <!-- TOC -->
 - [Migration Guide](#migration-guide)
+  - [Version 4.2.x to 5.0.x](#version-42x-to-50x)
+    - [StockView Controller Needs Mandatory Parameter for Routes material-stocks and product-stocks](#stockview-controller-needs-mandatory-parameter-for-routes-material-stocks-and-product-stocks)
+  - [Version 4.1.x to 4.2.x](#version-41x-to-42x)
+    - [Suppress Contract Creation for Digital Twin Registry (DTR)](#suppress-contract-creation-for-digital-twin-registry-dtr)
   - [Version 4.0.x to 4.1.x](#version-40x-to-41x)
     - [Database changes to support new notification functionality](#database-changes-to-support-new-notification-functionality)
   - [Version 3.0.x to 4.0.x](#version-30x-to-40x)
@@ -51,6 +55,16 @@ This migration guide is based on the `chartVersion` of the chart that also bumps
 > 
 > - Deploying an older version of the software may have used an older postgresql version. This is NOT applicable for the PURIS charts.
 > - The community is working out on how to resolve the issue.
+
+## Version 4.2.x to 5.0.x
+
+### StockView Controller Needs Mandatory Parameter for Routes material-stocks and product-stocks
+
+In case you made use of the backend routes `stockView/material-stocks` or `stockView/product-stocks`, both now need a mandatory parameter `ownMaterialNumber` accepting the base64 encoded material number (same as for production, demand and delivery). This is done to harmonize the API and fix [issue#979](https://github.com/eclipse-tractusx/puris/issues/979).
+
+Due to low usage volumes, we decided to not keep this part downward compatible.
+
+Please refer to the swagger-ui hosted at `your-backend-address/catena/swagger-ui/index.html` or the [latest version hosted at the api hub.](https://eclipse-tractusx.github.io/api-hub/puris/)
 
 ## Version 4.1.x to 4.2.x
 

--- a/docs/api/openAPI.yaml
+++ b/docs/api/openAPI.yaml
@@ -1376,7 +1376,7 @@ components:
       type: apiKey
 info:
   title: PURIS FOSS Open API
-  version: 3.3.0
+  version: 4.0.0
 openapi: 3.1.0
 paths:
   /days-of-supply/customer:
@@ -3661,8 +3661,17 @@ paths:
       - stock-view-controller
   /stockView/material-stocks:
     get:
-      description: Returns a list of all material-stocks
+      description: Get all material stocks for the given material number.
       operationId: getMaterialStocks
+      parameters:
+      - description: encoded in base64
+        in: query
+        name: ownMaterialNumber
+        required: true
+        schema:
+          additionalProperties: false
+          maxItems: 50
+          type: string
       responses:
         '200':
           content:
@@ -3674,6 +3683,7 @@ paths:
                 maxItems: 50
                 type: array
           description: OK
+      summary: Get all material stocks for the given Material
       tags:
       - stock-view-controller
     post:
@@ -3805,8 +3815,17 @@ paths:
       - stock-view-controller
   /stockView/product-stocks:
     get:
-      description: Returns a list of all product-stocks
+      description: Get all material stocks for the given material number.
       operationId: getProductStocks
+      parameters:
+      - description: encoded in base64
+        in: query
+        name: ownMaterialNumber
+        required: true
+        schema:
+          additionalProperties: false
+          maxItems: 50
+          type: string
       responses:
         '200':
           content:
@@ -3818,6 +3837,7 @@ paths:
                 maxItems: 50
                 type: array
           description: OK
+      summary: Get all material stocks for the given Material
       tags:
       - stock-view-controller
     post:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "puris-frontend",
-    "version": "3.4.1",
+    "version": "4.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "puris-frontend",
-            "version": "3.4.1",
+            "version": "4.0.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@catena-x/portal-shared-components": "^2.1.31",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
     "name": "puris-frontend",
     "description": "Puris frontend",
     "license": "Apache-2.0",
-    "version": "3.5.0",
+    "version": "4.0.0",
     "type": "module",
     "scripts": {
         "dev": "vite --host --mode customer --port 5173",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
     "name": "puris-frontend",
     "description": "Puris frontend",
     "license": "Apache-2.0",
-    "version": "3.4.1",
+    "version": "3.5.0",
     "type": "module",
     "scripts": {
         "dev": "vite --host --mode customer --port 5173",

--- a/frontend/src/features/material-details/hooks/useMaterialDetails.ts
+++ b/frontend/src/features/material-details/hooks/useMaterialDetails.ts
@@ -53,7 +53,7 @@ export function useMaterialDetails(materialNumber: string, direction: DirectionT
     const { productions, isLoadingProductions, refreshProduction } = useProduction(materialNumber ?? null, null);
     const { demands, isLoadingDemands, refreshDemand } = useDemand(materialNumber ?? null, null);
     const { deliveries, isLoadingDeliveries, refreshDelivery } = useDelivery(materialNumber ?? null, null);
-    const { stocks, isLoadingStocks, refreshStocks } = useStocks(direction === 'INBOUND' ? 'material' : 'product');
+    const { stocks, isLoadingStocks, refreshStocks } = useStocks(direction === 'INBOUND' ? 'material' : 'product', materialNumber);
     const { supplies, isLoadingSupply, refreshSupply } = useDaysOfSupply(materialNumber, direction);
     const { partners, isLoadingPartners } = usePartners(direction === 'INBOUND' ? 'material' : 'product', materialNumber);
     const [expandablePartners, setExpandablePartners] = useState<Expandable<Partner>[]>([]);

--- a/frontend/src/features/stock-view/hooks/useStocks.ts
+++ b/frontend/src/features/stock-view/hooks/useStocks.ts
@@ -23,14 +23,15 @@ import { useFetch } from '@hooks/useFetch';
 import { Stock, StockType } from '@models/types/data/stock';
 
 
-export const useStocks = <T extends StockType>(type: T) => {
+export const useStocks = <T extends StockType>(type: T, ownMaterialNumber: string) => {
   const url = type === 'material' ? config.app.ENDPOINT_MATERIAL_STOCKS : config.app.ENDPOINT_PRODUCT_STOCKS;
+  const query = `?ownMaterialNumber=${btoa(ownMaterialNumber)}`;
   const {
       data: stocks,
       error: stocksError,
       isLoading: isLoadingStocks,
       refresh: refreshStocks,
-  } = useFetch<Stock[]>(config.app.BACKEND_BASE_URL + url);
+  } = useFetch<Stock[]>(config.app.BACKEND_BASE_URL + url + query);
   return {
       stocks,
       stocksError,

--- a/local/bruno/puris-integration-test/Test_01-MAD/01_02-Operational Data/Customer/Stock/Get Semiconductor Material Stock.bru
+++ b/local/bruno/puris-integration-test/Test_01-MAD/01_02-Operational Data/Customer/Stock/Get Semiconductor Material Stock.bru
@@ -5,13 +5,24 @@ meta {
 }
 
 get {
-  url: {{CUSTOMER_PURIS_BACKEND}}/catena/stockView/material-stocks
+  url: {{CUSTOMER_PURIS_BACKEND}}/catena/stockView/material-stocks?ownMaterialNumber={{B64_MNR_CUSTOMER}}
   body: none
   auth: none
 }
 
+params:query {
+  ownMaterialNumber: {{B64_MNR_CUSTOMER}}
+}
+
 headers {
   X-Api-Key: {{CUSTOMER_PURIS_BACKEND_API_KEY}}
+}
+
+script:pre-request {
+  var plain = bru.getEnvVar("MATERIAL_NUMBER_CUSTOMER")
+  var encoded = Buffer.from(plain).toString("base64")
+  bru.setVar("B64_MNR_CUSTOMER", encoded)
+  
 }
 
 tests {

--- a/local/bruno/puris-integration-test/Test_01-MAD/01_02-Operational Data/Customer/Stock/Get Semiconductor Material Stock.bru
+++ b/local/bruno/puris-integration-test/Test_01-MAD/01_02-Operational Data/Customer/Stock/Get Semiconductor Material Stock.bru
@@ -22,7 +22,6 @@ script:pre-request {
   var plain = bru.getEnvVar("MATERIAL_NUMBER_CUSTOMER")
   var encoded = Buffer.from(plain).toString("base64")
   bru.setVar("B64_MNR_CUSTOMER", encoded)
-  
 }
 
 tests {

--- a/local/bruno/puris-integration-test/Test_01-MAD/01_02-Operational Data/Supplier/Stock/Get Semiconductor Product Stocks.bru
+++ b/local/bruno/puris-integration-test/Test_01-MAD/01_02-Operational Data/Supplier/Stock/Get Semiconductor Product Stocks.bru
@@ -5,13 +5,23 @@ meta {
 }
 
 get {
-  url: {{SUPPLIER_PURIS_BACKEND}}/catena/stockView/product-stocks
+  url: {{SUPPLIER_PURIS_BACKEND}}/catena/stockView/product-stocks?ownMaterialNumber={{B64_MNR_SUPPLIER}}
   body: none
   auth: none
 }
 
+params:query {
+  ownMaterialNumber: {{B64_MNR_SUPPLIER}}
+}
+
 headers {
   X-Api-Key: {{SUPPLIER_PURIS_BACKEND_API_KEY}}
+}
+
+script:pre-request {
+  var plain = bru.getEnvVar("MATERIAL_NUMBER_SUPPLIER")
+  var encoded = Buffer.from(plain).toString("base64")
+  bru.setVar("B64_MNR_SUPPLIER", encoded)
 }
 
 tests {


### PR DESCRIPTION
## Description

- added `ownMaterialNumber` parameter to `stockView/material-stocks` and `stockView/product-stocks`
- added `ownMaterialNumber` parameter to `useStocks` hook
- adjusted bruno requests to accommodate the change

resolves #979 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
