### PR TITLE
feat: remove PasswordEncoder and change it with custom anoynmization 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,76 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v6.1.1
+
+The following Changelog lists the changes. Please refer to the [documentation](docs/README.md) for configuration needs and understanding the concept changes.
+
+The **need for configuration updates** is **marked bold**.
+
+### Added
+
+- /
+
+### Changed
+
+- /
+
+### Fixes
+
+- **replaced `BCryptPasswordEncoder` with a custom HMAC-SHA256-based `AnonymizationService` for hashing identifiers in anonymized submodels** ([#1180](https://github.com/eclipse-tractusx/puris/pull/1180))
+
+### Version Bumps
+
+- /
+
+### Known Knowns
+
+#### Running With Shared DTR and EDC
+
+PURIS FOSS may not be run on a shared DTR and EDC with full scope. See [Admin Guide](docs/admin/Admin_Guide.md#running-the-puris-foss-application-on-shared-enablement-services) for more information of possible scenarios.
+
+#### Limitations to anonymized submodels
+
+ Currently, the anonymized submodels are limited to single customer scenarios, where each Digital Twin is exclusive to one partner. 
+#### Upgradeability
+
+Data base migrations are performed but assets.
+
+#### Data Sovereignty
+
+For productive use the following enhancements are encouraged
+
+* User FrontEnd available: Role Company Admin is able to query catalogue and see negotiations and transfers But company rules / policies need to be configured upfront in backend (via postman) to enable automatic contract negotiations, responsibility lies with Company Admin role  
+  --> add section in the User Manual describing this and the (legal) importance and responsibility behind defining these rules
+* Currently only one standard policy per reg. connector / customer instance is supported (more precisely one for DTR, one for all submodels), negotiation happens automatically based on this  
+  --> enhance option to select partner and define specific policies (to be planned in context of BPDM Integration)  
+  --> UI for specific configuration by dedicated role (e.g. Comp Admin) and more flexible policy configuration (withoutv code changes) is needed
+* As a non-Admin user I do not have ability to view policies in detail  
+  --> transparency for users when interacting with and requesting / consuming data via dashboard / views on underlying usage policies to be enhanced
+* ContractReference Constraint or configuration of policies specific to one partner only has notnot implemented  
+  --> clarification of potential reference to "PURIS standard contract" and enabling of ContractReference for 24.08.
+* unclear meaning of different stati in negotations  
+  --> add view of successfull contract agreeements wrt which data have been closed
+* current logging only done on info level  
+  --> enhance logging of policies (currently only available at debug level)
+* in case of non-matching policies (tested in various scenarios) no negotiation takes place  
+  --> enhance visualization or specific Error message to user
+* no validation of the Schema "profile": "cx-policy:profile2405" (required to ensure interop with other PURIS apps)
+
+#### Styleguide
+
+##### Overall
+
+* Brief description at the top of each page describing content would be nice for better user experience.
+
+##### Catalog
+
+* No action possible -> unclear to user when and how user will consume an offer
+
+##### Negotiations
+
+* Add filters for transparency (bpnl, state)
+
 ## v6.1.0
 
 The following Changelog lists the changes. Please refer to the [documentation](docs/README.md) for configuration needs and understanding the concept changes.

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <groupId>org.eclipse.tractusx.puris</groupId>
     <artifactId>puris-backend</artifactId>
-    <version>6.1.0</version>
+    <version>6.1.1</version>
     <name>puris-backend</name>
     <description>PURIS Backend</description>
     <properties>

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/security/SecurityConfig.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/security/SecurityConfig.java
@@ -43,8 +43,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -52,8 +50,6 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.List;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 @EnableWebSecurity
@@ -155,11 +151,6 @@ public class SecurityConfig {
     @ConditionalOnProperty(name = "puris.dtr.idp.enabled", havingValue = "true")
     public OAuth2ClientInterceptor oAuth2ClientInterceptor() {
         return new OAuth2ClientInterceptor(objectMapper, dtrSecurityConfiguration.getTokenUrl(), dtrSecurityConfiguration.getPurisClientId(), dtrSecurityConfiguration.getPurisClientSecret(), dtrSecurityConfiguration.getGrant_type());
-    }
-
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
     }
 
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/security/logic/AnonymizationService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/security/logic/AnonymizationService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Volkswagen AG
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.tractusx.puris.backend.common.security.logic;
+
+import org.springframework.stereotype.Service;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.util.Base64;
+
+/**
+ * Anonymizes identifiers (e.g. global asset IDs, BPNS) sent to a partner as part of an
+ * anonymized SAMM payload, by hashing them with HMAC-SHA256 keyed with a per-request salt
+ * (e.g. the contract agreement id) so hashes cannot be correlated across agreements.
+ */
+@Service
+public class AnonymizationService {
+
+    private static final String HMAC_ALGORITHM = "HmacSHA256";
+
+    public String anonymize(String value, String salt) {
+        try {
+            Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+            mac.init(new SecretKeySpec(salt.getBytes(StandardCharsets.UTF_8), HMAC_ALGORITHM));
+            byte[] hmacBytes = mac.doFinal(value.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(hmacBytes);
+        } catch (GeneralSecurityException e) {
+            throw new IllegalStateException("Failed to anonymize value", e);
+        }
+    }
+}

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/delivery/logic/adapter/DeliveryInformationSammMapper.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/delivery/logic/adapter/DeliveryInformationSammMapper.java
@@ -20,6 +20,7 @@
 package org.eclipse.tractusx.puris.backend.delivery.logic.adapter;
 
 import org.eclipse.tractusx.puris.backend.common.domain.model.measurement.ItemQuantityEntity;
+import org.eclipse.tractusx.puris.backend.common.security.logic.AnonymizationService;
 import org.eclipse.tractusx.puris.backend.delivery.domain.model.EventTypeEnumeration;
 import org.eclipse.tractusx.puris.backend.delivery.domain.model.OwnDelivery;
 import org.eclipse.tractusx.puris.backend.delivery.domain.model.ReportedDelivery;
@@ -37,7 +38,6 @@ import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.MaterialPartnerRelationService;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.MaterialService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import lombok.extern.slf4j.Slf4j;
 import java.util.ArrayList;
@@ -56,7 +56,7 @@ public class DeliveryInformationSammMapper {
     private MaterialService materialService;
 
     @Autowired
-    private PasswordEncoder passwordEncoder;
+    private AnonymizationService anonymizationService;
 
     public DeliveryInformation ownDeliveryToSamm(List<OwnDelivery> deliveryList, Partner partner, Material material) {
         if (deliveryList.stream().anyMatch(deli -> !deli.getPartner().equals(partner))) {
@@ -122,15 +122,15 @@ public class DeliveryInformationSammMapper {
             return null;
         }
         DeliveryInformationAnonymized samm = new DeliveryInformationAnonymized();
-        samm.setMaterialGlobalAssetIdAnonymized(passwordEncoder.encode(material.getMaterialNumberCx() + salt));
+        samm.setMaterialGlobalAssetIdAnonymized(anonymizationService.anonymize(material.getMaterialNumberCx(), salt));
         samm.setDeliveries(new HashSet<>());
         for (var delivery : deliveryList) {
             var anonymizedDelivery = new DeliveryAnonymized(
                 new ItemQuantityEntity(delivery.getQuantity(), delivery.getMeasurementUnit()),
                 delivery.getLastUpdatedOnDateTime(),
                 Set.of(new TransitEvent(delivery.getDateOfDeparture(), delivery.getDepartureType()), new TransitEvent(delivery.getDateOfArrival(), delivery.getArrivalType())),
-                passwordEncoder.encode(delivery.getOriginBpns() + salt),
-                passwordEncoder.encode(delivery.getDestinationBpns() + salt)
+                anonymizationService.anonymize(delivery.getOriginBpns(), salt),
+                anonymizationService.anonymize(delivery.getDestinationBpns(), salt)
             );
             samm.getDeliveries().add(anonymizedDelivery);
         }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/production/logic/adapter/PlannedProductionSammMapper.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/production/logic/adapter/PlannedProductionSammMapper.java
@@ -20,6 +20,7 @@
 package org.eclipse.tractusx.puris.backend.production.logic.adapter;
 
 import org.eclipse.tractusx.puris.backend.common.domain.model.measurement.ItemQuantityEntity;
+import org.eclipse.tractusx.puris.backend.common.security.logic.AnonymizationService;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.MaterialPartnerRelationService;
@@ -29,7 +30,6 @@ import org.eclipse.tractusx.puris.backend.production.logic.dto.plannedproduction
 import org.eclipse.tractusx.puris.backend.production.logic.dto.anonymizedplannedproductionsamm.PlannedProductionOutputAnonymized;
 import org.eclipse.tractusx.puris.backend.production.logic.dto.anonymizedplannedproductionsamm.AllocatedPlannedProductionOutputAnonymized;
 
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import lombok.extern.slf4j.Slf4j;
@@ -45,7 +45,7 @@ public class PlannedProductionSammMapper {
     private MaterialPartnerRelationService mprService;
 
     @Autowired
-    private PasswordEncoder passwordEncoder;
+    private AnonymizationService anonymizationService;
 
     public PlannedProductionOutput ownProductionToSamm(List<OwnProduction> production, Partner partner, Material material) {
         if (production.stream().anyMatch(prod -> !prod.getPartner().equals(partner))) {
@@ -106,12 +106,12 @@ public class PlannedProductionSammMapper {
             return null;
         }
         PlannedProductionOutputAnonymized samm = new PlannedProductionOutputAnonymized();
-        samm.setMaterialGlobalAssetIdAnonymized(passwordEncoder.encode(material.getMaterialNumberCx() + salt));
+        samm.setMaterialGlobalAssetIdAnonymized(anonymizationService.anonymize(material.getMaterialNumberCx(), salt));
         samm.setAllocatedPlannedProductionOutputs(new HashSet<>());
         for (var production : productionList) {
             var anonymizedAllocatedPlannedProductionOutput = new AllocatedPlannedProductionOutputAnonymized(
                 new ItemQuantityEntity(production.getQuantity(), production.getMeasurementUnit()),
-                passwordEncoder.encode(production.getProductionSiteBpns() + salt),
+                anonymizationService.anonymize(production.getProductionSiteBpns(), salt),
                 production.getEstimatedTimeOfCompletion(),
                 production.getLastUpdatedOnDateTime()
             );

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/adapter/ItemStockSammMapper.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/logic/adapter/ItemStockSammMapper.java
@@ -22,6 +22,7 @@ package org.eclipse.tractusx.puris.backend.stock.logic.adapter;
 
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.tractusx.puris.backend.common.domain.model.measurement.ItemQuantityEntity;
+import org.eclipse.tractusx.puris.backend.common.security.logic.AnonymizationService;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.MaterialPartnerRelationService;
@@ -31,7 +32,6 @@ import org.eclipse.tractusx.puris.backend.stock.logic.dto.anonymizeditemstocksam
 import org.eclipse.tractusx.puris.backend.stock.logic.dto.anonymizeditemstocksamm.ItemStockAnonymizedSamm;
 import org.eclipse.tractusx.puris.backend.stock.logic.dto.itemstocksamm.*;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -48,7 +48,7 @@ public class ItemStockSammMapper {
     @Autowired
     private MaterialPartnerRelationService mprService;
     @Autowired
-    private PasswordEncoder passwordEncoder;
+    private AnonymizationService anonymizationService;
 
     public ItemStockSamm materialItemStocksToItemStockSamm(List<MaterialItemStock> materialItemStocks, Partner partner, Material material) {
         return listToItemStockSamm(materialItemStocks, DirectionCharacteristic.INBOUND, partner, material);
@@ -130,16 +130,16 @@ public class ItemStockSammMapper {
         ItemStockAnonymizedSamm samm = new ItemStockAnonymizedSamm();
 
         if (directionCharacteristic == DirectionCharacteristic.INBOUND) {
-            samm.setMaterialGlobalAssetIdAnonymized(passwordEncoder.encode(mprService.find(material, partner).getPartnerCXNumber() + salt));
+            samm.setMaterialGlobalAssetIdAnonymized(anonymizationService.anonymize(mprService.find(material, partner).getPartnerCXNumber(), salt));
         } else {
-            samm.setMaterialGlobalAssetIdAnonymized(passwordEncoder.encode(material.getMaterialNumberCx() + salt));
+            samm.setMaterialGlobalAssetIdAnonymized(anonymizationService.anonymize(material.getMaterialNumberCx(), salt));
         }
 
         samm.setDirection(directionCharacteristic);
         var anonymizedAllocatedStockList = new HashSet<AllocatedStockAnonymized>();
         for (var itemStock : itemStocks) {
             ItemQuantityEntity itemQuantityEntity = new ItemQuantityEntity(itemStock.getQuantity(), itemStock.getMeasurementUnit());
-            AllocatedStockAnonymized allocatedStock = new AllocatedStockAnonymized(itemQuantityEntity, passwordEncoder.encode(itemStock.getLocationBpns() + salt), itemStock.isBlocked(), itemStock.getLastUpdatedOnDateTime());
+            AllocatedStockAnonymized allocatedStock = new AllocatedStockAnonymized(itemQuantityEntity, anonymizationService.anonymize(itemStock.getLocationBpns(), salt), itemStock.isBlocked(), itemStock.getLastUpdatedOnDateTime());
             anonymizedAllocatedStockList.add(allocatedStock);
         }
         samm.setAllocatedStocksAnonymized(anonymizedAllocatedStockList);

--- a/backend/src/test/java/org/eclipse/tractusx/puris/backend/delivery/logic/adapter/DeliveryInformationSammMapperTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/puris/backend/delivery/logic/adapter/DeliveryInformationSammMapperTest.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import org.eclipse.tractusx.puris.backend.common.domain.model.measurement.ItemQuantityEntity;
 import org.eclipse.tractusx.puris.backend.common.domain.model.measurement.ItemUnitEnumeration;
+import org.eclipse.tractusx.puris.backend.common.security.logic.AnonymizationService;
 import org.eclipse.tractusx.puris.backend.delivery.domain.model.EventTypeEnumeration;
 import org.eclipse.tractusx.puris.backend.delivery.domain.model.ReportedDelivery;
 import org.eclipse.tractusx.puris.backend.delivery.domain.model.OwnDelivery;
@@ -50,7 +51,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -92,7 +92,7 @@ class DeliveryInformationSammMapperTest {
     MaterialService materialService;
 
     @Mock
-    PasswordEncoder passwordEncoder;
+    AnonymizationService anonymizationService;
 
     @Test
     void ownDeliveryToSamm_success() {
@@ -161,7 +161,7 @@ class DeliveryInformationSammMapperTest {
                 .lastUpdatedOnDateTime(now)
                 .build();
 
-        when(passwordEncoder.encode(anyString())).thenAnswer(invocation -> "enc:" + invocation.getArgument(0));
+        when(anonymizationService.anonymize(anyString(), anyString())).thenAnswer(invocation -> "enc:" + invocation.getArgument(0));
 
         var samm = mapper.ownDeliveryToAnonymizedSamm(List.of(od), PARTNER, MATERIAL_3, "SALT");
         assertNotNull(samm);

--- a/backend/src/test/java/org/eclipse/tractusx/puris/backend/production/logic/adapter/PlannedProductionSammMapperTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/puris/backend/production/logic/adapter/PlannedProductionSammMapperTest.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import org.eclipse.tractusx.puris.backend.common.domain.model.measurement.ItemQuantityEntity;
 import org.eclipse.tractusx.puris.backend.common.domain.model.measurement.ItemUnitEnumeration;
+import org.eclipse.tractusx.puris.backend.common.security.logic.AnonymizationService;
 import org.eclipse.tractusx.puris.backend.production.domain.model.ReportedProduction;
 import org.eclipse.tractusx.puris.backend.production.domain.model.OwnProduction;
 import org.eclipse.tractusx.puris.backend.production.logic.dto.anonymizedplannedproductionsamm.AllocatedPlannedProductionOutputAnonymized;
@@ -47,7 +48,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
@@ -90,7 +90,7 @@ class PlannedProductionSammMapperTest {
     MaterialService materialService;
 
     @Mock
-    PasswordEncoder passwordEncoder;
+    AnonymizationService anonymizationService;
 
     @Test
     void ownProductionToSamm_success() {
@@ -152,7 +152,7 @@ class PlannedProductionSammMapperTest {
                 .estimatedTimeOfCompletion(now)
                 .build();
 
-        when(passwordEncoder.encode(anyString())).thenAnswer(invocation -> "enc:" + invocation.getArgument(0));
+        when(anonymizationService.anonymize(anyString(), anyString())).thenAnswer(invocation -> "enc:" + invocation.getArgument(0));
 
         var samm = mapper.ownProductionToAnonymizedSamm(List.of(op), PARTNER, MATERIAL_3, "SALT");
         assertNotNull(samm);

--- a/backend/src/test/java/org/eclipse/tractusx/puris/backend/stock/logic/adapter/ItemStockAnonymizedSammMapperTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/puris/backend/stock/logic/adapter/ItemStockAnonymizedSammMapperTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.eclipse.tractusx.puris.backend.common.domain.model.measurement.ItemUnitEnumeration;
+import org.eclipse.tractusx.puris.backend.common.security.logic.AnonymizationService;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.MaterialPartnerRelation;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
@@ -46,7 +47,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import static org.mockito.Mockito.when;
 import org.mockito.MockitoAnnotations;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class ItemStockAnonymizedSammMapperTest {
@@ -92,7 +92,7 @@ public class ItemStockAnonymizedSammMapperTest {
     private MaterialService materialService;
 
     @Mock
-    PasswordEncoder passwordEncoder;
+    AnonymizationService anonymizationService;
 
     @InjectMocks
     private ItemStockSammMapper itemStockSammMapper;
@@ -136,7 +136,7 @@ public class ItemStockAnonymizedSammMapperTest {
         // When
         when(mprService.find(semiconductorMaterial, supplierPartner)).thenReturn(mpr);
 
-        when(passwordEncoder.encode(anyString())).thenAnswer(invocation -> "enc:" + invocation.getArgument(0));
+        when(anonymizationService.anonymize(anyString(), anyString())).thenAnswer(invocation -> "enc:" + invocation.getArgument(0));
 
         ItemStockAnonymizedSamm materialItemStockAnonymizedSamm = itemStockSammMapper.materialItemStocksToItemStockAnonymizedSamm(List.of(materialItemStock), supplierPartner, semiconductorMaterial, "SALT");
 

--- a/charts/puris/Chart.yaml
+++ b/charts/puris/Chart.yaml
@@ -36,10 +36,10 @@ dependencies:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 7.1.0
+version: 7.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "6.1.0"
+appVersion: "6.1.1"

--- a/charts/puris/README.md
+++ b/charts/puris/README.md
@@ -1,6 +1,6 @@
 # puris
 
-![Version: 7.1.0](https://img.shields.io/badge/Version-7.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.1.0](https://img.shields.io/badge/AppVersion-6.1.0-informational?style=flat-square)
+![Version: 7.1.1](https://img.shields.io/badge/Version-7.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.1.1](https://img.shields.io/badge/AppVersion-6.1.1-informational?style=flat-square)
 
 A helm chart for Kubernetes deployment of PURIS
 

--- a/docs/api/openAPI.yaml
+++ b/docs/api/openAPI.yaml
@@ -1848,7 +1848,7 @@ components:
       type: apiKey
 info:
   title: PURIS FOSS Open API
-  version: 6.1.0
+  version: 6.1.1
 openapi: 3.1.0
 paths:
   /batch/partner-data-update:
@@ -2391,9 +2391,8 @@ paths:
           description: Internal Server Error
         '501':
           description: Unsupported representation
-      summary: 'This endpoint receives the Delivery Information Anonymized Submodel
-        1.0.0 requests. This endpoint is meant to be accessed by our own EDC only,
-        on behalf of the partner identified by the bpnl path parameter. '
+      summary: This endpoint receives the Delivery Information Anonymized Submodel
+        1.0.0 requests. This endpoint is meant to be accessed by our own EDC only.
       tags:
       - delivery-request-api-controller
   /delivery-information/request/{materialNumberCx}/submodel/{representation}:
@@ -3290,8 +3289,7 @@ paths:
         '501':
           description: Unsupported representation
       summary: 'This endpoint receives the ItemStockAnonymized Submodel 1.0.0 requests.
-        This endpoint is meant to be accessed by our own EDC only, on behalf of the
-        partner identified by the bpnl path parameter. '
+        This endpoint is meant to be accessed by our own EDC only. '
       tags:
       - item-stock-request-api-controller
   /item-stock/request/{materialnumber}/{direction}/submodel/{representation}:
@@ -4176,8 +4174,7 @@ paths:
         '501':
           description: Unsupported representation
       summary: 'This endpoint receives the Anonymized Planned Production Submodel
-        1.0.0 requests. This endpoint is meant to be accessed by our own EDC only,
-        on behalf of the partner identified by the bpnl path parameter. '
+        1.0.0 requests. This endpoint is meant to be accessed by our own EDC only. '
       tags:
       - production-request-api-controller
   /planned-production/request/{materialnumbercx}/submodel/{representation}:

--- a/docs/architecture/06_runtime_view.md
+++ b/docs/architecture/06_runtime_view.md
@@ -176,7 +176,7 @@ SubmodelDescriptor → contract submodel asset → transfer → EDR → `$value`
 
 3. **Contract-scoped anonymization**  
    Selected sensitive properties are replaced by hashed variants, and some are omitted entirely.
-   Hashing uses Spring Security’s `PasswordEncoder` with a **salt** to reduce correlation across agreements.
+   Hashing uses a custom `AnonymizationService` (HMAC-SHA256, Base64-encoded) with a **salt** to reduce correlation across agreements.
    The salt is taken from the **contract agreement id** supplied in request header `contract-agreement-id`.
 
 4. **Self-access enforcement via BPNL path segment**  

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "puris-frontend",
-    "version": "6.1.0",
+    "version": "6.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "puris-frontend",
-            "version": "6.1.0",
+            "version": "6.1.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@catena-x/portal-shared-components": "^2.1.31",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
     "name": "puris-frontend",
     "description": "Puris frontend",
     "license": "Apache-2.0",
-    "version": "6.1.0",
+    "version": "6.1.1",
     "type": "module",
     "scripts": {
         "dev": "npm run customer & npm run supplier",


### PR DESCRIPTION
…function

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

- replaced `BCryptPasswordEncoder` with a custom HMAC-SHA256-based `AnonymizationService` for hashing identifiers in anonymized submodels** 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
relates to: ([#1178](https://github.com/eclipse-tractusx/puris/issues/1178))
## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files ([TRG 7.02](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02))
- [x] Documentation Notice are present on all affected files ([TRG 7.07](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07))
- [ ] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
- [x] **Changelog** updated (`changelog.md`) with PR reference and brief summary.
- [x] **Frontend** version bumped, if needed (`frontend/package.json`, `frontend/package-lock.json`)
- [x] **Backend** version bumped, if needed (`backend/pom.xml`)
- [x] **Open API** specification updated, if controllers have been changed (use python script `scripts/generate_openapi_yaml.py` with running customer backend)
