### PR TITLE
fix: changed expected heading in e2e test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The **need for configuration updates** is **marked bold**.
 - don't fail during startup if own partner already exists ([#1062](https://github.com/eclipse-tractusx/puris/pull/1062))
 - in demo setup, skip setup if run has been performed before ([#1065](https://github.com/eclipse-tractusx/puris/pull/1065))
 - Improved documentation, added option for persitent containers and a .env file for bruno ([1024](https://github.com/eclipse-tractusx/puris/pull/1024))
+- fixed incorrect expected heading in E2E test suite ([#1057](https://github.com/eclipse-tractusx/puris/pull/1057))
 
 ### Known Knowns
 

--- a/local/testing/e2e/cypress/e2e/customer/material-details-view-data-display.spec.cy.js
+++ b/local/testing/e2e/cypress/e2e/customer/material-details-view-data-display.spec.cy.js
@@ -42,7 +42,7 @@ describe('material details view', () => {
                     cy.getByTestId('back-button').should('exist');
 
                     const informationType = direction === 'Inbound' ? 'Demand' : 'Production';
-                    cy.contains(`${informationType} Information for ${material.name} (${direction})`).should('exist');
+                    cy.contains(`${informationType} Information for ${material.name} (${material.ownMaterialNumber}), (${direction})`).should('exist');
 
                     // check if the correct action buttons are visible
                     let applicablePartners = [];


### PR DESCRIPTION
## Description

- fixed a small bug in the Cypress tests

resolves #1056 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
