### PR TITLE
Fix/policy store left operands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The **need for configuration updates** is **marked bold**.
   - Added frontend implementation of data exhcange requests and approvals ([#1175](https://github.com/eclipse-tractusx/puris/pull/1175))
   - Updated documentation files with new feature information ([#1190](https://github.com/eclipse-tractusx/puris/pull/1190))
 - Added IRS Adapter to exchange data with an external Item Relationship Service
-  - Added PolicyStoreService and IrsRequestQueue to register policies on startup ([#1195](https://github.com/eclipse-tractusx/puris/pull/1195))
+  - Added PolicyStoreService and IrsRequestQueue to register policies on startup ([#1195](https://github.com/eclipse-tractusx/puris/pull/1195), [#1208](https://github.com/eclipse-tractusx/puris/pull/1208))
   - Added Logic to manage Irs Grants and keep them in sync with application state ([#1203](https://github.com/eclipse-tractusx/puris/pull/1203))
   - Added Job Management logic to create jobs and automatically poll for results ([#1205](https://github.com/eclipse-tractusx/puris/pull/1205))
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/irs/logic/service/IrsRequestBodybuilder.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/irs/logic/service/IrsRequestBodybuilder.java
@@ -99,9 +99,10 @@ public class IrsRequestBodybuilder {
 
         ObjectNode payload = objectMapper.createObjectNode();
         ObjectNode context = objectMapper.createObjectNode();
+        String policyNamespace = PolicyProfileVersionEnumeration.POLICY_PROFILE_2405.CX_POLICY_NAMESPACE;
         context.put("odrl", JsonLdConstants.ODRL_NAMESPACE);
         context.put("edc", JsonLdConstants.EDC_NAMESPACE);
-        context.put("cx-policy", PolicyProfileVersionEnumeration.POLICY_PROFILE_2405.CX_POLICY_CONTEXT);
+        context.put("cx-policy", policyNamespace);
         payload.set("@context", context);
         payload.put("@type", "PolicyDefinitionRequestDto");
         payload.put("@id", policyId);
@@ -113,7 +114,6 @@ public class IrsRequestBodybuilder {
         ObjectNode permission = objectMapper.createObjectNode();
         permission.put("odrl:action", "use");
 
-        String policyNamespace = PolicyProfileVersionEnumeration.POLICY_PROFILE_2405.CX_POLICY_NAMESPACE;
         ObjectNode constraint = objectMapper.createObjectNode();
         constraint.put("@type", "LogicalConstraint");
         ArrayNode andArray = objectMapper.createArrayNode();

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/irs/logic/service/IrsRequestBodybuilder.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/irs/logic/service/IrsRequestBodybuilder.java
@@ -89,7 +89,7 @@ public class IrsRequestBodybuilder {
      * EDC negotiation. No {@code businessPartnerNumber} is set, so the policy applies to every BPN.
      *
      * @param policyId the ID of the policy to be created
-     * @param purpose  the usage purpose to be set in the policy
+     * @param purpose the usage purpose to be set in the policy
      * @return the request body as a JsonNode
      */
     public JsonNode buildFrameworkPolicyCreationRequestBody(String policyId, String purpose) {

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/irs/logic/service/IrsRequestBodybuilder.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/irs/logic/service/IrsRequestBodybuilder.java
@@ -21,7 +21,6 @@ package org.eclipse.tractusx.puris.backend.irs.logic.service;
 import java.time.Duration;
 import java.time.Instant;
 
-import org.eclipse.tractusx.puris.backend.common.edc.domain.model.AssetType;
 import org.eclipse.tractusx.puris.backend.common.edc.domain.model.JsonLdConstants;
 import org.eclipse.tractusx.puris.backend.common.util.VariablesService;
 import org.eclipse.tractusx.puris.backend.irs.IrsAdapterConfiguration;
@@ -90,7 +89,7 @@ public class IrsRequestBodybuilder {
      * EDC negotiation. No {@code businessPartnerNumber} is set, so the policy applies to every BPN.
      *
      * @param policyId the ID of the policy to be created
-     * @param purpose the usage purpose to be set in the policy
+     * @param purpose  the usage purpose to be set in the policy
      * @return the request body as a JsonNode
      */
     public JsonNode buildFrameworkPolicyCreationRequestBody(String policyId, String purpose) {
@@ -104,18 +103,22 @@ public class IrsRequestBodybuilder {
         context.put("edc", JsonLdConstants.EDC_NAMESPACE);
         context.put("cx-policy", PolicyProfileVersionEnumeration.POLICY_PROFILE_2405.CX_POLICY_CONTEXT);
         payload.set("@context", context);
+        payload.put("@type", "PolicyDefinitionRequestDto");
         payload.put("@id", policyId);
 
         ObjectNode policy = objectMapper.createObjectNode();
+        policy.put("@type", "Set");
+        policy.put("profile", "cx-policy:" + PolicyProfileVersionEnumeration.POLICY_PROFILE_2405.getValue());
         ArrayNode permissions = objectMapper.createArrayNode();
         ObjectNode permission = objectMapper.createObjectNode();
         permission.put("odrl:action", "use");
-        permission.put("@type", "Set");
 
+        String policyNamespace = PolicyProfileVersionEnumeration.POLICY_PROFILE_2405.CX_POLICY_NAMESPACE;
         ObjectNode constraint = objectMapper.createObjectNode();
+        constraint.put("@type", "LogicalConstraint");
         ArrayNode andArray = objectMapper.createArrayNode();
-        andArray.add(buildEqConstraint("cx-policy:FrameworkAgreement", variablesService.getPurisFrameworkAgreementWithVersion()));
-        andArray.add(buildEqConstraint("cx-policy:UsagePurpose", purpose));
+        andArray.add(buildEqConstraint(policyNamespace + "FrameworkAgreement", variablesService.getPurisFrameworkAgreementWithVersion()));
+        andArray.add(buildEqConstraint(policyNamespace + "UsagePurpose", purpose));
         constraint.set("odrl:and", andArray);
         permission.set("odrl:constraint", constraint);
 
@@ -141,6 +144,7 @@ public class IrsRequestBodybuilder {
 
     private ObjectNode buildEqConstraint(String leftOperand, String rightOperand) {
         ObjectNode constraint = objectMapper.createObjectNode();
+        constraint.put("@type", "LogicalConstraint");
         constraint.put("odrl:leftOperand", leftOperand);
         ObjectNode operator = objectMapper.createObjectNode();
         operator.put("@id", "odrl:eq");

--- a/backend/src/test/java/org/eclipse/tractusx/puris/backend/irs/logic/service/IrsRequestBodybuilderTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/puris/backend/irs/logic/service/IrsRequestBodybuilderTest.java
@@ -70,7 +70,7 @@ class IrsRequestBodybuilderTest {
 
         assertThat(payload.get("@context").get("odrl").asText()).isEqualTo(JsonLdConstants.ODRL_NAMESPACE);
         assertThat(payload.get("@context").get("edc").asText()).isEqualTo(JsonLdConstants.EDC_NAMESPACE);
-        assertThat(payload.get("@context").get("cx-policy").asText()).isEqualTo(PolicyProfileVersionEnumeration.POLICY_PROFILE_2405.CX_POLICY_CONTEXT);
+        assertThat(payload.get("@context").get("cx-policy").asText()).isEqualTo(PolicyProfileVersionEnumeration.POLICY_PROFILE_2405.CX_POLICY_NAMESPACE);
         assertThat(payload.get("@id").asText()).isEqualTo("some-policy-id");
     }
 

--- a/backend/src/test/java/org/eclipse/tractusx/puris/backend/irs/logic/service/IrsRequestBodybuilderTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/puris/backend/irs/logic/service/IrsRequestBodybuilderTest.java
@@ -90,12 +90,14 @@ class IrsRequestBodybuilderTest {
         assertThat(andArray).hasSize(2);
 
         JsonNode frameworkAgreementConstraint = andArray.get(0);
-        assertThat(frameworkAgreementConstraint.get("odrl:leftOperand").asText()).isEqualTo("cx-policy:FrameworkAgreement");
+        String frameworkAgreementLeftOperand = PolicyProfileVersionEnumeration.POLICY_PROFILE_2405.CX_POLICY_NAMESPACE + "FrameworkAgreement";
+        assertThat(frameworkAgreementConstraint.get("odrl:leftOperand").asText()).isEqualTo(frameworkAgreementLeftOperand);
         assertThat(frameworkAgreementConstraint.get("odrl:operator").get("@id").asText()).isEqualTo("odrl:eq");
         assertThat(frameworkAgreementConstraint.get("odrl:rightOperand").asText()).isEqualTo(FRAMEWORK_AGREEMENT_WITH_VERSION);
 
         JsonNode usagePurposeConstraint = andArray.get(1);
-        assertThat(usagePurposeConstraint.get("odrl:leftOperand").asText()).isEqualTo("cx-policy:UsagePurpose");
+        String usagePurposeLeftOperand = PolicyProfileVersionEnumeration.POLICY_PROFILE_2405.CX_POLICY_NAMESPACE + "UsagePurpose";
+        assertThat(usagePurposeConstraint.get("odrl:leftOperand").asText()).isEqualTo(usagePurposeLeftOperand);
         assertThat(usagePurposeConstraint.get("odrl:operator").get("@id").asText()).isEqualTo("odrl:eq");
         assertThat(usagePurposeConstraint.get("odrl:rightOperand").asText()).isEqualTo("some-purpose");
     }


### PR DESCRIPTION
## Description

- adjusted policies to be added to the policy store to ensure compatibility

Target json format:

```json
{
  "payload": {
    "@context": {
      "odrl": "http://www.w3.org/ns/odrl/2",
      "edc": "https://w3id.org/edc/v0.0.1/ns/",
      "cx-policy": "https://w3id.org/catenax/policy/"
    },
    "@type": "PolicyDefinitionRequestDto",
    "@id": "global_submodel_contract_policy",
    "policy": {
      "@type": "Set",
      "profile": "cx-policy:profile2405",
      "odrl:permission": [
        {
          "odrl:action": "use",
          "odrl:constraint": {
            "@type": "LogicalConstraint",
            "odrl:and": [
              {
                "@type": "LogicalConstraint",
                "odrl:leftOperand": "https://w3id.org/catenax/policy/FrameworkAgreement",
                "odrl:operator": {
                  "@id": "odrl:eq"
                },
                "odrl:rightOperand": "DataExchangeGovernance:1.0"
              },
              {
                "@type": "LogicalConstraint",
                "odrl:leftOperand": "https://w3id.org/catenax/policy/UsagePurpose",
                "odrl:operator": {
                  "@id": "odrl:eq"
                },
                "odrl:rightOperand": "cx.puris.base:1"
              }
            ]
          }
        }
      ]
    }
  },
  "validUntil": "2099-12-12T23:59:59.999Z"
}
```

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files ([TRG 7.02](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02))
- [x] Documentation Notice are present on all affected files ([TRG 7.07](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07))
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
- [x] **Changelog** updated (`changelog.md`) with PR reference and brief summary.
- [x] **Frontend** version bumped, if needed (`frontend/package.json`, `frontend/package-lock.json`)
- [x] **Backend** version bumped, if needed (`backend/pom.xml`)
- [x] **Open API** specification updated, if controllers have been changed (use python script `scripts/generate_openapi_yaml.py` with running customer backend)
