### PR TITLE
chore: bump edc and dtr versions for 25.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The **need for configuration updates** is **marked bold**.
 
 - bump spring boot from 3.5.4 to 3.5.7 ([#1040](https://github.com/eclipse-tractusx/puris/pull/1040))
 - ci(quality-checks.yaml): configure notice file checks ([#1041](https://github.com/eclipse-tractusx/puris/pull/1041))
+- bump dtr version to 0.10.0-RC1 ([#1043](https://github.com/eclipse-tractusx/puris/pull/1043))
+- bump edc version to 0.10.2 ([#1043](https://github.com/eclipse-tractusx/puris/pull/1043))
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Beside the dependencies provided in the Helm Chart, the following dependencies h
 
 | Application                                                                                                       | App Version | Chart Version |
 | ----------------------------------------------------------------------------------------------------------------- | ----------- | ------------- |
-| [Tractus-X Connector](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector)       | 0.10.0      | 0.10.0        |
-| [Digital Twin Registry](https://github.com/eclipse-tractusx/sldt-digital-twin-registry/tree/main/charts/registry) | 0.9.0       | 0.9.0         |
+| [Tractus-X Connector](https://github.com/eclipse-tractusx/tractusx-edc/tree/main/charts/tractusx-connector)       | 0.10.2      | 0.10.2        |
+| [Digital Twin Registry](https://github.com/eclipse-tractusx/sldt-digital-twin-registry/tree/main/charts/registry) | 0.10.0      | 0.10.0        |
 
 ## Overview of Implemented Standards
 

--- a/local/docker-compose.yaml
+++ b/local/docker-compose.yaml
@@ -97,7 +97,7 @@ services:
       - "host.docker.internal:host-gateway" # Adjusts container's host file to allow for communication with docker-host machine
 
   dtr-customer:
-    image: tractusx/sldt-digital-twin-registry:0.9.0-RC1
+    image: tractusx/sldt-digital-twin-registry:0.10.0-RC1
     container_name: dtr-customer
     depends_on:
       postgres-all:
@@ -285,7 +285,7 @@ services:
       - "host.docker.internal:host-gateway" # Adjusts container's host file to allow for communication with docker-host machine
 
   dtr-supplier:
-    image: tractusx/sldt-digital-twin-registry:0.9.0-RC1
+    image: tractusx/sldt-digital-twin-registry:0.10.0-RC1
     container_name: dtr-supplier
     depends_on:
       postgres-all:

--- a/local/tractus-x-edc/docker-compose.yaml
+++ b/local/tractus-x-edc/docker-compose.yaml
@@ -21,13 +21,13 @@
 
 services:
   control-plane:
-    image: tractusx/edc-controlplane-postgresql-hashicorp-vault:0.10.0-rc2
+    image: tractusx/edc-controlplane-postgresql-hashicorp-vault:0.10.2
     volumes:
       - ./config/default/opentelemetry.properties:/app/opentelemetry.properties
       - ./config/default/logging.properties:/app/logging.properties
 
   data-plane:
-    image: tractusx/edc-dataplane-hashicorp-vault:0.10.0-rc2
+    image: tractusx/edc-dataplane-hashicorp-vault:0.10.2
     volumes:
       - ./config/default/opentelemetry.properties:/app/opentelemetry.properties
       - ./config/default/logging.properties:/app/logging.properties


### PR DESCRIPTION
## Description

- bumped EDC version to 0.10.2
- bumped DTR version to 0.10.0-RC1

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] ~~If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).~~
