### PR TITLE
chore: update dependabot config to group security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,13 +26,32 @@ updates:
     directory: "/backend/"
     schedule:
       interval: "daily"
+    groups:
+      backend-security-updates:
+        applies-to: "security-updates"
 
   - package-ecosystem: "npm"
-    directory: "/frontend/"
+    directories: 
+      - "/frontend/"
+      - "/local/"
     schedule:
       interval: "daily"
+    groups:
+      frontend-security-updates:
+        applies-to: "security-updates"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      github-actions-security-updates:
+        applies-to: "security-updates"
+  
+  - package-ecosystem: "pip"
+    directory: "/local/"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-security-updates:
+        applies-to: "security-updates"


### PR DESCRIPTION
## Description

- added rule for "pip" package ecosystem
- included "/local/" in npm rule
- added security update groups per package ecosystem

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files ([TRG 7.02](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02))
- [x] Documentation Notice are present on all affected files ([TRG 7.07](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07))
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
- [x] **Changelog** updated (`changelog.md`) with PR reference and brief summary.
- [x] **Frontend** version bumped, if needed (`frontend/package.json`, `frontend/package-lock.json`)
- [x] **Backend** version bumped, if needed (`backend/pom.xml`)
- [x] **Open API** specification updated, if controllers have been changed (use python script `scripts/generate_openapi_yaml.py` with running customer backend)
