### PR TITLE
fix: fix failing DTR tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The **need for configuration updates** is **marked bold**.
 
 ### Fixes
 
-- /
+- Fix the new part type information controller that was causing an issue with the DTR tests ([#1204](https://github.com/eclipse-tractusx/puris/pull/1204))
 
 ### Version Bumps
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
@@ -1424,12 +1424,13 @@ public class EdcAdapterService {
      */
     public String getCxIdFromPartTypeInformation(MaterialPartnerRelation mpr) {
         String cxId = fetchCxId(mpr, AssetType.PART_TYPE_INFORMATION_SUBMODEL);
-        if (cxId != null) {
-            return cxId;
+        if (cxId != null) return cxId;
+        log.info("PartTypeInformation 2.0.0 unavailable at partner {} for {}, falling back to 1.0.0", mpr.getPartner().getBpnl(), mpr.getMaterial().getOwnMaterialNumber());
+        cxId = fetchCxId(mpr, AssetType.PART_TYPE_INFORMATION_LEGACY_SUBMODEL);
+        if (cxId == null) {
+            log.error("Could not obtain partner CX id for {} from {} via either PartTypeInformation version", mpr.getMaterial().getOwnMaterialNumber(), mpr.getPartner().getBpnl());
         }
-        log.info("PartTypeInformation 2.0.0 unavailable at partner {} for {}, falling back to 1.0.0",
-            mpr.getPartner().getBpnl(), mpr.getMaterial().getOwnMaterialNumber());
-        return fetchCxId(mpr, AssetType.PART_TYPE_INFORMATION_LEGACY_SUBMODEL);
+        return cxId;
     }
 
     private String fetchCxId(MaterialPartnerRelation mpr, AssetType type) {

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartTypeInformationController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartTypeInformationController.java
@@ -155,7 +155,7 @@ public class PartTypeInformationController {
             return ProductLookup.error(HttpStatus.UNAUTHORIZED);
         }
         log.info("{} requests part type information {} on {}", bpnl, version, decodedMaterialNumber.replaceAll("[\\r\\n]", "_"));
-        Material material = materialService.findByOwnMaterialNumber(materialnumber);
+        Material material = materialService.findByOwnMaterialNumber(decodedMaterialNumber);
         if (material == null || !material.isProductFlag()) {
             return ProductLookup.error(HttpStatus.NOT_FOUND);
         }


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
- Fix the part type information controller that was causing an issue with the DTR tests

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files ([TRG 7.02](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02))
- [x] Documentation Notice are present on all affected files ([TRG 7.07](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07))
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
- [x] **Changelog** updated (`changelog.md`) with PR reference and brief summary.
- [x] **Frontend** version bumped, if needed (`frontend/package.json`, `frontend/package-lock.json`)
- [x] **Backend** version bumped, if needed (`backend/pom.xml`)
- [x] **Open API** specification updated, if controllers have been changed (use python script `scripts/generate_openapi_yaml.py` with running customer backend)
