### PR TITLE
feat: utilize latest supported dsp version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The **need for configuration updates** is **marked bold**.
 - migrated to policy profile 2509 and adapted support for DSP 1.0 ([#1125](https://github.com/eclipse-tractusx/puris/pull/1125))
 - implemented edc cross version communication support ([#1136](https://github.com/eclipse-tractusx/puris/pull/1136))
 - refactored EDC integration with better separation of concerns ([#1144](https://github.com/eclipse-tractusx/puris/pull/1144))
+- updated negotiation and transfer logic to utilize latest DSP version ([#1153](https://github.com/eclipse-tractusx/puris/pull/1153))
 
 ### Fixes
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -84,6 +84,12 @@ feather (4.29)
 * SPDX-FileCopyrightText: https://github.com/International-Data-Spaces-Association/ids-specification/blob/main/LICENSE
 * Source URL: https://international-data-spaces-association.github.io/ids-specification/2024-1/common/schema/context.json
 
+#### dspace-2025-1 ([main](./backend/src/main/resources/json-ld/dspace-2025-1.jsonld), [test](./backend/src/test/resources/json-ld/dspace-2025-1.jsonld))
+
+* SPDX-License-Identifier: Apache-2.0
+* SPDX-FileCopyrightText: https://github.com/eclipse-dataspace-protocol-base/DataspaceProtocol/blob/main/LICENSE
+* Source URL: https://eclipse-dataspace-protocol-base.github.io/DataspaceProtocol/2025-1/message/schema/dspace.jsonld
+
 #### edc-v1 ([main](./backend/src/main/resources/json-ld/edc-v1.jsonld), [test](./backend/src/test/resources/json-ld/edc-v1.jsonld))
 
 * SPDX-License-Identifier: Apache-2.0

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/controller/EdcController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/controller/EdcController.java
@@ -27,6 +27,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Response;
 import org.eclipse.tractusx.puris.backend.common.edc.logic.service.EdcAdapterService;
+import org.eclipse.tractusx.puris.backend.common.edc.logic.service.EdcAdapterService.DspaceVersionParams;
 import org.eclipse.tractusx.puris.backend.common.util.PatternStore;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -73,7 +74,8 @@ public class EdcController {
             if (!PatternStore.URL_PATTERN.matcher(dspUrl).matches()) {
                 return ResponseEntity.badRequest().build();
             }
-            var catalogResponse = edcAdapter.getCatalogResponse(dspUrl, partnerBpnl, null);
+            DspaceVersionParams dspaceVersionParams = edcAdapter.getPartnerDspaceVersionParams(partnerBpnl, dspUrl);
+            var catalogResponse = edcAdapter.getCatalogResponse(dspaceVersionParams, null);
             if (catalogResponse != null && catalogResponse.isSuccessful()) {
                 var responseString = catalogResponse.body().string();
                 catalogResponse.body().close();

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/controller/EdcController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/controller/EdcController.java
@@ -74,6 +74,9 @@ public class EdcController {
             if (!PatternStore.URL_PATTERN.matcher(dspUrl).matches()) {
                 return ResponseEntity.badRequest().build();
             }
+            if (!PatternStore.BPNL_PATTERN.matcher(partnerBpnl).matches()) {
+                return ResponseEntity.badRequest().build();
+            }
             DspaceVersionParams dspaceVersionParams = edcAdapter.getPartnerDspaceVersionParams(partnerBpnl, dspUrl);
             var catalogResponse = edcAdapter.getCatalogResponse(dspaceVersionParams, null);
             if (catalogResponse != null && catalogResponse.isSuccessful()) {

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/domain/model/JsonLdConstants.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/domain/model/JsonLdConstants.java
@@ -32,5 +32,7 @@ public final class JsonLdConstants {
     public final static String AAS_SEMANTICS_NAMESPACE = "https://admin-shell.io/aas/3/0/HasSemantics/";
     public final static String TX_NAMESPACE = "https://w3id.org/tractusx/v0.0.1/ns/";
     public final static String TX_AUTH_NAMESPACE = "https://w3id.org/tractusx/auth/";
+    public final static String TX_AUTH_CONTEXT = "https://w3id.org/tractusx/auth/v1.0.0";
     public final static String DCAT_NAMESPACE = "http://www.w3.org/ns/dcat#";
+    public final static String DSPACE_CONTEXT_2025_1 = "https://w3id.org/dspace/2025/1/context.jsonld";
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
@@ -44,6 +44,7 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 /**
@@ -54,6 +55,7 @@ import java.util.regex.Pattern;
 @Slf4j
 public class EdcAdapterService {
     private static final OkHttpClient CLIENT = new OkHttpClient();
+    private final Map<DspaceVersionCacheKey, DspaceVersionParams> dspaceVersionParamsCache = new ConcurrentHashMap<>();
     @Autowired
     private VariablesService variablesService;
     private final ObjectMapper objectMapper;
@@ -400,30 +402,27 @@ public class EdcAdapterService {
 
     /**
      * Retrieve the response to an unfiltered catalog request from the partner
-     * with the given dspUrl
+     * using the resolved DSP version parameters.
      *
-     * @param dspUrl      The dspUrl of your partner
-     * @param partnerBpnl The bpnl of your partner
-     * @param filter      Map of key (leftOperand) and values (rightOperand) to use as filterExpression with equal operand
+     * @param dspaceVersionParams Resolved DSP endpoint, connector id and protocol version of your partner
+     * @param filter              Map of key (leftOperand) and values (rightOperand) to use as filterExpression with equal operand
      * @return The response containing the full catalog, if successful
      */
-    public Response getCatalogResponse(String dspUrl, String partnerBpnl, Map<String, String> filter) throws IOException {
-        DspaceVersionParams dspaceVersionParams = getPartnerDspaceVersionParams(partnerBpnl, dspUrl);
+    public Response getCatalogResponse(DspaceVersionParams dspaceVersionParams, Map<String, String> filter) throws IOException {
         return sendPostRequest(edcRequestBodyBuilder.buildBasicCatalogRequestBody(dspaceVersionParams, filter), List.of("v3", "catalog", "request"));
     }
 
     /**
      * Retrieve an (unfiltered) catalog from the partner with the
-     * given dspUrl
+     * resolved DSP version parameters.
      *
-     * @param dspUrl      The dspUrl of your partner
-     * @param partnerBpnl The bpnl of your partner
-     * @param filter      Map of key (leftOperand) and values (rightOperand) to use as filterExpression with equal operand
+     * @param dspaceVersionParams Resolved DSP endpoint, connector id and protocol version of your partner
+     * @param filter              Map of key (leftOperand) and values (rightOperand) to use as filterExpression with equal operand
      * @return The full catalog
      * @throws IOException If the connection to the partners control plane fails
      */
-    public JsonNode getCatalog(String dspUrl, String partnerBpnl, Map<String, String> filter) throws IOException {
-        try (var response = getCatalogResponse(dspUrl, partnerBpnl, filter)) {
+    public JsonNode getCatalog(DspaceVersionParams dspaceVersionParams, Map<String, String> filter) throws IOException {
+        try (var response = getCatalogResponse(dspaceVersionParams, filter)) {
             JsonNode responseNode = objectMapper.readTree(response.body().string());
             log.debug("Got Catalog response {}", responseNode.toPrettyString());
             return responseNode;
@@ -441,76 +440,87 @@ public class EdcAdapterService {
      */
     public record DspaceVersionParams (String counterPartyId, String counterPartyAddress, DspProtocolVersionEnum protocol) {}
 
+    private record DspaceVersionCacheKey(String partnerBpnl, String dspUrl) {}
+
     /**
      * represents the latest version information from dspaceVersionParams endpoint
      *
      * @param partnerBpnl The bpnl of your partner used for identification and lookup of did 
      * @param dspUrl      The dsp url known from your partner (master data / discovery)
-     * @return the latest {@link DspaceVersionParams} of your partner or a fallback prior to TX Connector 0.10.0
+     * @return the cached or freshly resolved {@link DspaceVersionParams} of your partner, or a fallback prior to TX Connector 0.10.0
      */
     public DspaceVersionParams getPartnerDspaceVersionParams(String partnerBpnl, String dspUrl) throws IOException{
-        JsonNode dspaceVersionParmsRequest = edcRequestBodyBuilder.buildDspaceVersionParamsRequest(dspUrl, partnerBpnl);
-        Response response = this.sendPostRequest(dspaceVersionParmsRequest, List.of("v4alpha", "connectordiscovery", "dspaceversionparams"));
-        
-        DspaceVersionParams dspaceVersionParams = null;
+        DspaceVersionCacheKey cacheKey = new DspaceVersionCacheKey(partnerBpnl, dspUrl);
+        DspaceVersionParams cachedParams = dspaceVersionParamsCache.get(cacheKey);
+        if (cachedParams != null) {
+            log.debug("Using cached Dspace Version Params for partner {} and dspUrl {}", partnerBpnl, dspUrl);
+            return cachedParams;
+        }
+
+        JsonNode dspaceVersionParamsRequest = edcRequestBodyBuilder.buildDspaceVersionParamsRequest(dspUrl, partnerBpnl);
         final DspaceVersionParams fallback = new DspaceVersionParams(partnerBpnl, dspUrl, DspProtocolVersionEnum.V_0_8);
-        // if connector version < 0.10.x 404 is returned, then assemble default from dsp v0.8
-        if (response.code() == 404)
-        {
-            // Note: following swagger-ui counterPartyId should be a did - likely this is an upstream example bug
-            log.debug("Connector does not yet support endpoint /v4alpha/connectordiscovery/dspversionparams. Fallback to following parameters: {}", fallback.toString());
-            return fallback;
-        } else if (!response.isSuccessful()){
-            log.warn("Dspace version could not be determined and error was not expected. Status code {}; error: {}", response.code(), response.body());
-            log.debug("No supported version found, fallback: {}", fallback.toString());
-            return fallback;
-        }
-        JsonNode responseNode = objectMapper.readTree(response.body().string());
-        responseNode = jsonLdUtils.expand(responseNode, variablesService.getEdcProfileVersion());
-            
-        log.debug("Got response from Dspace Version Params request: {}", responseNode.toPrettyString());
+        try (Response response = this.sendPostRequest(dspaceVersionParamsRequest, List.of("v4alpha", "connectordiscovery", "dspversionparams"))) {
+            DspaceVersionParams dspaceVersionParams = null;
+            // if connector version < 0.10.x 404 is returned, then assemble default from dsp v0.8
+            if (response.code() == 404)
+            {
+                // Note: following swagger-ui counterPartyId should be a did - likely this is an upstream example bug
+                log.debug("Connector does not yet support endpoint /v4alpha/connectordiscovery/dspversionparams. Fallback to following parameters: {}", fallback.toString());
+                dspaceVersionParamsCache.put(cacheKey, fallback);
+                return fallback;
+            } else if (!response.isSuccessful()){
+                log.warn("Dspace version could not be determined and error was not expected. Status code {}; error: {}", response.code(), response.body());
+                log.debug("No supported version found, fallback: {}", fallback.toString());
+                return fallback;
+            }
+            JsonNode responseNode = objectMapper.readTree(response.body().string());
+            responseNode = jsonLdUtils.expand(responseNode, variablesService.getEdcProfileVersion());
+                
+            log.debug("Got response from Dspace Version Params request: {}", responseNode.toPrettyString());
 
-        ArrayNode responseArray = null;
-        // ensure it's an array
-        if (responseNode.isObject()){
-            responseArray = objectMapper.createArrayNode().add(responseNode);
-        } else {
-            responseArray = (ArrayNode) responseNode;
-        }
+            ArrayNode responseArray = null;
+            // ensure it's an array
+            if (responseNode.isObject()){
+                responseArray = objectMapper.createArrayNode().add(responseNode);
+            } else {
+                responseArray = (ArrayNode) responseNode;
+            }
 
-        // collect supported dspace versions
-        List<DspaceVersionParams> partnerSupportedDspaceVersions = new ArrayList<>();
-        for (JsonNode entry: responseArray){
-            // fallback to v.0.8 in case of missing information / issues
-            String counterPartyAddress = entry.get(JsonLdConstants.EDC_NAMESPACE + "counterPartyAddress")
-                .get(0)
-                .get("@value")
-                .asText(dspUrl);
-            String counterPartyId = entry.get(JsonLdConstants.EDC_NAMESPACE + "counterPartyId")
-                .get(0)
-                .get("@value")
-                .asText(partnerBpnl);
-            String protocolString = entry.get(JsonLdConstants.EDC_NAMESPACE + "protocol")
-                .get(0)
-                .get("@value")
-                .asText(DspProtocolVersionEnum.V_0_8.getVersion());
-            DspProtocolVersionEnum dspProtocolVersion = DspProtocolVersionEnum.fromVersion(protocolString);
-            dspaceVersionParams = new DspaceVersionParams(counterPartyId, counterPartyAddress, dspProtocolVersion);
-            log.debug("Partner supports the following dsp version: {}", dspaceVersionParams.toString());
-            partnerSupportedDspaceVersions.add(dspaceVersionParams);
-        }
+            // collect supported dspace versions
+            List<DspaceVersionParams> partnerSupportedDspaceVersions = new ArrayList<>();
+            for (JsonNode entry: responseArray){
+                // fallback to v.0.8 in case of missing information / issues
+                String counterPartyAddress = entry.get(JsonLdConstants.EDC_NAMESPACE + "counterPartyAddress")
+                    .get(0)
+                    .get("@value")
+                    .asText(dspUrl);
+                String counterPartyId = entry.get(JsonLdConstants.EDC_NAMESPACE + "counterPartyId")
+                    .get(0)
+                    .get("@value")
+                    .asText(partnerBpnl);
+                String protocolString = entry.get(JsonLdConstants.EDC_NAMESPACE + "protocol")
+                    .get(0)
+                    .get("@value")
+                    .asText(DspProtocolVersionEnum.V_0_8.getVersion());
+                DspProtocolVersionEnum dspProtocolVersion = DspProtocolVersionEnum.fromVersion(protocolString);
+                dspaceVersionParams = new DspaceVersionParams(counterPartyId, counterPartyAddress, dspProtocolVersion);
+                log.debug("Partner supports the following dsp version: {}", dspaceVersionParams.toString());
+                partnerSupportedDspaceVersions.add(dspaceVersionParams);
+            }
 
-        // Identify the highest enum in the list of supported versions based on natural order (youngest -> latest)
-        Optional<DspaceVersionParams> latest = partnerSupportedDspaceVersions.stream()
-            .max(Comparator.comparingInt(p -> p.protocol().ordinal()));
+            // Identify the highest enum in the list of supported versions based on natural order (youngest -> latest)
+            Optional<DspaceVersionParams> latest = partnerSupportedDspaceVersions.stream()
+                .max(Comparator.comparingInt(p -> p.protocol().ordinal()));
 
-        // If found any is given / latest found return it or use fallback
-        if (latest.isPresent()) {
-            log.debug("Will use the following dsp version information for partner: {}", latest.get().toString());
-            return latest.get();
-        } else {
-            log.debug("No supported version found, fallback: {}", fallback.toString());
-            return fallback;
+            // If found any is given / latest found return it or use fallback
+            if (latest.isPresent()) {
+                log.debug("Will use the following dsp version information for partner: {}", latest.get().toString());
+                dspaceVersionParamsCache.put(cacheKey, latest.get());
+                return latest.get();
+            } else {
+                log.debug("No supported version found, fallback: {}", fallback.toString());
+                return fallback;
+            }
         }
     }
 
@@ -526,23 +536,21 @@ public class EdcAdapterService {
      * @throws IOException If the connection to the partners control plane fails
      */
     private JsonNode initiateNegotiation(Partner partner, JsonNode catalogItem) throws IOException {
-        return initiateNegotiation(partner, catalogItem, null);
+        DspaceVersionParams dspaceVersionParams = getPartnerDspaceVersionParams(partner.getBpnl(), partner.getEdcUrl());
+        return initiateNegotiation(catalogItem, dspaceVersionParams);
     }
 
     /**
-     * Helper method for contracting a certain asset as specified in the catalog item from
-     * a specific Partner.
+     * Helper method for negotiating a contract for a specific catalog item using
+     * already resolved DSP version parameters.
      *
-     * @param partner     The Partner to negotiate with
-     * @param catalogItem An excerpt from a catalog.
-     * @param dspUrl      The dspUrl if a specific (not from MAD Partner) needs to be used, if null, the partners edcUrl is taken
+     * @param catalogItem         An excerpt from a catalog
+     * @param dspaceVersionParams Resolved DSP endpoint, connector id and protocol version of the counterparty
      * @return The JSON response to your contract offer.
      * @throws IOException If the connection to the partners control plane fails
      */
-    private JsonNode initiateNegotiation(Partner partner, JsonNode catalogItem, String dspUrl) throws IOException {
-        // use dspUrl as provided, if set - else use partner
-        dspUrl = dspUrl != null && !dspUrl.isEmpty() ? dspUrl : partner.getEdcUrl();
-        var requestBody = edcRequestBodyBuilder.buildAssetNegotiationBody(partner, catalogItem, dspUrl);
+    private JsonNode initiateNegotiation(JsonNode catalogItem, DspaceVersionParams dspaceVersionParams) throws IOException {
+        var requestBody = edcRequestBodyBuilder.buildAssetNegotiationBody(catalogItem, dspaceVersionParams);
         try (Response response = sendPostRequest(requestBody, List.of("v3", "contractnegotiations"))) {
             JsonNode responseNode = objectMapper.readTree(response.body().string());
             log.debug("Result from negotiation {}", responseNode.toPrettyString());
@@ -582,13 +590,15 @@ public class EdcAdapterService {
      * Sends a request to the own control plane in order to initiate a transfer of
      * a previously negotiated asset.
      *
-     * @param partner    The partner
-     * @param contractId The contract id
+     * @param partner       The partner
+     * @param contractId    The contract id
+     * @param partnerEdcUrl The DSP URL to use for this transfer
      * @return The response object
      * @throws IOException If the connection to your control plane fails
      */
     public JsonNode initiateProxyPullTransfer(Partner partner, String contractId, String partnerEdcUrl) throws IOException {
-        var body = edcRequestBodyBuilder.buildProxyPullRequestBody(partner, contractId, partnerEdcUrl);
+        DspaceVersionParams dspaceVersionParams = getPartnerDspaceVersionParams(partner.getBpnl(), partnerEdcUrl);
+        var body = edcRequestBodyBuilder.buildProxyPullRequestBody(contractId, dspaceVersionParams);
         try (var response = sendPostRequest(body, List.of("v3", "transferprocesses"))) {
             String data = response.body().string();
             JsonNode result = objectMapper.readTree(data);
@@ -877,7 +887,8 @@ public class EdcAdapterService {
                 "'" + JsonLdConstants.DCT_NAMESPACE + "type'.'@id'",
                 JsonLdConstants.CX_TAXO_NAMESPACE + "DigitalTwinRegistry"
             );
-            var responseNode = getCatalog(partner.getEdcUrl(), partner.getBpnl(), equalFilters);
+            DspaceVersionParams dspaceVersionParams = getPartnerDspaceVersionParams(partner.getBpnl(), partner.getEdcUrl());
+            var responseNode = getCatalog(dspaceVersionParams, equalFilters);
             responseNode = jsonLdUtils.expand(responseNode, partner.getPolicyProfileVersion());
             log.debug("Catalog response after expansion: {}", responseNode);
 
@@ -1224,7 +1235,8 @@ public class EdcAdapterService {
 
     public boolean negotiateContract(Partner partner, String assetId, AssetType type, String dspUrl, Map<String, String> equalFilters) {
         try {
-            var responseNode = getCatalog(dspUrl, partner.getBpnl(), equalFilters);
+            DspaceVersionParams dspaceVersionParams = getPartnerDspaceVersionParams(partner.getBpnl(), dspUrl);
+            var responseNode = getCatalog(dspaceVersionParams, equalFilters);
             responseNode = jsonLdUtils.expand(responseNode, partner.getPolicyProfileVersion());
 
             // per specifciation jsonLd wraps into an array if multiple entries, thus take first entry as we get only one contract.
@@ -1265,7 +1277,7 @@ public class EdcAdapterService {
                 log.warn("CATALOG CONTENT \n" + catalogArray.toPrettyString());
                 return false;
             }
-            JsonNode negotiationResponse = initiateNegotiation(partner, targetCatalogEntry, dspUrl);
+            JsonNode negotiationResponse = initiateNegotiation(targetCatalogEntry, dspaceVersionParams);
             String negotiationId = negotiationResponse.get("@id").asText();
             // Await confirmation of contract and contractId
             String contractId = null;
@@ -1313,7 +1325,8 @@ public class EdcAdapterService {
      * Helper method to check whether you and the contract offer from the other party have the
      * same framework agreement policy. The given catalogEntry must be expanded!
      *
-     * @param catalogEntry the catalog item containing the desired api asset in expanded form
+        * @param catalogEntry   the catalog item containing the desired api asset in expanded form
+        * @param profileVersion the policy profile version to validate against
      * @return true, if the policy matches yours, otherwise false
      */
     public boolean testContractPolicyConstraints(JsonNode catalogEntry, PolicyProfileVersionEnumeration profileVersion) {

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
@@ -1325,8 +1325,8 @@ public class EdcAdapterService {
      * Helper method to check whether you and the contract offer from the other party have the
      * same framework agreement policy. The given catalogEntry must be expanded!
      *
-        * @param catalogEntry   the catalog item containing the desired api asset in expanded form
-        * @param profileVersion the policy profile version to validate against
+     * @param catalogEntry   the catalog item containing the desired api asset in expanded form
+     * @param profileVersion the policy profile version to validate against
      * @return true, if the policy matches yours, otherwise false
      */
     public boolean testContractPolicyConstraints(JsonNode catalogEntry, PolicyProfileVersionEnumeration profileVersion) {

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/util/EdcRequestBodyBuilder.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/util/EdcRequestBodyBuilder.java
@@ -343,8 +343,8 @@ public class EdcRequestBodyBuilder {
      * Creates the request body for initiating a negotiation in DSP protocol.
      * Will use the policy terms as specified in the catalog item.
      *
-        * @param dcatCatalogItem     The catalog entry that describes the target asset
-        * @param dspaceVersionParams Resolved DSP endpoint, connector id and protocol version of the counterparty
+     * @param dcatCatalogItem     The catalog entry that describes the target asset
+     * @param dspaceVersionParams Resolved DSP endpoint, connector id and protocol version of the counterparty
      * @return The request body
      */
     public JsonNode buildAssetNegotiationBody(JsonNode dcatCatalogItem, DspaceVersionParams dspaceVersionParams) {
@@ -387,8 +387,8 @@ public class EdcRequestBodyBuilder {
      * Creates the request body for requesting a proxy pull transfer using the
      * DSP protocol and the Tractus-X-EDC.
      *
-        * @param contractID          The contract agreement id to transfer against
-        * @param dspaceVersionParams Resolved DSP endpoint, connector id and protocol version of the counterparty
+     * @param contractID          The contract agreement id to transfer against
+     * @param dspaceVersionParams Resolved DSP endpoint, connector id and protocol version of the counterparty
      * @return The request body
      */
     public JsonNode buildProxyPullRequestBody(String contractID, DspaceVersionParams dspaceVersionParams) {

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/util/EdcRequestBodyBuilder.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/util/EdcRequestBodyBuilder.java
@@ -100,9 +100,8 @@ public class EdcRequestBodyBuilder {
      * with nested catalog item properties, so it seems advisable to check
      * for the filter criteria programmatically.
      *
-     * @param counterPartyDspUrl The protocol url of the other party
-     * @param counterPartyBpnl   The bpnl of the other party
-     * @param filter             Key-value-pairs, may be empty or null
+     * @param dspaceVersionParams Resolved DSP endpoint, connector id and protocol version of the other party
+     * @param filter              Key-value-pairs, may be empty or null
      * @return The request body
      */
     public ObjectNode buildBasicCatalogRequestBody(DspaceVersionParams dspaceVersionParams, Map<String, String> filter) {
@@ -234,6 +233,7 @@ public class EdcRequestBodyBuilder {
      * Creates a request body in order to register a contract policy that
      * allows only participants of the framework agreement.
      *
+     * @param profileVersion The policy profile version to encode in the policy
      * @return the request body
      */
     public JsonNode buildPurisFrameworkPolicy(PolicyProfileVersionEnumeration profileVersion) {
@@ -243,6 +243,8 @@ public class EdcRequestBodyBuilder {
     /**
      * Creates a request body in order to register a contract policy for the DTR that
      * allows only participants of the framework agreement to access the DTR asset.
+     *
+     * @param profileVersion The policy profile version to encode in the policy
      * @return the request body
      */
     public JsonNode buildDtrFrameworkPolicy(PolicyProfileVersionEnumeration profileVersion) {
@@ -341,20 +343,19 @@ public class EdcRequestBodyBuilder {
      * Creates the request body for initiating a negotiation in DSP protocol.
      * Will use the policy terms as specified in the catalog item.
      *
-     * @param partner         The Partner to negotiate with
-     * @param dcatCatalogItem The catalog entry that describes the target asset.
-     * @param dspUrl          The dspUrl if a specific (not from MAD Partner) needs to be used, not null
+        * @param dcatCatalogItem     The catalog entry that describes the target asset
+        * @param dspaceVersionParams Resolved DSP endpoint, connector id and protocol version of the counterparty
      * @return The request body
      */
-    public JsonNode buildAssetNegotiationBody(Partner partner, JsonNode dcatCatalogItem, String dspUrl) {
+    public JsonNode buildAssetNegotiationBody(JsonNode dcatCatalogItem, DspaceVersionParams dspaceVersionParams) {
         ObjectNode body = MAPPER.createObjectNode();
         ObjectNode contextNode = MAPPER.createObjectNode();
         contextNode.put(JsonLdConstants.VOCAB_KEY, JsonLdConstants.EDC_NAMESPACE);
         contextNode.put("odrl", JsonLdConstants.ODRL_NAMESPACE);
         body.set("@context", contextNode);
         body.put("@type", "ContractRequest");
-        body.put("counterPartyAddress", dspUrl);
-        body.put("protocol", "dataspace-protocol-http");
+        body.put("counterPartyAddress", dspaceVersionParams.counterPartyAddress());
+        body.put("protocol", dspaceVersionParams.protocol().getVersion());
 
         // extract policy and information from offer
         // framework agreement and co has been checked during catalog request
@@ -368,7 +369,7 @@ public class EdcRequestBodyBuilder {
         targetIdObject.put("@id", assetId);
         ((ObjectNode) policyNode).put("@context", "http://www.w3.org/ns/odrl.jsonld");
         ((ObjectNode) policyNode).set("target", targetIdObject);
-        ((ObjectNode) policyNode).put("assigner", partner.getBpnl());
+        ((ObjectNode) policyNode).put("assigner", dspaceVersionParams.counterPartyId());
 
         ObjectNode offerNode = MAPPER.createObjectNode();
         String offerId = policyNode.get("@id").asText();
@@ -386,17 +387,16 @@ public class EdcRequestBodyBuilder {
      * Creates the request body for requesting a proxy pull transfer using the
      * DSP protocol and the Tractus-X-EDC.
      *
-     * @param partner    The Partner who controls the target asset
-     * @param contractID The contractId
-     * @param assetId    The assetId
+        * @param contractID          The contract agreement id to transfer against
+        * @param dspaceVersionParams Resolved DSP endpoint, connector id and protocol version of the counterparty
      * @return The request body
      */
-    public JsonNode buildProxyPullRequestBody(Partner partner, String contractID, String partnerEdcUrl) {
+    public JsonNode buildProxyPullRequestBody(String contractID, DspaceVersionParams dspaceVersionParams) {
         var body = getEdcContextObject();
-        body.put("connectorId", partner.getBpnl());
-        body.put("counterPartyAddress", partnerEdcUrl);
+        body.put("connectorId", dspaceVersionParams.counterPartyId());
+        body.put("counterPartyAddress", dspaceVersionParams.counterPartyAddress());
         body.put("contractId", contractID);
-        body.put("protocol", "dataspace-protocol-http");
+        body.put("protocol", dspaceVersionParams.protocol().getVersion());
         body.put("managedResources", false);
         body.put("transferType", "HttpData-PULL");
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/util/JsonLdUtils.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/util/JsonLdUtils.java
@@ -75,16 +75,17 @@ public class JsonLdUtils {
             profile2405.DSPACE_NAMESPACE, prefix + "dspace-v08.jsonld",
             JsonLdConstants.DCAT_NAMESPACE, prefix + "dcat.jsonld",
             JsonLdConstants.EDC_NAMESPACE, prefix + "edc-v1.jsonld",
-            JsonLdConstants.TX_AUTH_NAMESPACE, prefix + "tx-auth-v1.jsonld",
+            JsonLdConstants.TX_AUTH_CONTEXT, prefix + "tx-auth-v1.jsonld",
             JsonLdConstants.TX_NAMESPACE, prefix + "tx-v1.jsonld"
         );
         Map<String, String> filesMap2509 = Map.of(
             profile2509.CX_POLICY_CONTEXT, prefix + "cx-policy-2509.jsonld",
             profile2509.ODRL_REMOTE_CONTEXT, prefix + "odrl-2025-1.jsonld",
             profile2509.DSPACE_NAMESPACE, prefix + "dspace-v1.jsonld",
+            JsonLdConstants.DSPACE_CONTEXT_2025_1, prefix + "dspace-2025-1.jsonld",
             JsonLdConstants.DCAT_NAMESPACE, prefix + "dcat.jsonld",
             JsonLdConstants.EDC_NAMESPACE, prefix + "edc-v1.jsonld",
-            JsonLdConstants.TX_AUTH_NAMESPACE, prefix + "tx-auth-v1.jsonld",
+            JsonLdConstants.TX_AUTH_CONTEXT, prefix + "tx-auth-v1.jsonld",
             JsonLdConstants.TX_NAMESPACE, prefix + "tx-v1.jsonld"
         );
 

--- a/backend/src/main/resources/json-ld/dspace-2025-1.jsonld
+++ b/backend/src/main/resources/json-ld/dspace-2025-1.jsonld
@@ -1,0 +1,451 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "dct": "http://purl.org/dc/terms/",
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "dspace": "https://w3id.org/dspace/2025/1/",
+    "DatasetRequestMessage": {
+      "@id": "dspace:DatasetRequestMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "dataset": "dspace:dataset"
+      }
+    },
+    "CatalogRequestMessage": {
+      "@id": "dspace:CatalogRequestMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "filter": {
+          "@id": "dspace:filter",
+          "@container": "@set"
+        }
+      }
+    },
+    "CatalogError": {
+      "@id": "dspace:CatalogError",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "code": "dspace:code",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        }
+      }
+    },
+    "ContractRequestMessage": {
+      "@id": "dspace:ContractRequestMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "@import": "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
+        "@propagate": true,
+        "callbackAddress": "dspace:callbackAddress",
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "offer": {
+          "@type": "@id",
+          "@id": "dspace:offer"
+        }
+      }
+    },
+    "ContractOfferMessage": {
+      "@id": "dspace:ContractOfferMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "@import": "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
+        "@propagate": true,
+        "callbackAddress": "dspace:callbackAddress",
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "offer": {
+          "@type": "@id",
+          "@id": "dspace:offer"
+        }
+      }
+    },
+    "ContractAgreementMessage": {
+      "@id": "dspace:ContractAgreementMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "@import": "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
+        "@propagate": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "agreement": {
+          "@id": "dspace:agreement",
+          "@type": "@id"
+        },
+        "timestamp": "dspace:timestamp"
+      }
+    },
+    "ContractAgreementVerificationMessage": {
+      "@id": "dspace:ContractAgreementVerificationMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        }
+      }
+    },
+    "ContractNegotiationEventMessage": {
+      "@id": "dspace:ContractNegotiationEventMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "eventType": {
+          "@type": "@vocab",
+          "@id": "dspace:eventType"
+        }
+      }
+    },
+    "ContractNegotiationTerminationMessage": {
+      "@id": "dspace:ContractNegotiationTerminationMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "code": "dspace:code",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        },
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        }
+      }
+    },
+    "ContractNegotiation": {
+      "@id": "dspace:ContractNegotiation",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "state": {
+          "@type": "@vocab",
+          "@id": "dspace:state"
+        }
+      }
+    },
+    "ContractNegotiationError": {
+      "@id": "dspace:ContractNegotiationError",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "code": "dspace:code",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        }
+      }
+    },
+    "TransferRequestMessage": {
+      "@id": "dspace:TransferRequestMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "callbackAddress": "dspace:callbackAddress",
+        "dataAddress": "dspace:dataAddress",
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "format": {
+          "@type": "@vocab",
+          "@id": "dct:format"
+        },
+        "agreementId": {
+          "@type": "@id",
+          "@id": "dspace:agreementId"
+        }
+      }
+    },
+    "TransferStartMessage": {
+      "@id": "dspace:TransferStartMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "dataAddress": "dspace:dataAddress"
+      }
+    },
+    "TransferCompletionMessage": {
+      "@id": "dspace:TransferCompletionMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        }
+      }
+    },
+    "TransferTerminationMessage": {
+      "@id": "dspace:TransferTerminationMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "code": "dspace:code",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        },
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        }
+      }
+    },
+    "TransferSuspensionMessage": {
+      "@id": "dspace:TransferSuspensionMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "code": "dspace:code",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        },
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        }
+      }
+    },
+    "TransferError": {
+      "@id": "dspace:TransferError",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "code": "dspace:code",
+        "consumerPid": "dspace:consumerPid",
+        "providerPid": "dspace:providerPid",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        }
+      }
+    },
+    "DataAddress": {
+      "@id": "dspace:DataAddress",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "endpointType": {
+          "@type": "@vocab",
+          "@id": "dspace:endpointType"
+        },
+        "endpointProperties": {
+          "@id": "dspace:endpointProperties",
+          "@container": "@set"
+        },
+        "endpoint": "dspace:endpoint"
+      }
+    },
+    "EndpointProperty": {
+      "@id": "dspace:EndpointProperty",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "name": "dspace:name",
+        "value": "dspace:value"
+      }
+    },
+    "TransferProcess": {
+      "@id": "dspace:TransferProcess",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "state": {
+          "@type": "@vocab",
+          "@id": "dspace:state"
+        }
+      }
+    },
+    "VersionsError": {
+      "@id": "dspace:VersionsError",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "code": "dspace:code",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        }
+      }
+    },
+    "Catalog": {
+      "@id": "dcat:Catalog",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "service": {
+          "@id": "dcat:service",
+          "@container": "@set"
+        },
+        "participantId": {
+          "@type": "@id",
+          "@id": "dspace:participantId"
+        },
+        "catalog": {
+          "@id": "dcat:catalog",
+          "@container": "@set"
+        },
+        "dataset": {
+          "@id": "dcat:dataset",
+          "@container": "@set"
+        },
+        "distribution": {
+          "@id": "dcat:distribution",
+          "@container": "@set"
+        }
+      }
+    },
+    "Dataset": {
+      "@id": "dcat:Dataset",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "@import": "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
+        "@propagate": true,
+        "distribution": {
+          "@id": "dcat:distribution",
+          "@container": "@set"
+        },
+        "hasPolicy": {
+          "@id": "odrl:hasPolicy",
+          "@container": "@set"
+        }
+      }
+    },
+    "DataService": {
+      "@id": "dcat:DataService",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "endpointDescription": "dcat:endpointDescription",
+        "endpointURL": "dcat:endpointURL"
+      }
+    },
+    "Distribution": {
+      "@id": "dcat:Distribution",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "format": {
+          "@type": "@vocab",
+          "@id": "dct:format"
+        },
+        "accessService": {
+          "@id": "dcat:accessService"
+        }
+      }
+    },
+    "CatalogService": {
+      "@id":"dspace:CatalogService",
+      "@context": {
+        "id": "@id",
+        "type": "@type",
+        "serviceEndpoint": {
+          "@id": "https://www.w3.org/ns/did#serviceEndpoint",
+          "@type": "@id"
+        }
+      }
+    },
+    "ACCEPTED": "dspace:ACCEPTED",
+    "FINALIZED": "dspace:FINALIZED",
+    "REQUESTED": "dspace:REQUESTED",
+    "STARTED": "dspace:STARTED",
+    "COMPLETED": "dspace:COMPLETED",
+    "SUSPENDED": "dspace:SUSPENDED",
+    "TERMINATED": "dspace:TERMINATED",
+    "OFFERED": "dspace:OFFERED",
+    "AGREED": "dspace:AGREED",
+    "VERIFIED": "dspace:VERIFIED"
+  }
+}

--- a/backend/src/test/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterServiceTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterServiceTest.java
@@ -52,6 +52,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -390,6 +392,48 @@ public class EdcAdapterServiceTest {
         DspaceVersionParams actualDspaceVersionParams = edcAdapterService.getPartnerDspaceVersionParams(partnerBpnl, partnerDspUrl);
 
         assertEquals(expectedDspaceVerstionParams, actualDspaceVersionParams);
+    }
+
+    @Test
+    public void dspaceVersionParamsRequestedTwice_getDspaceVersionParams_usesCachedInformation() throws IOException {
+        String expectedCounterPartyAddress = "https://provider.domain.com/api/dsp/2025-1";
+        String expectedProtocolString = "dataspace-protocol-http:2025-1";
+        String expectedCounterPartyId = "did:web:one-example.com";
+        DspaceVersionParams expectedDspaceVerstionParams = new DspaceVersionParams(
+            expectedCounterPartyId,
+            expectedCounterPartyAddress,
+            DspProtocolVersionEnum.fromVersion(expectedProtocolString));
+
+        String validJsonLd = "[{\n" +
+            "  \"@context\": {\n" +
+            "    \"edc\": \"https://w3id.org/edc/v0.0.1/ns/\",\n" +
+            "    \"tx\": \"https://w3id.org/tractusx/v0.0.1/ns/\"\n" +
+            "  },\n" +
+            "  \"edc:counterPartyId\": \"" + expectedCounterPartyId + "\",\n" +
+            "  \"edc:counterPartyAddress\": \"" + expectedCounterPartyAddress + "\",\n" +
+            "  \"edc:protocol\": \"" + expectedProtocolString + "\"\n" +
+            "}]";
+
+        String partnerBpnl = "BPNL4444444444XX";
+        String partnerDspUrl = "http://customer-control-plane:8184/api/v1/dsp";
+
+        Response mockResponse = mock(Response.class);
+        ResponseBody mockBody = mock(ResponseBody.class);
+        when(mockResponse.code()).thenReturn(200);
+        when(mockResponse.isSuccessful()).thenReturn(true);
+        when(mockResponse.body()).thenReturn(mockBody);
+        when(mockBody.string()).thenReturn(validJsonLd);
+
+        doReturn(mockResponse)
+            .when(edcAdapterService)
+            .sendPostRequest(any(), any());
+
+        DspaceVersionParams firstCall = edcAdapterService.getPartnerDspaceVersionParams(partnerBpnl, partnerDspUrl);
+        DspaceVersionParams secondCall = edcAdapterService.getPartnerDspaceVersionParams(partnerBpnl, partnerDspUrl);
+
+        assertEquals(expectedDspaceVerstionParams, firstCall);
+        assertEquals(expectedDspaceVerstionParams, secondCall);
+        verify(edcAdapterService, times(1)).sendPostRequest(any(), any());
     }
 
     private final static String unexpectedProhibition = "{\n" +

--- a/backend/src/test/resources/json-ld/dspace-2025-1.jsonld
+++ b/backend/src/test/resources/json-ld/dspace-2025-1.jsonld
@@ -1,0 +1,451 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "dct": "http://purl.org/dc/terms/",
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "dspace": "https://w3id.org/dspace/2025/1/",
+    "DatasetRequestMessage": {
+      "@id": "dspace:DatasetRequestMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "dataset": "dspace:dataset"
+      }
+    },
+    "CatalogRequestMessage": {
+      "@id": "dspace:CatalogRequestMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "filter": {
+          "@id": "dspace:filter",
+          "@container": "@set"
+        }
+      }
+    },
+    "CatalogError": {
+      "@id": "dspace:CatalogError",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "code": "dspace:code",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        }
+      }
+    },
+    "ContractRequestMessage": {
+      "@id": "dspace:ContractRequestMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "@import": "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
+        "@propagate": true,
+        "callbackAddress": "dspace:callbackAddress",
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "offer": {
+          "@type": "@id",
+          "@id": "dspace:offer"
+        }
+      }
+    },
+    "ContractOfferMessage": {
+      "@id": "dspace:ContractOfferMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "@import": "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
+        "@propagate": true,
+        "callbackAddress": "dspace:callbackAddress",
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "offer": {
+          "@type": "@id",
+          "@id": "dspace:offer"
+        }
+      }
+    },
+    "ContractAgreementMessage": {
+      "@id": "dspace:ContractAgreementMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "@import": "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
+        "@propagate": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "agreement": {
+          "@id": "dspace:agreement",
+          "@type": "@id"
+        },
+        "timestamp": "dspace:timestamp"
+      }
+    },
+    "ContractAgreementVerificationMessage": {
+      "@id": "dspace:ContractAgreementVerificationMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        }
+      }
+    },
+    "ContractNegotiationEventMessage": {
+      "@id": "dspace:ContractNegotiationEventMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "eventType": {
+          "@type": "@vocab",
+          "@id": "dspace:eventType"
+        }
+      }
+    },
+    "ContractNegotiationTerminationMessage": {
+      "@id": "dspace:ContractNegotiationTerminationMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "code": "dspace:code",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        },
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        }
+      }
+    },
+    "ContractNegotiation": {
+      "@id": "dspace:ContractNegotiation",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "state": {
+          "@type": "@vocab",
+          "@id": "dspace:state"
+        }
+      }
+    },
+    "ContractNegotiationError": {
+      "@id": "dspace:ContractNegotiationError",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "code": "dspace:code",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        }
+      }
+    },
+    "TransferRequestMessage": {
+      "@id": "dspace:TransferRequestMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "callbackAddress": "dspace:callbackAddress",
+        "dataAddress": "dspace:dataAddress",
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "format": {
+          "@type": "@vocab",
+          "@id": "dct:format"
+        },
+        "agreementId": {
+          "@type": "@id",
+          "@id": "dspace:agreementId"
+        }
+      }
+    },
+    "TransferStartMessage": {
+      "@id": "dspace:TransferStartMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "dataAddress": "dspace:dataAddress"
+      }
+    },
+    "TransferCompletionMessage": {
+      "@id": "dspace:TransferCompletionMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        }
+      }
+    },
+    "TransferTerminationMessage": {
+      "@id": "dspace:TransferTerminationMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "code": "dspace:code",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        },
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        }
+      }
+    },
+    "TransferSuspensionMessage": {
+      "@id": "dspace:TransferSuspensionMessage",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "code": "dspace:code",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        },
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        }
+      }
+    },
+    "TransferError": {
+      "@id": "dspace:TransferError",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "code": "dspace:code",
+        "consumerPid": "dspace:consumerPid",
+        "providerPid": "dspace:providerPid",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        }
+      }
+    },
+    "DataAddress": {
+      "@id": "dspace:DataAddress",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "endpointType": {
+          "@type": "@vocab",
+          "@id": "dspace:endpointType"
+        },
+        "endpointProperties": {
+          "@id": "dspace:endpointProperties",
+          "@container": "@set"
+        },
+        "endpoint": "dspace:endpoint"
+      }
+    },
+    "EndpointProperty": {
+      "@id": "dspace:EndpointProperty",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "name": "dspace:name",
+        "value": "dspace:value"
+      }
+    },
+    "TransferProcess": {
+      "@id": "dspace:TransferProcess",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "providerPid": {
+          "@type": "@id",
+          "@id": "dspace:providerPid"
+        },
+        "consumerPid": {
+          "@type": "@id",
+          "@id": "dspace:consumerPid"
+        },
+        "state": {
+          "@type": "@vocab",
+          "@id": "dspace:state"
+        }
+      }
+    },
+    "VersionsError": {
+      "@id": "dspace:VersionsError",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "code": "dspace:code",
+        "reason": {
+          "@id": "dspace:reason",
+          "@container": "@set"
+        }
+      }
+    },
+    "Catalog": {
+      "@id": "dcat:Catalog",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "service": {
+          "@id": "dcat:service",
+          "@container": "@set"
+        },
+        "participantId": {
+          "@type": "@id",
+          "@id": "dspace:participantId"
+        },
+        "catalog": {
+          "@id": "dcat:catalog",
+          "@container": "@set"
+        },
+        "dataset": {
+          "@id": "dcat:dataset",
+          "@container": "@set"
+        },
+        "distribution": {
+          "@id": "dcat:distribution",
+          "@container": "@set"
+        }
+      }
+    },
+    "Dataset": {
+      "@id": "dcat:Dataset",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "@import": "https://w3id.org/dspace/2025/1/odrl-profile.jsonld",
+        "@propagate": true,
+        "distribution": {
+          "@id": "dcat:distribution",
+          "@container": "@set"
+        },
+        "hasPolicy": {
+          "@id": "odrl:hasPolicy",
+          "@container": "@set"
+        }
+      }
+    },
+    "DataService": {
+      "@id": "dcat:DataService",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "endpointDescription": "dcat:endpointDescription",
+        "endpointURL": "dcat:endpointURL"
+      }
+    },
+    "Distribution": {
+      "@id": "dcat:Distribution",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "format": {
+          "@type": "@vocab",
+          "@id": "dct:format"
+        },
+        "accessService": {
+          "@id": "dcat:accessService"
+        }
+      }
+    },
+    "CatalogService": {
+      "@id":"dspace:CatalogService",
+      "@context": {
+        "id": "@id",
+        "type": "@type",
+        "serviceEndpoint": {
+          "@id": "https://www.w3.org/ns/did#serviceEndpoint",
+          "@type": "@id"
+        }
+      }
+    },
+    "ACCEPTED": "dspace:ACCEPTED",
+    "FINALIZED": "dspace:FINALIZED",
+    "REQUESTED": "dspace:REQUESTED",
+    "STARTED": "dspace:STARTED",
+    "COMPLETED": "dspace:COMPLETED",
+    "SUSPENDED": "dspace:SUSPENDED",
+    "TERMINATED": "dspace:TERMINATED",
+    "OFFERED": "dspace:OFFERED",
+    "AGREED": "dspace:AGREED",
+    "VERIFIED": "dspace:VERIFIED"
+  }
+}


### PR DESCRIPTION
## Description

- updated negotiation and transfer requests to utilize latest supported DSP version
- added missing JsonLd context files

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files ([TRG 7.02](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02)
- [x] Documentation Notice are present on all affected files ([TRG 7.07](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07))
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
- [x] **Changelog** updated (`changelog.md`) with PR reference and brief summary.
- [x] **Frontend** version bumped, if needed (`frontend/package.json`, `frontend/package-lock.json`)
- [x] **Backend** version bumped, if needed (`backend/pom.xml`)
- [x] **Open API** specification updated, if controllers have been changed (use python script `scripts/generate_openapi_yaml.py` with running customer backend)
