### PR TITLE
feat: added bruno tests for anonymized delivery information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The **need for configuration updates** is **marked bold**.
 - Added version to about license ([#1067](https://github.com/eclipse-tractusx/puris/pull/1067))
 - Added update flow to Material Details View buttons ([#1034](https://github.com/eclipse-tractusx/puris/pull/1034))
 - Added submodel implementation for delivery information anyonymized ([#1095](https://github.com/eclipse-tractusx/puris/pull/1095))
+- Added bruno tests for delivery information anonymized ([#1101](https://github.com/eclipse-tractusx/puris/pull/1101))
 
 ### Changed
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/delivery/logic/service/DeliveryRequestApiService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/delivery/logic/service/DeliveryRequestApiService.java
@@ -129,7 +129,7 @@ public class DeliveryRequestApiService {
         Material material = materialService.findByMaterialNumberCx(materialNumberCx);
         
         if (material != null) {
-            return mprService.find(material.getOwnMaterialNumber(), partner.getBpnl());
+            return mprService.find(partner.getBpnl(), material.getOwnMaterialNumber());
         }
         MaterialPartnerRelation mpr = mprService.findByPartnerAndPartnerCXNumber(partner, materialNumberCx);
         if (mpr == null) {

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/01-Contract setup/01-Delivery/01-Create Contract policy.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/01-Contract setup/01-Delivery/01-Create Contract policy.bru
@@ -45,3 +45,9 @@ settings {
   encodeUrl: true
   timeout: 0
 }
+
+tests {
+  test("Status code is 200", function () {
+      expect(res.getStatus()).to.equal(200);
+  });
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/01-Contract setup/01-Delivery/01-Create Contract policy.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/01-Contract setup/01-Delivery/01-Create Contract policy.bru
@@ -1,0 +1,47 @@
+meta {
+  name: 01-Create Contract policy
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{SUPPLIER_EDC}}/{{MANAGEMENT_PATH}}/v3/policydefinitions
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "@context" : [ "http://www.w3.org/ns/odrl.jsonld", {
+      "edc" : "https://w3id.org/edc/v0.0.1/ns/",
+      "cx-policy" : "https://w3id.org/catenax/policy/"
+    } ],
+    "@type" : "PolicyDefinitionRequestDto",
+    "@id" : "AnonyimizedDeliveryContractPolicy",
+    "edc:policy" : {
+      "@type" : "Set",
+      "permission" : [ {
+        "action" : "use",
+        "constraint" : {
+          "@type" : "LogicalConstraint",
+          "and" : [ {
+            "@type" : "LogicalConstraint",
+            "leftOperand" : "cx-policy:FrameworkAgreement",
+            "operator" : "eq",
+            "rightOperand" : "DataExchangeGovernance:1.0"
+          }, {
+            "@type" : "LogicalConstraint",
+            "leftOperand" : "cx-policy:UsagePurpose",
+            "operator" : "eq",
+            "rightOperand" : "cx.puris.base:1"
+          } ]
+        }
+      } ]
+    }
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/01-Contract setup/01-Delivery/02-Create Access policy.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/01-Contract setup/01-Delivery/02-Create Access policy.bru
@@ -45,3 +45,9 @@ settings {
   encodeUrl: true
   timeout: 0
 }
+
+tests {
+  test("Status code is 200", function () {
+      expect(res.getStatus()).to.equal(200);
+  });
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/01-Contract setup/01-Delivery/02-Create Access policy.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/01-Contract setup/01-Delivery/02-Create Access policy.bru
@@ -1,0 +1,47 @@
+meta {
+  name: 02-Create Access policy
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{SUPPLIER_EDC}}/{{MANAGEMENT_PATH}}/v3/policydefinitions
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "@context" : [ "http://www.w3.org/ns/odrl.jsonld", {
+      "edc" : "https://w3id.org/edc/v0.0.1/ns/",
+      "cx-policy" : "https://w3id.org/catenax/policy/"
+    } ],
+    "@type" : "PolicyDefinitionRequestDto",
+    "@id" : "AnonyimizedDeliveryAccessPolicy",
+    "edc:policy" : {
+      "@type" : "Set",
+      "permission" : [ {
+        "action" : "use",
+        "constraint" : {
+          "@type" : "LogicalConstraint",
+          "and" : [ {
+            "@type" : "LogicalConstraint",
+            "leftOperand" : "cx-policy:Membership",
+            "operator" : "eq",
+            "rightOperand" : "active"
+          }, {
+            "@type" : "LogicalConstraint",
+            "leftOperand" : "BusinessPartnerNumber",
+            "operator" : "eq",
+            "rightOperand" : "{{CUSTOMER_BPNL}}"
+          } ]
+        }
+      } ]
+    }
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/01-Contract setup/01-Delivery/03-Create Contract Definitiion.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/01-Contract setup/01-Delivery/03-Create Contract Definitiion.bru
@@ -10,13 +10,7 @@ meta {
 post {
   url: {{SUPPLIER_EDC}}/{{MANAGEMENT_PATH}}/v3/contractdefinitions
   body: json
-  auth: apikey
-}
-
-auth:apikey {
-  key: X-API-KEY
-  value: {{SUPPLIER_EDC_API_KEY}}
-  placement: header
+  auth: inherit
 }
 
 body:json {

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/01-Contract setup/01-Delivery/03-Create Contract Definitiion.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/01-Contract setup/01-Delivery/03-Create Contract Definitiion.bru
@@ -1,0 +1,44 @@
+meta {
+  name: 03-Create Contract Definitiion
+  type: http
+  seq: 1
+  tags: [
+    share-enablement-services
+  ]
+}
+
+post {
+  url: {{SUPPLIER_EDC}}/{{MANAGEMENT_PATH}}/v3/contractdefinitions
+  body: json
+  auth: apikey
+}
+
+auth:apikey {
+  key: X-API-KEY
+  value: {{SUPPLIER_EDC_API_KEY}}
+  placement: header
+}
+
+body:json {
+  {
+      "@context": {
+          "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+      },
+      "@id": "AnonymizedDeliveryContractDefinition",
+      "@type": "ContractDefinition",
+      "accessPolicyId": "AnonyimizedDeliveryAccessPolicy",
+      "contractPolicyId": "AnonyimizedDeliveryContractPolicy",
+      "assetsSelector" : {
+          "@type" : "CriterionDto",
+          "operandLeft": "{{EDC_NAMESPACE}}id",
+          "operator": "=",
+          "operandRight": "deliveryanonymizedsubmodel-api-asset@{{SUPPLIER_BPNL}}"
+      }
+  }
+}
+
+tests {
+  test("Status code is 200", function () {
+      expect(res.getStatus()).to.equal(200);
+  });
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/01-Contract setup/01-Delivery/folder.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/01-Contract setup/01-Delivery/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: 01-Delivery
+  seq: 1
+}
+
+auth {
+  mode: inherit
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/01-Contract setup/folder.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/01-Contract setup/folder.bru
@@ -1,0 +1,14 @@
+meta {
+  name: 01-Contract setup
+  seq: 1
+}
+
+auth {
+  mode: apikey
+}
+
+auth:apikey {
+  key: X-API-KEY
+  value: {{CUSTOMER_EDC_API_KEY}}
+  placement: header
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/01-Retrieve Submodel Descriptor from DTR/01-Query Catalog for DTR.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/01-Retrieve Submodel Descriptor from DTR/01-Query Catalog for DTR.bru
@@ -1,0 +1,104 @@
+meta {
+  name: 01-Query Catalog for DTR
+  type: http
+  seq: 1
+  tags: [
+    exchange-anonymized-data
+  ]
+}
+
+post {
+  url: {{CUSTOMER_EDC}}/{{MANAGEMENT_PATH}}/v3/catalog/request
+  body: json
+  auth: apikey
+}
+
+auth:apikey {
+  key: X-API-KEY
+  value: {{CUSTOMER_EDC_API_KEY}}
+  placement: header
+}
+
+body:json {
+  {
+    "@context": {
+      "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+    },
+    "@type": "CatalogRequest",
+    "protocol": "dataspace-protocol-http",
+    "counterPartyAddress": "{{SUPPLIER_EDC_EXT_HOSTNAME}}/{{PROTOCOL_PATH}}",
+    "counterPartyId": "{{SUPPLIER_BPNL}}",
+    "querySpec": {
+      "offset": 0,
+      "limit": 100,
+      "filter": "",
+      "range": {
+        "from": 0,
+        "to": 100
+      },
+      "filterExpression": [
+        {
+          "@type": "CriterionDto",
+          "operandLeft": "https://w3id.org/catenax/ontology/common#version",
+          "operator": "=",
+          "operandRight": "3.0"
+        },
+        {
+          "@type": "CriterionDto",
+          "operandLeft": "'http://purl.org/dc/terms/type'.'@id'",
+          "operator": "=",
+          "operandRight": "https://w3id.org/catenax/taxonomy#DigitalTwinRegistry"
+        }
+      ]
+    }
+  }
+}
+
+script:post-response {
+  const contractAgreementId = bru.getVar("DTR_CONTRACT_AGREEMENT_ID");
+  if (!contractAgreementId) {
+    let jsonData = res.getBody();
+  
+    let catalog = jsonData['dcat:dataset'];
+  
+    let offer = catalog["odrl:hasPolicy"]
+    const offerId = offer["@id"]
+    const assetId = catalog.id
+  
+    offer.offerId = offerId
+    delete offer["@id"]
+  
+    offer.assetId = assetId
+  
+    offer = {
+        "@context": "http://www.w3.org/ns/odrl.jsonld",
+        "@type": "odrl:Offer",
+        "@id": offerId,
+        "assigner": jsonData["dspace:participantId"],
+        "odrl:permission": {
+            "odrl:target": assetId,
+            "odrl:action": {
+                "odrl:type": "http://www.w3.org/ns/odrl/2/use"
+            },
+            "odrl:constraint": catalog["odrl:hasPolicy"]["odrl:permission"]["odrl:constraint"]
+        },
+        "odrl:prohibition": [],
+        "odrl:obligation": [],
+        "odrl:target": {
+            "@id": assetId
+        }
+    }
+  
+    bru.setVar("DTR_CATALOG_OFFER", JSON.stringify(offer))
+    bru.setVar("DTT_CATALOG_OFFER_ID", offerId)
+  } else {
+    bru.runner.setNextRequest("04-Initiate Transfer")
+  }
+  
+}
+
+tests {
+  test("Status code is 200", function () {
+      expect(res.getStatus()).to.equal(200);
+  });
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/01-Retrieve Submodel Descriptor from DTR/02-Initiate Negotation for DTR.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/01-Retrieve Submodel Descriptor from DTR/02-Initiate Negotation for DTR.bru
@@ -1,0 +1,45 @@
+meta {
+  name: 02-Initiate Negotation for DTR
+  type: http
+  seq: 2
+  tags: [
+    exchange-anonymized-data
+  ]
+}
+
+post {
+  url: {{CUSTOMER_EDC}}/{{MANAGEMENT_PATH}}/v3/contractnegotiations
+  body: json
+  auth: apikey
+}
+
+auth:apikey {
+  key: X-API-KEY
+  value: {{CUSTOMER_EDC_API_KEY}}
+  placement: header
+}
+
+body:json {
+  {
+    "@context": {
+          "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
+      "odrl": "http://www.w3.org/ns/odrl/2/",
+          "cx-policy": "https://w3id.org/catenax/policy/"
+    },
+    "@type": "ContractRequest",
+    "counterPartyAddress": "{{SUPPLIER_EDC_EXT_HOSTNAME}}/{{PROTOCOL_PATH}}",
+    "protocol": "dataspace-protocol-http",
+    "policy": {{DTR_CATALOG_OFFER}}
+  }
+}
+
+script:post-response {
+  const jsonData = res.getBody();
+  bru.setVar("DTR_NEGOTIATION_ID", jsonData["@id"]);
+}
+
+tests {
+  test("Status code is 200", function () {
+      expect(res.getStatus()).to.equal(200);
+  });
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/01-Retrieve Submodel Descriptor from DTR/03-Get DTR Negotation by id.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/01-Retrieve Submodel Descriptor from DTR/03-Get DTR Negotation by id.bru
@@ -1,0 +1,36 @@
+meta {
+  name: 03-Get DTR Negotation by id
+  type: http
+  seq: 3
+  tags: [
+    exchange-anonymized-data
+  ]
+}
+
+get {
+  url: {{CUSTOMER_EDC}}/{{MANAGEMENT_PATH}}/v3/contractnegotiations/{{DTR_NEGOTIATION_ID}}
+  body: none
+  auth: apikey
+}
+
+auth:apikey {
+  key: X-API-KEY
+  value: {{CUSTOMER_EDC_API_KEY}}
+  placement: header
+}
+
+script:pre-request {
+  console.log("Waiting 5 seconds to let negotiation terminate");
+  await (new Promise(resolve => setTimeout(resolve, 5000)));
+}
+
+script:post-response {
+  const jsonData = res.getBody();
+  bru.setVar("DTR_CONTRACT_AGREEMENT_ID", jsonData.contractAgreementId);
+}
+
+tests {
+  test("Status code is 200", function () {
+      expect(res.getStatus()).to.equal(200);
+  });
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/01-Retrieve Submodel Descriptor from DTR/04-Initiate Transfer.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/01-Retrieve Submodel Descriptor from DTR/04-Initiate Transfer.bru
@@ -1,0 +1,48 @@
+meta {
+  name: 04-Initiate Transfer
+  type: http
+  seq: 4
+  tags: [
+    exchange-anonymized-data
+  ]
+}
+
+post {
+  url: {{CUSTOMER_EDC}}/{{MANAGEMENT_PATH}}/v3/transferprocesses
+  body: json
+  auth: apikey
+}
+
+auth:apikey {
+  key: X-API-KEY
+  value: {{CUSTOMER_EDC_API_KEY}}
+  placement: header
+}
+
+body:json {
+  {
+      "@context": {
+          "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+      },
+      "assetId": "{{DTR_ASSET_ID}}",
+      "counterPartyAddress": "{{SUPPLIER_EDC_EXT_HOSTNAME}}/{{PROTOCOL_PATH}}",
+      "connectorId": "{{SUPPLIER_BPNL}}",
+      "contractId": "{{DTR_CONTRACT_AGREEMENT_ID}}",
+      "transferType": "HttpData-PULL",
+      "dataDestination": {
+          "type": "HttpProxy"
+      },
+      "protocol": "dataspace-protocol-http"
+  }
+}
+
+script:post-response {
+  const jsonData = res.getBody();
+  bru.setVar("DTR_TRANSFER_PROCESS_ID", jsonData["@id"]);
+}
+
+tests {
+  test("Status code is 200", function () {
+      expect(res.getStatus()).to.equal(200);
+  });
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/01-Retrieve Submodel Descriptor from DTR/05-Get Transfer By ID.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/01-Retrieve Submodel Descriptor from DTR/05-Get Transfer By ID.bru
@@ -35,13 +35,7 @@ body:json {
       "privateProperties": {
           "receiverHttpEndpoint": "{{BACKEND_SERVICE}}"
       },
-      "protocol": "dataspace-protocol-http",
-      "callbackAddresses":{
-          "events": [
-              "transfer.process.started"
-          ],
-          "uri": "http://edr-service:80/edr-log"
-      }
+      "protocol": "dataspace-protocol-http"
   }
 }
 

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/01-Retrieve Submodel Descriptor from DTR/05-Get Transfer By ID.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/01-Retrieve Submodel Descriptor from DTR/05-Get Transfer By ID.bru
@@ -1,0 +1,52 @@
+meta {
+  name: 05-Get Transfer By ID
+  type: http
+  seq: 5
+  tags: [
+    exchange-anonymized-data
+  ]
+}
+
+get {
+  url: {{CUSTOMER_EDC}}/{{MANAGEMENT_PATH}}/v3/transferprocesses/{{DTR_TRANSFER_PROCESS_ID}}
+  body: none
+  auth: apikey
+}
+
+auth:apikey {
+  key: X-API-KEY
+  value: {{CUSTOMER_EDC_API_KEY}}
+  placement: header
+}
+
+body:json {
+  {
+      "@context": {
+          "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+      },
+      "assetId": "{{DTR_ASSET_ID}}",
+      "connectorAddress": "{{SUPPLIER_EDC_EXT_HOSTNAME}}/{{PROTOCOL_PATH}}",
+      "connectorId": "{{SUPPLIER_BPNL}}",
+      "contractId": "{{DTR_CONTRACT_AGREEMENT_ID}}",
+      "transferType": "HttpData-PULL",
+      "dataDestination": {
+          "type": "HttpProxy"
+      },
+      "privateProperties": {
+          "receiverHttpEndpoint": "{{BACKEND_SERVICE}}"
+      },
+      "protocol": "dataspace-protocol-http",
+      "callbackAddresses":{
+          "events": [
+              "transfer.process.started"
+          ],
+          "uri": "http://edr-service:80/edr-log"
+      }
+  }
+}
+
+tests {
+  test("Status code is 200", function () {
+      expect(res.getStatus()).to.equal(200);
+  });
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/01-Retrieve Submodel Descriptor from DTR/06-Get EDR for Transfer.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/01-Retrieve Submodel Descriptor from DTR/06-Get EDR for Transfer.bru
@@ -1,0 +1,41 @@
+meta {
+  name: 06-Get EDR for Transfer
+  type: http
+  seq: 6
+  tags: [
+    exchange-anonymized-data
+  ]
+}
+
+get {
+  url: {{CUSTOMER_EDC}}/{{MANAGEMENT_PATH}}/v3/edrs/{{DTR_TRANSFER_PROCESS_ID}}/dataaddress?auto_refresh=true
+  body: none
+  auth: apikey
+}
+
+params:query {
+  auto_refresh: true
+}
+
+auth:apikey {
+  key: X-API-KEY
+  value: {{CUSTOMER_EDC_API_KEY}}
+  placement: header
+}
+
+script:pre-request {
+  console.log("Waiting 10 seconds to let transfer process start");
+  await new Promise(resolve => setTimeout(resolve, 10000));
+}
+
+script:post-response {
+  const jsonData = res.getBody();
+  bru.setVar("DTR_EDR_AUTH", jsonData.authorization);
+  bru.setVar("DTR_EDR_ENDPOINT", jsonData.endpoint);
+}
+
+tests {
+  test("Status code is 200", function () {
+      expect(res.getStatus()).to.equal(200);
+  });
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/01-Retrieve Submodel Descriptor from DTR/07-Look up shell at DTR.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/01-Retrieve Submodel Descriptor from DTR/07-Look up shell at DTR.bru
@@ -1,0 +1,51 @@
+meta {
+  name: 07-Look up shell at DTR
+  type: http
+  seq: 7
+  tags: [
+    exchange-anonymized-data
+  ]
+}
+
+get {
+  url: {{DTR_EDR_ENDPOINT}}/lookup/shells?assetIds={{ASSET_IDS_QUERY}}
+  body: none
+  auth: apikey
+}
+
+params:query {
+  assetIds: {{ASSET_IDS_QUERY}}
+}
+
+headers {
+  Authorization: {{EDR_AUTH}}
+}
+
+auth:apikey {
+  key: Authorization
+  value: {{DTR_EDR_AUTH}}
+  placement: header
+}
+
+script:pre-request {
+  const btoa = require("btoa");
+  
+  let query = "{\"name\":\"manufacturerPartId\",\"value\":\"" + bru.getEnvVar("MATERIAL_NUMBER_SUPPLIER") + "\"}";
+  query += ",{\"name\":\"digitalTwinType\",\"value\":\"PartType\"}";
+  query += ",{\"name\":\"manufacturerId\",\"value\":\"" + bru.getEnvVar("SUPPLIER_BPNS") + "\"}";
+  const encodedQuery = btoa(query)
+  bru.setVar("ASSET_IDS_QUERY", encodedQuery)
+}
+
+script:post-response {
+  const btoa = require("btoa");
+  const aasId = res.body.result[0];
+  const encodedAasId = btoa(aasId);
+  bru.setVar("AAS_IDENTIFIER", encodedAasId);
+}
+
+tests {
+  test("Status code is 200", function () {
+      expect(res.getStatus()).to.equal(200);
+  });
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/01-Retrieve Submodel Descriptor from DTR/08 - Get shell descriptors.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/01-Retrieve Submodel Descriptor from DTR/08 - Get shell descriptors.bru
@@ -1,0 +1,43 @@
+meta {
+  name: 08 - Get shell descriptors
+  type: http
+  seq: 8
+  tags: [
+    exchange-anonymized-data
+  ]
+}
+
+get {
+  url: {{DTR_EDR_ENDPOINT}}/shell-descriptors/:aasIdentifier
+  body: none
+  auth: apikey
+}
+
+params:path {
+  aasIdentifier: {{AAS_IDENTIFIER}}
+}
+
+auth:apikey {
+  key: Authorization
+  value: {{DTR_EDR_AUTH}}
+  placement: header
+}
+
+script:post-response {
+  const jsonData = res.getBody();
+  const semanticId = "urn:samm:io.catenax.delivery_information_anonymized:1.0.0#DeliveryInformationAnonymized"
+  
+  const anonymizedDeliverySubmodelDescriptor = jsonData.submodelDescriptors.find(smd => smd.semanticId.keys.some(kv => kv.value === semanticId));
+  
+  if (anonymizedDeliverySubmodelDescriptor !== null) {
+    const submodelEndpoint = anonymizedDeliverySubmodelDescriptor.endpoints[0].protocolInformation.href;
+    const dspEndpoint = anonymizedDeliverySubmodelDescriptor.endpoints[0].protocolInformation.subprotocolBody.split("dspEndpoint=")[1];
+    bru.setVar("SUBMODEL_ENDPOINT", submodelEndpoint);
+    bru.setVar("DSP_ENDPOINT", dspEndpoint)
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/01-Retrieve Submodel Descriptor from DTR/08 - Get shell descriptors.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/01-Retrieve Submodel Descriptor from DTR/08 - Get shell descriptors.bru
@@ -41,3 +41,9 @@ settings {
   encodeUrl: true
   timeout: 0
 }
+
+tests {
+  test("Status code is 200", function () {
+      expect(res.getStatus()).to.equal(200);
+  });
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/01-Retrieve Submodel Descriptor from DTR/09-Terminate Transfer.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/01-Retrieve Submodel Descriptor from DTR/09-Terminate Transfer.bru
@@ -1,0 +1,36 @@
+meta {
+  name: 09-Terminate Transfer
+  type: http
+  seq: 9
+  tags: [
+    exchange-anonymized-data
+  ]
+}
+
+post {
+  url: {{CUSTOMER_EDC}}/{{MANAGEMENT_PATH}}/v3/transferprocesses/{{DTR_TRANSFER_PROCESS_ID}}/terminate
+  body: json
+  auth: apikey
+}
+
+auth:apikey {
+  key: X-API-KEY
+  value: {{CUSTOMER_EDC_API_KEY}}
+  placement: header
+}
+
+body:json {
+  {
+    "@context": {
+      "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+    },
+    "@type": "https://w3id.org/edc/v0.0.1/ns/TerminateTransfer",
+    "reason": "a reason to terminate"
+  }
+}
+
+tests {
+  test("Status code is 204", function () {
+      expect(res.getStatus()).to.equal(204);
+  });
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/01-Retrieve Submodel Descriptor from DTR/folder.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/01-Retrieve Submodel Descriptor from DTR/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: 01-Retrieve Submodel Descriptor from DTR
+  seq: 1
+}
+
+auth {
+  mode: inherit
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/02-Retrieve Submodel Data/01-Query Catalog for Submodel.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/02-Retrieve Submodel Data/01-Query Catalog for Submodel.bru
@@ -1,0 +1,101 @@
+meta {
+  name: 01-Query Catalog for Submodel
+  type: http
+  seq: 1
+  tags: [
+    exchange-anonymized-data
+  ]
+}
+
+post {
+  url: {{CUSTOMER_EDC}}/{{MANAGEMENT_PATH}}/v3/catalog/request
+  body: json
+  auth: apikey
+}
+
+auth:apikey {
+  key: X-API-KEY
+  value: {{CUSTOMER_EDC_API_KEY}}
+  placement: header
+}
+
+body:json {
+  {
+    "@context": {
+      "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+    },
+    "@type": "CatalogRequest",
+    "protocol": "dataspace-protocol-http",
+    "counterPartyAddress": "{{SUPPLIER_EDC_EXT_HOSTNAME}}/{{PROTOCOL_PATH}}",
+    "counterPartyId": "{{SUPPLIER_BPNL}}",
+    "querySpec": {
+      "offset": 0,
+      "limit": 100,
+      "filter": "",
+      "range": {
+        "from": 0,
+        "to": 100
+      },
+      "filterExpression": [
+        {
+          "@type": "CriterionDto",
+          "operandLeft": "https://w3id.org/catenax/ontology/common#version",
+          "operator": "=",
+          "operandRight": "3.0"
+        },
+        {
+          "@type": "CriterionDto",
+          "operandLeft": "'http://purl.org/dc/terms/type'.'@id'",
+          "operator": "=",
+          "operandRight": "https://w3id.org/catenax/taxonomy#Submodel"
+        }
+      ]
+    }
+  }
+}
+
+script:post-response {
+  let jsonData = res.getBody();
+  const semanticId = "urn:samm:io.catenax.delivery_information_anonymized:1.0.0#DeliveryInformationAnonymized";
+  
+  let catalog = jsonData['dcat:dataset'];
+  
+  const catalogEntry = catalog.find(ce => ce["https://admin-shell.io/aas/3/0/HasSemantics/semanticId"]["@id"] === semanticId)
+  
+  let offer = catalogEntry["odrl:hasPolicy"]
+  const offerId = offer["@id"]
+  const assetId = catalogEntry.id
+  
+  offer.offerId = offerId
+  delete offer["@id"]
+  
+  offer.assetId = assetId
+  
+  offer = {
+      "@context": "http://www.w3.org/ns/odrl.jsonld",
+      "@type": "odrl:Offer",
+      "@id": offerId,
+      "assigner": jsonData["dspace:participantId"],
+      "odrl:permission": {
+          "odrl:target": assetId,
+          "odrl:action": {
+              "odrl:type": "http://www.w3.org/ns/odrl/2/use"
+          },
+          "odrl:constraint": offer["odrl:permission"]["odrl:constraint"]
+      },
+      "odrl:prohibition": [],
+      "odrl:obligation": [],
+      "odrl:target": {
+          "@id": assetId
+      }
+  }
+  
+  bru.setVar("SUBMODEL_CATALOG_OFFER", JSON.stringify(offer))
+  bru.setVar("SUBMODEL_CATALOG_OFFER_ID", offerId)
+}
+
+tests {
+  test("Status code is 200", function () {
+      expect(res.getStatus()).to.equal(200);
+  });
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/02-Retrieve Submodel Data/02-Initiate Negotation for Submodel asset.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/02-Retrieve Submodel Data/02-Initiate Negotation for Submodel asset.bru
@@ -1,0 +1,45 @@
+meta {
+  name: 02-Initiate Negotation for Submodel asset
+  type: http
+  seq: 2
+  tags: [
+    exchange-anonymized-data
+  ]
+}
+
+post {
+  url: {{CUSTOMER_EDC}}/{{MANAGEMENT_PATH}}/v3/contractnegotiations
+  body: json
+  auth: apikey
+}
+
+auth:apikey {
+  key: X-API-KEY
+  value: {{CUSTOMER_EDC_API_KEY}}
+  placement: header
+}
+
+body:json {
+  {
+    "@context": {
+          "@vocab": "https://w3id.org/edc/v0.0.1/ns/",
+      "odrl": "http://www.w3.org/ns/odrl/2/",
+          "cx-policy": "https://w3id.org/catenax/policy/"
+    },
+    "@type": "ContractRequest",
+    "counterPartyAddress": "{{SUPPLIER_EDC_EXT_HOSTNAME}}/{{PROTOCOL_PATH}}",
+    "protocol": "dataspace-protocol-http",
+    "policy": {{SUBMODEL_CATALOG_OFFER}}
+  }
+}
+
+script:post-response {
+  const jsonData = res.getBody();
+  bru.setVar("DTR_NEGOTIATION_ID", jsonData["@id"]);
+}
+
+tests {
+  test("Status code is 200", function () {
+      expect(res.getStatus()).to.equal(200);
+  });
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/02-Retrieve Submodel Data/03-Get Submodel Negotation by id.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/02-Retrieve Submodel Data/03-Get Submodel Negotation by id.bru
@@ -1,0 +1,36 @@
+meta {
+  name: 03-Get Submodel Negotation by id
+  type: http
+  seq: 3
+  tags: [
+    exchange-anonymized-data
+  ]
+}
+
+get {
+  url: {{CUSTOMER_EDC}}/{{MANAGEMENT_PATH}}/v3/contractnegotiations/{{DTR_NEGOTIATION_ID}}
+  body: none
+  auth: apikey
+}
+
+auth:apikey {
+  key: X-API-KEY
+  value: {{CUSTOMER_EDC_API_KEY}}
+  placement: header
+}
+
+script:pre-request {
+  console.log("Waiting 5 seconds to let negotiation terminate");
+  await (new Promise(resolve => setTimeout(resolve, 5000)));
+}
+
+script:post-response {
+  const jsonData = res.getBody();
+  bru.setVar("SUBMODEL_CONTRACT_AGREEMENT_ID", jsonData.contractAgreementId);
+}
+
+tests {
+  test("Status code is 200", function () {
+      expect(res.getStatus()).to.equal(200);
+  });
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/02-Retrieve Submodel Data/04-Initiate Transfer.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/02-Retrieve Submodel Data/04-Initiate Transfer.bru
@@ -1,0 +1,48 @@
+meta {
+  name: 04-Initiate Transfer
+  type: http
+  seq: 4
+  tags: [
+    exchange-anonymized-data
+  ]
+}
+
+post {
+  url: {{CUSTOMER_EDC}}/{{MANAGEMENT_PATH}}/v3/transferprocesses
+  body: json
+  auth: apikey
+}
+
+auth:apikey {
+  key: X-API-KEY
+  value: {{CUSTOMER_EDC_API_KEY}}
+  placement: header
+}
+
+body:json {
+  {
+      "@context": {
+          "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+      },
+      "assetId": "deliveryanonymizedsubmodel-api-asset@{{SUPPLIER_BPNL}}",
+      "counterPartyAddress": "{{SUPPLIER_EDC_EXT_HOSTNAME}}/{{PROTOCOL_PATH}}",
+      "connectorId": "{{SUPPLIER_BPNL}}",
+      "contractId": "{{SUBMODEL_CONTRACT_AGREEMENT_ID}}",
+      "transferType": "HttpData-PULL",
+      "dataDestination": {
+          "type": "HttpProxy"
+      },
+      "protocol": "dataspace-protocol-http"
+  }
+}
+
+script:post-response {
+  const jsonData = res.getBody();
+  bru.setVar("SUBMODEL_TRANSFER_PROCESS_ID", jsonData["@id"]);
+}
+
+tests {
+  test("Status code is 200", function () {
+      expect(res.getStatus()).to.equal(200);
+  });
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/02-Retrieve Submodel Data/05-Get EDR for Transfer.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/02-Retrieve Submodel Data/05-Get EDR for Transfer.bru
@@ -1,0 +1,40 @@
+meta {
+  name: 05-Get EDR for Transfer
+  type: http
+  seq: 5
+  tags: [
+    exchange-anonymized-data
+  ]
+}
+
+get {
+  url: {{CUSTOMER_EDC}}/{{MANAGEMENT_PATH}}/v3/edrs/{{SUBMODEL_TRANSFER_PROCESS_ID}}/dataaddress?auto_refresh=true
+  body: none
+  auth: apikey
+}
+
+params:query {
+  auto_refresh: true
+}
+
+auth:apikey {
+  key: X-API-KEY
+  value: {{CUSTOMER_EDC_API_KEY}}
+  placement: header
+}
+
+script:pre-request {
+  console.log("Waiting 10 seconds to let transfer process start");
+  await new Promise(resolve => setTimeout(resolve, 10000));
+}
+
+script:post-response {
+  const jsonData = res.getBody();
+  bru.setVar("SUBMODEL_EDR_AUTH", jsonData.authorization);
+}
+
+tests {
+  test("Status code is 200", function () {
+      expect(res.getStatus()).to.equal(200);
+  });
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/02-Retrieve Submodel Data/06-Pull data from submodel endpoint.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/02-Retrieve Submodel Data/06-Pull data from submodel endpoint.bru
@@ -1,0 +1,30 @@
+meta {
+  name: 06-Pull data from submodel endpoint
+  type: http
+  seq: 6
+  tags: [
+    exchange-anonymized-data
+  ]
+}
+
+get {
+  url: {{SUBMODEL_ENDPOINT}}/$value
+  body: none
+  auth: apikey
+}
+
+headers {
+  Authorization: {{SUBMODEL_EDR_AUTH}}
+}
+
+auth:apikey {
+  key: Authorization
+  value: {{SUBMODEL_EDR_AUTH}}
+  placement: header
+}
+
+tests {
+  test("Status code is 200", function () {
+      expect(res.getStatus()).to.equal(200);
+  });
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/02-Retrieve Submodel Data/07-Terminate Transfer.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/02-Retrieve Submodel Data/07-Terminate Transfer.bru
@@ -1,0 +1,36 @@
+meta {
+  name: 07-Terminate Transfer
+  type: http
+  seq: 7
+  tags: [
+    exchange-anonymized-data
+  ]
+}
+
+post {
+  url: {{CUSTOMER_EDC}}/{{MANAGEMENT_PATH}}/v3/transferprocesses/{{SUBMODEL_TRANSFER_PROCESS_ID}}/terminate
+  body: json
+  auth: apikey
+}
+
+auth:apikey {
+  key: X-API-KEY
+  value: {{CUSTOMER_EDC_API_KEY}}
+  placement: header
+}
+
+body:json {
+  {
+    "@context": {
+      "@vocab": "https://w3id.org/edc/v0.0.1/ns/"
+    },
+    "@type": "https://w3id.org/edc/v0.0.1/ns/TerminateTransfer",
+    "reason": "a reason to terminate"
+  }
+}
+
+tests {
+  test("Status code is 204", function () {
+      expect(res.getStatus()).to.equal(204);
+  });
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/02-Retrieve Submodel Data/folder.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/02-Retrieve Submodel Data/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: 02-Retrieve Submodel Data
+  seq: 1
+}
+
+auth {
+  mode: inherit
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/folder.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/01-Delivery/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: 01-Delivery
+  seq: 1
+}
+
+auth {
+  mode: inherit
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/folder.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/02-Contract Negotiation/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: 02-Contract Negotiation
+  seq: 2
+}
+
+auth {
+  mode: inherit
+}

--- a/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/folder.bru
+++ b/local/bruno/puris-integration-test/Test_02-EDC/Exchange anonymized submodel data/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: Exchange anonymized submodel data
+  seq: 3
+}
+
+auth {
+  mode: inherit
+}

--- a/local/bruno/puris-integration-test/collection.bru
+++ b/local/bruno/puris-integration-test/collection.bru
@@ -1,0 +1,3 @@
+vars:pre-request {
+  EDC_NAMESPACE: https://w3id.org/edc/v0.0.1/ns/
+}


### PR DESCRIPTION
## Description

- added Bruno tests for anonymized delivery information
- the tests consist of 3 phases:
  - contract creation
  - DTR negotiation and retrieval of submodel descriptors
  - submodel asset negotiation and retrieval of submodel data

resolves #1080 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files ([TRG 7.02](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02)
- [x] Documentation Notice are present on all affected files ([TRG 7.07](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07))
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
- [x] **Changelog** updated (`changelog.md`) with PR reference and brief summary.
- [x] **Frontend** version bumped, if needed (`frontend/package.json`, `frontend/package-lock.json`)
- [x] **Backend** version bumped, if needed (`backend/pom.xml`)
- [x] **Open API** specification updated, if controllers have been changed (use python script `scripts/generate_openapi_yaml.py` with running customer backend)
