### PR TITLE
feat(frontend): add site designations to material relations setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The **need for configuration updates** is **marked bold**.
 - Added component to copy text to clipboard for puris frontend ([#1058](https://github.com/eclipse-tractusx/puris/pull/1058))
 - Added version to about license ([#1067](https://github.com/eclipse-tractusx/puris/pull/1067))
 - Added site designations per material partner relationhip ([#1061](https://github.com/eclipse-tractusx/puris/pull/1061))
+- Added site designations per material partner relationhip in the frontend and display in table ([#1073](https://github.com/eclipse-tractusx/puris/pull/1073))
 
 ### Changed
 

--- a/frontend/src/features/master-data/components/MasterDataView.tsx
+++ b/frontend/src/features/master-data/components/MasterDataView.tsx
@@ -34,12 +34,35 @@ import { Add } from '@mui/icons-material';
 import { MaterialPartnerRelation } from '@models/types/data/material-partner-relation';
 import { getAllMaterialPartnerRelations, postMaterialPartnerRelation } from '@services/material-partner-relation-service';
 import { MaterialPartnerRelationModal } from './MaterialpartnerRelationModal';
+import { BPNS } from '@models/types/edc/bpn';
 
 const getDirectionLabel = (row: Material): string => {
     if (row.materialFlag && row.productFlag) return 'Bidirectional';
     if (row.materialFlag) return 'Inbound';
     if (row.productFlag) return 'Outbound';
     return 'Unknown';
+};
+
+const renderSitesBpnsCell = (sitesBpns?: BPNS[]) => {
+    if (!sitesBpns || sitesBpns.length === 0) {
+        return ( <Box display="flex" alignItems="center" justifyContent="center" width="100%" height="100%">-</Box> );
+    }
+    return (
+        <Box
+            display="flex"
+            flexDirection="column"
+            justifyContent="center"
+            width="100%"
+            height="100%"
+            sx={{ whiteSpace: 'normal', wordBreak: 'break-word', py: 0.5 }}
+        >
+        {sitesBpns.map((siteBpn) => (
+            <Box key={siteBpn} sx={{ lineHeight: 1.2, mb: 0.5, '&:last-of-type': { mb: 0 } }}>
+                {siteBpn}
+            </Box>
+        ))}
+        </Box>
+    );
 };
 
 const createParnerColumns = () => {
@@ -235,6 +258,20 @@ export const MasterDataView = () => {
                             field: 'partnerBuysMaterial',
                             flex: 1,
                             valueGetter: (params) => (params.row.partnerBuysMaterial ? 'Yes' : 'No'),
+                        },
+                        {
+                            field: 'ownDemandingSiteBpnss',
+                            headerName: 'Demanding Sites',
+                            flex: 2,
+                            sortable: false,
+                            renderCell: (data: { row: MaterialPartnerRelation }) => renderSitesBpnsCell(data.row.ownDemandingSiteBpnss),
+                        },
+                        {
+                            field: 'ownProducingSiteBpnss',
+                            headerName: 'Producing Sites',
+                            flex: 2,
+                            sortable: false,
+                            renderCell: (data: { row: MaterialPartnerRelation }) => renderSitesBpnsCell(data.row.ownProducingSiteBpnss),
                         },
                     ]}
                     rows={mprs ?? []}

--- a/frontend/src/features/master-data/components/MaterialpartnerRelationModal.tsx
+++ b/frontend/src/features/master-data/components/MaterialpartnerRelationModal.tsx
@@ -123,7 +123,7 @@ export const MaterialPartnerRelationModal = ({ open, materials, partners, mprs, 
         handleClose();
     };
 
-    const showStockingSites = !!temporaryMpr.partnerSuppliesMaterial;
+    const showDemandingSite = !!temporaryMpr.partnerSuppliesMaterial;
     const showProducingSites = !!temporaryMpr.partnerBuysMaterial;
 
     return (
@@ -226,7 +226,7 @@ export const MaterialPartnerRelationModal = ({ open, materials, partners, mprs, 
                                 </Stack>
                             </Stack>
                         </Grid>
-                        {showStockingSites && (
+                        {showDemandingSite && (
                             <Grid item xs={12}>
                                 <InputLabel>Demanding Sites</InputLabel>
                                 <Autocomplete

--- a/frontend/src/features/master-data/components/MaterialpartnerRelationModal.tsx
+++ b/frontend/src/features/master-data/components/MaterialpartnerRelationModal.tsx
@@ -88,7 +88,7 @@ export const MaterialPartnerRelationModal = ({ open, materials, partners, mprs, 
             ownMaterialNumber: value?.ownMaterialNumber ?? '',
             partnerSuppliesMaterial: value?.materialFlag,
             partnerBuysMaterial: value?.productFlag,
-            ...(supplies ? {} : { ownStockingSiteBpnss: [] }),
+            ...(supplies ? {} : { ownDemandingSiteBpnss: [] }),
             ...(buys ? {} : { ownProducingSiteBpnss: [] }),
         });
     };
@@ -160,7 +160,7 @@ export const MaterialPartnerRelationModal = ({ open, materials, partners, mprs, 
                                     setTemporaryMpr((prev) => ({
                                         ...prev,
                                         partnerBpnl: value?.bpnl ?? '',
-                                        ownStockingSiteBpnss: [],
+                                        ownDemandingSiteBpnss: [],
                                         ownProducingSiteBpnss: [],
                                     }))
                                 }
@@ -203,7 +203,7 @@ export const MaterialPartnerRelationModal = ({ open, materials, partners, mprs, 
                                             setTemporaryMpr((prev) => ({
                                                 ...prev,
                                                 partnerSuppliesMaterial: event.target.checked,
-                                                ...(event.target.checked ? {} : { ownStockingSiteBpnss: [] }),
+                                                ...(event.target.checked ? {} : { ownDemandingSiteBpnss: [] }),
                                             }))
                                         }
                                         data-testid="mpr-modal-partner-supplies-material"

--- a/frontend/src/models/types/data/material-partner-relation.ts
+++ b/frontend/src/models/types/data/material-partner-relation.ts
@@ -18,10 +18,14 @@ under the License.
 SPDX-License-Identifier: Apache-2.0
 */
 
+import { BPNS } from "../edc/bpn";
+
 export type MaterialPartnerRelation = {
     ownMaterialNumber: string;
     partnerBpnl: string;
     partnerMaterialNumber: string;
     partnerSuppliesMaterial: boolean;
     partnerBuysMaterial: boolean;
+    ownDemandingSiteBpnss: BPNS[];
+    ownProducingSiteBpnss: BPNS[];
 };


### PR DESCRIPTION
## Description
- added table columns for sites in material partner relation table
- added site designations as part of the material partner relations creation modal

Solves #1050 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files ([TRG 7.02](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02)
- [x] Documentation Notice are present on all affected files ([TRG 7.07](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07))
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
- [x] **Changelog** updated (`changelog.md`) with PR reference and brief summary.
- [x] **Frontend** version bumped, if needed (`frontend/package.json`, `frontend/package-lock.json`)
- [x] **Backend** version bumped, if needed (`backend/pom.xml`)
- [x] **Open API** specification updated, if controllers have been changed (use python script `scripts/generate_openapi_yaml.py` with running customer backend)
