### PR TITLE
feat: implement anonymized demand request submodel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The **need for configuration updates** is **marked bold**.
   - Updated documentation files with new feature information ([#1190](https://github.com/eclipse-tractusx/puris/pull/1190))
   - Updated backend implementation with forwarding and tests ([#1198](https://github.com/eclipse-tractusx/puris/pull/1198))
 - Implement support for PartTypeInformation 2.0.0 submodel ([#1199](https://github.com/eclipse-tractusx/puris/pull/1199))
+- Added submodel implementation for anonymized demand request ([#1210](https://github.com/eclipse-tractusx/puris/pull/1210))
 
 ### Changed
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/ddtr/logic/util/DtrRequestBodyBuilder.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/ddtr/logic/util/DtrRequestBodyBuilder.java
@@ -101,6 +101,7 @@ public class DtrRequestBodyBuilder {
         submodelDescriptorsArray.add(createSubmodelObject(AssetType.DAYS_OF_SUPPLY.URN_SEMANTIC_ID, hrefs.directionHref(), variablesService.getDaysOfSupplySubmodelApiAssetId()));
         submodelDescriptorsArray.add(createSubmodelObject(AssetType.ITEM_STOCK_ANONYMIZED_SUBMODEL.URN_SEMANTIC_ID, hrefs.anonymizedDirectionHref(), variablesService.getItemStockAnonymizedSubmodelApiAssetId()));
         submodelDescriptorsArray.add(createSubmodelObject(AssetType.DELIVERY_ANONYMIZED_SUBMODEL.URN_SEMANTIC_ID, hrefs.anonymizedHref(), variablesService.getDeliveryAnonymizedSubmodelApiAssetId()));
+        submodelDescriptorsArray.add(createSubmodelObject(AssetType.DEMAND_ANONYMIZED_SUBMODEL.URN_SEMANTIC_ID, hrefs.anonymizedHref(), variablesService.getDemandAnonymizedSubmodelApiAssetId()));
         log.debug("Created body for material {}\n{}", material.getOwnMaterialNumber(), body.toPrettyString());
         return body;
     }
@@ -150,6 +151,7 @@ public class DtrRequestBodyBuilder {
         submodelDescriptorsArray.add(createSubmodelObject(AssetType.ITEM_STOCK_ANONYMIZED_SUBMODEL.URN_SEMANTIC_ID, hrefs.anonymizedDirectionHref(), variablesService.getItemStockAnonymizedSubmodelApiAssetId()));
         submodelDescriptorsArray.add(createSubmodelObject(AssetType.DELIVERY_ANONYMIZED_SUBMODEL.URN_SEMANTIC_ID, hrefs.anonymizedHref(), variablesService.getDeliveryAnonymizedSubmodelApiAssetId()));
         submodelDescriptorsArray.add(createSubmodelObject(AssetType.PRODUCTION_ANONYMIZED_SUBMODEL.URN_SEMANTIC_ID, hrefs.anonymizedHref(), variablesService.getProductionAnonymizedSubmodelApiAssetId()));
+        submodelDescriptorsArray.add(createSubmodelObject(AssetType.DEMAND_ANONYMIZED_SUBMODEL.URN_SEMANTIC_ID, hrefs.anonymizedHref(), variablesService.getDemandAnonymizedSubmodelApiAssetId()));
         submodelDescriptorsArray.add(createSubmodelObject(AssetType.SINGLE_LEVEL_BOM_AS_PLANNED_SUBMODEL.URN_SEMANTIC_ID, hrefs.href(), variablesService.getSingleLevelBomAsPlannedSubmodelApiAssetId()));
         submodelDescriptorsArray.add(createPartTypeLegacySubmodelObject(material.getOwnMaterialNumber()));
         submodelDescriptorsArray.add(createPartTypeSubmodelObject(material.getOwnMaterialNumber()));

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/domain/model/AssetType.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/domain/model/AssetType.java
@@ -36,6 +36,7 @@ public enum AssetType {
     ITEM_STOCK_ANONYMIZED_SUBMODEL("urn:samm:io.catenax.item_stock_anonymized:1.0.0#ItemStockAnonymized", "$value", "none", "1.0"),
     DELIVERY_ANONYMIZED_SUBMODEL("urn:samm:io.catenax.delivery_information_anonymized:1.0.0#DeliveryInformationAnonymized", "$value", "none", "1.0"),
     PRODUCTION_ANONYMIZED_SUBMODEL("urn:samm:io.catenax.planned_production_output_anonymized:1.0.0#PlannedProductionOutputAnonymized", "$value", "none", "1.0"),
+    DEMAND_ANONYMIZED_SUBMODEL("urn:samm:io.catenax.short_term_material_demand_anonymized:1.0.0#ShortTermMaterialDemandAnonymized", "$value", "ShortTermMaterialDemandAnonymized", "1.0"),
     SINGLE_LEVEL_BOM_AS_PLANNED_SUBMODEL("urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#SingleLevelBomAsPlanned", "$value", "SingleLevelBomAsPlanned", "3.0");
     
     public final String URN_SEMANTIC_ID;
@@ -66,6 +67,8 @@ public enum AssetType {
                 AssetType.DELIVERY_ANONYMIZED_SUBMODEL;
             case "urn:samm:io.catenax.planned_production_output_anonymized:1.0.0#PlannedProductionOutputAnonymized" ->
                 AssetType.PRODUCTION_ANONYMIZED_SUBMODEL;
+            case "urn:samm:io.catenax.short_term_material_demand_anonymized:1.0.0#ShortTermMaterialDemandAnonymized" ->
+                AssetType.DEMAND_ANONYMIZED_SUBMODEL;
             case "urn:samm:io.catenax.single_level_bom_as_planned:3.0.0#SingleLevelBomAsPlanned" ->
                 AssetType.SINGLE_LEVEL_BOM_AS_PLANNED_SUBMODEL;
             default -> AssetType.DTR; // Handle unknown URN by returning a default enum value

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/domain/model/DemandAnonymizedContractMapping.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/domain/model/DemandAnonymizedContractMapping.java
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2026 Volkswagen AG
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Apache License, Version 2.0 which is available at
+https://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+package org.eclipse.tractusx.puris.backend.common.edc.domain.model;
+
+import jakarta.persistence.Entity;
+import lombok.ToString;
+
+@Entity
+@ToString(callSuper = true)
+public class DemandAnonymizedContractMapping extends ContractMapping {
+    
+}

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/domain/repository/DemandAnonymizedContractMappingRepository.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/domain/repository/DemandAnonymizedContractMappingRepository.java
@@ -1,0 +1,31 @@
+/*
+Copyright (c) 2026 Volkswagen AG
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Apache License, Version 2.0 which is available at
+https://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+package org.eclipse.tractusx.puris.backend.common.edc.domain.repository;
+
+import org.eclipse.tractusx.puris.backend.common.edc.domain.model.ContractMapping;
+import org.eclipse.tractusx.puris.backend.common.edc.domain.model.DemandAnonymizedContractMapping;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DemandAnonymizedContractMappingRepository extends GeneralContractMappingRepository<DemandAnonymizedContractMapping> {
+    @Override
+    default Class<? extends ContractMapping> getType() {
+        return DemandAnonymizedContractMapping.class;
+    }
+}

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
@@ -242,6 +242,12 @@ public class EdcAdapterService {
             AssetType.PRODUCTION_ANONYMIZED_SUBMODEL.URN_SEMANTIC_ID
         )));
         result &= assetRegistration;
+        log.info("Registration of Anonymized Demand Information 1.0.0 submodel successful {}", (assetRegistration = registerSubmodelAsset(
+            variablesService.getDemandAnonymizedSubmodelApiAssetId(),
+            variablesService.getDemandAnonymizedSubmodelEndpoint(),
+            AssetType.DEMAND_ANONYMIZED_SUBMODEL.URN_SEMANTIC_ID
+        )));
+        result &= assetRegistration;
         log.info("Registration of Single Level Bom As Planned 3.0.0 submodel successful {}", (assetRegistration = registerSubmodelAsset(
             variablesService.getSingleLevelBomAsPlannedSubmodelApiAssetId(),
             variablesService.getSingleLevelBomAsPlannedSubmodelEndpoint(),
@@ -861,6 +867,7 @@ public class EdcAdapterService {
             case ITEM_STOCK_ANONYMIZED_SUBMODEL -> fetchSubmodelDataByDirection(mpr, AssetType.ITEM_STOCK_ANONYMIZED_SUBMODEL.URN_SEMANTIC_ID, direction);
             case DELIVERY_ANONYMIZED_SUBMODEL -> fetchSubmodelDataByDirection(mpr, AssetType.DELIVERY_ANONYMIZED_SUBMODEL.URN_SEMANTIC_ID, direction);
             case PRODUCTION_ANONYMIZED_SUBMODEL -> fetchSubmodelDataByDirection(mpr, AssetType.PRODUCTION_ANONYMIZED_SUBMODEL.URN_SEMANTIC_ID, direction);
+            case DEMAND_ANONYMIZED_SUBMODEL -> fetchSubmodelDataByDirection(mpr, AssetType.DEMAND_ANONYMIZED_SUBMODEL.URN_SEMANTIC_ID, direction);
             case SINGLE_LEVEL_BOM_AS_PLANNED_SUBMODEL -> fetchSubmodelDataByDirection(mpr, AssetType.SINGLE_LEVEL_BOM_AS_PLANNED_SUBMODEL.URN_SEMANTIC_ID, direction);
             case PART_TYPE_INFORMATION_LEGACY_SUBMODEL -> fetchSubmodelData(mpr, AssetType.PART_TYPE_INFORMATION_LEGACY_SUBMODEL.URN_SEMANTIC_ID, mpr.getPartnerMaterialNumber(), mpr.getPartner().getBpnl());
             case PART_TYPE_INFORMATION_SUBMODEL -> fetchSubmodelData(mpr, AssetType.PART_TYPE_INFORMATION_SUBMODEL.URN_SEMANTIC_ID, mpr.getPartnerMaterialNumber(), mpr.getPartner().getBpnl());
@@ -1304,6 +1311,7 @@ public class EdcAdapterService {
             case ITEM_STOCK_ANONYMIZED_SUBMODEL -> fetchSubmodelDataByDirection(mpr, AssetType.ITEM_STOCK_ANONYMIZED_SUBMODEL.URN_SEMANTIC_ID, direction);
             case DELIVERY_ANONYMIZED_SUBMODEL -> fetchSubmodelDataByDirection(mpr, AssetType.DELIVERY_ANONYMIZED_SUBMODEL.URN_SEMANTIC_ID, direction);
             case PRODUCTION_ANONYMIZED_SUBMODEL -> fetchSubmodelDataByDirection(mpr, AssetType.PRODUCTION_ANONYMIZED_SUBMODEL.URN_SEMANTIC_ID, direction);
+            case DEMAND_ANONYMIZED_SUBMODEL -> fetchSubmodelDataByDirection(mpr, AssetType.DEMAND_ANONYMIZED_SUBMODEL.URN_SEMANTIC_ID, direction);
             case PART_TYPE_INFORMATION_LEGACY_SUBMODEL ->  fetchSubmodelData(mpr, AssetType.PART_TYPE_INFORMATION_LEGACY_SUBMODEL.URN_SEMANTIC_ID, mpr.getPartnerMaterialNumber(), mpr.getPartner().getBpnl());
             case PART_TYPE_INFORMATION_SUBMODEL -> fetchSubmodelData(mpr, AssetType.PART_TYPE_INFORMATION_SUBMODEL.URN_SEMANTIC_ID, mpr.getPartnerMaterialNumber(), mpr.getPartner().getBpnl());
             case SINGLE_LEVEL_BOM_AS_PLANNED_SUBMODEL -> fetchSubmodelDataByDirection(mpr, AssetType.SINGLE_LEVEL_BOM_AS_PLANNED_SUBMODEL.URN_SEMANTIC_ID, direction);

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcContractMappingService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcContractMappingService.java
@@ -30,6 +30,7 @@ import org.eclipse.tractusx.puris.backend.common.edc.domain.repository.Productio
 import org.eclipse.tractusx.puris.backend.common.edc.domain.repository.DaysOfSupplyContractMappingRepository;
 import org.eclipse.tractusx.puris.backend.common.edc.domain.repository.DeliveryContractMappingRepository;
 import org.eclipse.tractusx.puris.backend.common.edc.domain.repository.DemandAndCapacityNotificationContractMappingRepository;
+import org.eclipse.tractusx.puris.backend.common.edc.domain.repository.DemandAnonymizedContractMappingRepository;
 import org.eclipse.tractusx.puris.backend.common.edc.domain.repository.DataExchangeRequestContractMappingRepository;
 import org.eclipse.tractusx.puris.backend.common.edc.domain.repository.DemandContractMappingRepository;
 import org.eclipse.tractusx.puris.backend.common.edc.domain.repository.DtrContractMappingRepository;
@@ -79,6 +80,9 @@ public class EdcContractMappingService {
 
     @Autowired
     private ProductionAnonymizedContractMappingRepository productionAnonymizedContractMappingRepository;
+
+    @Autowired
+    private DemandAnonymizedContractMappingRepository demandAnonymizedContractMappingRepository;
 
     @Autowired
     private PartTypeContractMappingRepository partTypeContractMappingRepository;
@@ -155,6 +159,7 @@ public class EdcContractMappingService {
             case ITEM_STOCK_ANONYMIZED_SUBMODEL -> itemStockAnonymizedContractMappingRepository;
             case DELIVERY_ANONYMIZED_SUBMODEL -> deliveryAnonymizedContractMappingRepository;
             case PRODUCTION_ANONYMIZED_SUBMODEL -> productionAnonymizedContractMappingRepository;
+            case DEMAND_ANONYMIZED_SUBMODEL -> demandAnonymizedContractMappingRepository;
             case PART_TYPE_INFORMATION_LEGACY_SUBMODEL -> partTypeLegacyContractMappingRepository;
             case PART_TYPE_INFORMATION_SUBMODEL -> partTypeContractMappingRepository;
             case DATA_EXCHANGE_REQUEST -> dataExchangeRequestContractMappingRepository;

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/util/VariablesService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/util/VariablesService.java
@@ -201,6 +201,21 @@ public class VariablesService {
     private String productionAnonymizedSubmodelApiAssetId;
 
     /**
+     * The url under which this application's anonymized demand request endpoint can
+     * be reached by external machines.
+     */
+    public String getDemandAnonymizedSubmodelEndpoint() {
+        return getPurisBaseUrl() + getContextPath() + "demand/anonymized/request";
+    }
+
+    @Value("${puris.demandanonymizedsubmodel.apiassetid}")
+    /**
+     * The assetId that shall be assigned to the Anonymized Demand request API
+     * during asset creation.
+     */
+    private String demandAnonymizedSubmodelApiAssetId;
+
+    /**
      * The url under which this application's single level bom as planned request endpoint can
      * be reached by external machines.
      */
@@ -410,6 +425,10 @@ public class VariablesService {
 
     public String getProductionAnonymizedSubmodelApiAssetId() {
         return productionAnonymizedSubmodelApiAssetId + "@" + ownBpnl;
+    }
+
+    public String getDemandAnonymizedSubmodelApiAssetId() {
+        return demandAnonymizedSubmodelApiAssetId + "@" + ownBpnl;
     }
 
     public String getSingleLevelBomAsPlannedSubmodelApiAssetId() {

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/demand/controller/DemandRequestApiController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/demand/controller/DemandRequestApiController.java
@@ -28,6 +28,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.tractusx.puris.backend.common.util.PatternStore;
+import org.eclipse.tractusx.puris.backend.common.util.VariablesService;
+import org.eclipse.tractusx.puris.backend.demand.logic.dto.anonymizeddamandsamm.ShortTermMaterialDemandAnonymized;
 import org.eclipse.tractusx.puris.backend.demand.logic.dto.demandsamm.ShortTermMaterialDemand;
 import org.eclipse.tractusx.puris.backend.demand.logic.services.DemandRequestApiService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,6 +49,9 @@ public class DemandRequestApiController {
 
     @Autowired
     private DemandRequestApiService demandRequestApiService;
+
+    @Autowired
+    private VariablesService variablesService;
 
     private final Pattern bpnlPattern = PatternStore.BPNL_PATTERN;
 
@@ -81,6 +86,43 @@ public class DemandRequestApiController {
             return ResponseEntity.status(501).build();
         }
         var samm = demandRequestApiService.handleDemandSubmodelRequest(bpnl, materialnumbercx);
+        if (samm == null) {
+            return ResponseEntity.status(500).build();
+        }
+        return ResponseEntity.ok(samm);
+    }
+
+    @Operation(summary = "This endpoint receives the ShortTermMaterialDemandAnonymized Submodel 1.0.0 requests. " +
+        "This endpoint is meant to be accessed by our own EDC only. ")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Ok"),
+        @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content),
+        @ApiResponse(responseCode = "403", description = "Access forbidden - self-access only", content = @Content),
+        @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content),
+        @ApiResponse(responseCode = "501", description = "Unsupported representation", content = @Content)
+    })
+    @GetMapping("anonymized/request/{materialnumbercx}/{partnerBpnl}/submodel/{representation}")
+    public ResponseEntity<ShortTermMaterialDemandAnonymized> getAnonymizedDemandMapping(
+        @RequestHeader("edc-bpn") String edcBpnl,
+        @RequestHeader("edc-contract-agreement-id") String contractAgreementId,
+        @PathVariable String materialnumbercx,
+        @PathVariable String partnerBpnl,
+        @PathVariable String representation
+    ) {
+        if (!bpnlPattern.matcher(partnerBpnl).matches() || !urnPattern.matcher(materialnumbercx).matches()) {
+            log.warn("Rejecting request at ShortTermMaterialDemandAnonymized Submodel request 1.0.0 endpoint");
+            return ResponseEntity.badRequest().build();
+        }
+        if (!variablesService.getOwnBpnl().equals(edcBpnl)) {
+            log.warn("Rejecting request at ShortTermMaterialDemandAnonymized Submodel request 1.0.0 endpoint, edc-bpn header did not match own BPNL");
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+        if (!"$value".equals(representation)) {
+            log.warn("Rejecting request at ShortTermMaterialDemandAnonymized Submodel request 1.0.0 endpoint, missing '$value' in request");
+            return ResponseEntity.status(501).build();
+        }
+        log.info("Received anonymized demand request for {} from {}", materialnumbercx, partnerBpnl);
+        var samm = demandRequestApiService.handleDemandAnonymizedSubmodelRequest(partnerBpnl, materialnumbercx, contractAgreementId);
         if (samm == null) {
             return ResponseEntity.status(500).build();
         }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/demand/logic/adapter/ShortTermMaterialDemandSammMapper.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/demand/logic/adapter/ShortTermMaterialDemandSammMapper.java
@@ -20,9 +20,12 @@
 package org.eclipse.tractusx.puris.backend.demand.logic.adapter;
 
 import org.eclipse.tractusx.puris.backend.common.domain.model.measurement.ItemQuantityEntity;
+import org.eclipse.tractusx.puris.backend.common.security.logic.AnonymizationService;
 import org.eclipse.tractusx.puris.backend.demand.domain.model.DemandCategoryEnumeration;
 import org.eclipse.tractusx.puris.backend.demand.domain.model.OwnDemand;
 import org.eclipse.tractusx.puris.backend.demand.domain.model.ReportedDemand;
+import org.eclipse.tractusx.puris.backend.demand.logic.dto.anonymizeddamandsamm.DemandSeriesAnonymized;
+import org.eclipse.tractusx.puris.backend.demand.logic.dto.anonymizeddamandsamm.ShortTermMaterialDemandAnonymized;
 import org.eclipse.tractusx.puris.backend.demand.logic.dto.demandsamm.Demand;
 import org.eclipse.tractusx.puris.backend.demand.logic.dto.demandsamm.DemandCategoryCharacteristic;
 import org.eclipse.tractusx.puris.backend.demand.logic.dto.demandsamm.DemandSeries;
@@ -46,16 +49,19 @@ import java.util.stream.Collectors;
 public class ShortTermMaterialDemandSammMapper {
     @Autowired
     private MaterialPartnerRelationService mprService;
-
+ 
     @Autowired
     private MaterialService materialService;
-
+ 
+    @Autowired
+    private AnonymizationService anonymizationService;
+ 
     public ShortTermMaterialDemand ownDemandToSamm(List<OwnDemand> demandList,Partner partner, Material material) {
         if (demandList.stream().anyMatch(dem -> !dem.getPartner().equals(partner))) {
             log.warn("Can't map demand list with different partners");
             return null;
         }
-
+ 
         if (demandList.stream().anyMatch(prod -> !prod.getMaterial().equals(material))) {
             log.warn("Can't map demand list with different materials");
             return null;
@@ -64,7 +70,7 @@ public class ShortTermMaterialDemandSammMapper {
                 .stream()
                 .collect(Collectors.groupingBy(demand -> new DemandGroupingHelper(demand.getDemandCategoryCode(), demand.getDemandLocationBpns(), demand.getSupplierLocationBpns())));
         ShortTermMaterialDemand samm = new ShortTermMaterialDemand();
-
+ 
         var mpr = mprService.findAll().stream().filter(mr -> mr.getMaterial().equals(material) && mr.getPartner().equals(partner)).findFirst().orElse(null);
         if (mpr == null) {
             log.warn("Could not identify materialPartnerRelation with ownMaterialNumber " + material.getOwnMaterialNumber()
@@ -72,7 +78,7 @@ public class ShortTermMaterialDemandSammMapper {
             return null;
         }
         samm.setMaterialGlobalAssetId(mpr.getPartnerCXNumber());
-
+ 
         var demandSeriesList = new HashSet<DemandSeries>();
         samm.setDemandSeries(demandSeriesList);
         for (var mappingHelperListEntry : groupedByCategory.entrySet()) {
@@ -98,17 +104,62 @@ public class ShortTermMaterialDemandSammMapper {
         }
         return samm;
     }
-
+ 
+    public ShortTermMaterialDemandAnonymized ownDemandToAnonymizedSamm(List<OwnDemand> demandList, Partner partner, Material material, String salt) {
+        if (demandList.stream().anyMatch(dem -> !dem.getPartner().equals(partner))) {
+            log.warn("Can't map demand list with different partners");
+            return null;
+        }
+ 
+        if (demandList.stream().anyMatch(dem -> !dem.getMaterial().equals(material))) {
+            log.warn("Can't map demand list with different materials");
+            return null;
+        }
+ 
+        var mpr = mprService.find(material, partner);
+        if (mpr == null) {
+            log.warn("Could not identify materialPartnerRelation with ownMaterialNumber " + material.getOwnMaterialNumber() + " and partner bpnl " + partner.getBpnl());
+            return null;
+        }
+ 
+        ShortTermMaterialDemandAnonymized samm = new ShortTermMaterialDemandAnonymized();
+        samm.setMaterialGlobalAssetIdAnonymized(anonymizationService.anonymize(mpr.getPartnerCXNumber(), salt));
+        var groupedByLocation = demandList.stream()
+            .collect(Collectors.groupingBy(demand -> new AnonymizedDemandGroupingHelper(demand.getDemandLocationBpns(), demand.getSupplierLocationBpns())));
+ 
+        var demandSeriesList = new HashSet<DemandSeriesAnonymized>();
+        samm.setDemandSeries(demandSeriesList);
+        for (var mappingHelperListEntry : groupedByLocation.entrySet()) {
+            var key = mappingHelperListEntry.getKey();
+            List<OwnDemand> demandsByLocation = mappingHelperListEntry.getValue();
+            DemandSeriesAnonymized demandSeries = new DemandSeriesAnonymized();
+            demandSeriesList.add(demandSeries);
+            var latestUpdate = demandsByLocation.stream().map(OwnDemand::getLastUpdatedOnDateTime).max(Date::compareTo).orElse(new Date());
+            demandSeries.setLastUpdatedOnDateTime(latestUpdate);
+            demandSeries.setCustomerLocationBpnsAnonymized(anonymizationService.anonymize(key.customerLocationBpns(), salt));
+            
+            demandSeries.setExpectedSupplierLocationBpnsAnonymized(key.expectedSupplierLocationBpns() == null ? null : anonymizationService.anonymize(key.expectedSupplierLocationBpns(), salt));
+            var demands = new HashSet<Demand>();
+            demandSeries.setDemands(demands);
+            for (var v : demandsByLocation) {
+                ItemQuantityEntity itemQuantityEntity = new ItemQuantityEntity(v.getQuantity(), v.getMeasurementUnit());
+                Demand dailyDemand = new Demand(itemQuantityEntity, v.getDay());
+                demands.add(dailyDemand);
+            }
+        }
+        return samm;
+    }
+ 
     public List<ReportedDemand> sammToReportedDemand(ShortTermMaterialDemand samm, Partner partner) {
         String matNbrCatenaX = samm.getMaterialGlobalAssetId();
         ArrayList<ReportedDemand> outputList = new ArrayList<>();
-
+ 
         var material = materialService.findByMaterialNumberCx(matNbrCatenaX);
         if (material == null) {
             log.warn("Could not identify material with given CatenaXNbr ");
             return outputList;
         }
-
+ 
         for (var demandSeries : samm.getDemandSeries()) {
             for (var demand : demandSeries.getDemands()) {
                 var builder = ReportedDemand.builder();
@@ -128,9 +179,11 @@ public class ShortTermMaterialDemandSammMapper {
         }
         return outputList;
     }
-
+ 
     private record DemandGroupingHelper(DemandCategoryEnumeration category, String customerLocationBpns, String expectedSupplierLocationBpns) {}
-
+ 
+    private record AnonymizedDemandGroupingHelper(String customerLocationBpns, String expectedSupplierLocationBpns) {}
+ 
     private DemandCategoryCharacteristic mapDemandCategory(DemandCategoryEnumeration category) {
         return switch (category) {
             case DEMAND_DEFAULT -> DemandCategoryCharacteristic.DEMAND_CATEGORY;
@@ -143,7 +196,7 @@ public class ShortTermMaterialDemandSammMapper {
             case DEMAND_EXTRAORDINARY_DEMAND -> DemandCategoryCharacteristic.DEMAND_CATEGORY_EXTRAORDINARY_DEMAND;
         };
     }
-
+ 
     private DemandCategoryEnumeration mapDemandCategory(DemandCategoryCharacteristic category) {
         return switch (category) {
             case DEMAND_CATEGORY -> DemandCategoryEnumeration.DEMAND_DEFAULT;

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/demand/logic/dto/anonymizeddamandsamm/DemandSeriesAnonymized.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/demand/logic/dto/anonymizeddamandsamm/DemandSeriesAnonymized.java
@@ -1,0 +1,97 @@
+/*
+Copyright (c) 2026 Volkswagen AG
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Apache License, Version 2.0 which is available at
+https://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+package org.eclipse.tractusx.puris.backend.demand.logic.dto.anonymizeddamandsamm;
+
+import java.util.Date;
+import java.util.Objects;
+import java.util.Set;
+
+import org.eclipse.tractusx.puris.backend.common.util.PatternStore;
+import org.eclipse.tractusx.puris.backend.demand.logic.dto.demandsamm.Demand;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+public class DemandSeriesAnonymized {
+ 
+    @NotNull
+    @Valid
+    private Set<Demand> demands;
+ 
+    @Pattern.List({
+        @Pattern(regexp = PatternStore.NON_EMPTY_NON_VERTICAL_WHITESPACE_STRING),
+        @Pattern(regexp = PatternStore.NOT_BPNS_STRING)
+    })
+    private String expectedSupplierLocationBpnsAnonymized;
+ 
+    @NotNull
+    @Pattern.List({
+        @Pattern(regexp = PatternStore.NON_EMPTY_NON_VERTICAL_WHITESPACE_STRING),
+        @Pattern(regexp = PatternStore.NOT_BPNS_STRING)
+    })
+    private String customerLocationBpnsAnonymized;
+ 
+    @NotNull
+    private Date lastUpdatedOnDateTime;
+ 
+    @JsonCreator
+    public DemandSeriesAnonymized(@JsonProperty(value = "demands") Set<Demand> demands,
+            @JsonProperty(value = "expectedSupplierLocationBpnsAnonymized") String expectedSupplierLocationBpnsAnonymized,
+            @JsonProperty(value = "customerLocationBpnsAnonymized") String customerLocationBpnsAnonymized,
+            @JsonProperty(value = "lastUpdatedOnDateTime") Date lastUpdatedOnDateTime) {
+        this.demands = demands;
+        this.expectedSupplierLocationBpnsAnonymized = expectedSupplierLocationBpnsAnonymized;
+        this.customerLocationBpnsAnonymized = customerLocationBpnsAnonymized;
+        this.lastUpdatedOnDateTime = lastUpdatedOnDateTime;
+    }
+ 
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+ 
+        final DemandSeriesAnonymized that = (DemandSeriesAnonymized) o;
+        return Objects.equals(demands, that.demands)
+                && Objects.equals(expectedSupplierLocationBpnsAnonymized, that.expectedSupplierLocationBpnsAnonymized)
+                && Objects.equals(customerLocationBpnsAnonymized, that.customerLocationBpnsAnonymized)
+                && Objects.equals(lastUpdatedOnDateTime, that.lastUpdatedOnDateTime);
+    }
+ 
+    @Override
+    public int hashCode() {
+        return Objects.hash(demands, expectedSupplierLocationBpnsAnonymized, customerLocationBpnsAnonymized,
+            lastUpdatedOnDateTime);
+    }
+}

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/demand/logic/dto/anonymizeddamandsamm/ShortTermMaterialDemandAnonymized.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/demand/logic/dto/anonymizeddamandsamm/ShortTermMaterialDemandAnonymized.java
@@ -1,0 +1,75 @@
+/*
+Copyright (c) 2026 Volkswagen AG
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Apache License, Version 2.0 which is available at
+https://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+package org.eclipse.tractusx.puris.backend.demand.logic.dto.anonymizeddamandsamm;
+
+import java.util.HashSet;
+import java.util.Objects;
+
+import org.eclipse.tractusx.puris.backend.common.util.PatternStore;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+public class ShortTermMaterialDemandAnonymized {
+ 
+    @NotNull
+    @Valid
+    private HashSet<DemandSeriesAnonymized> demandSeries;
+ 
+    @Pattern(regexp = PatternStore.NON_EMPTY_NON_VERTICAL_WHITESPACE_STRING)
+    private String materialGlobalAssetIdAnonymized;
+ 
+    @JsonCreator
+    public ShortTermMaterialDemandAnonymized(@JsonProperty(value = "demandSeries") HashSet<DemandSeriesAnonymized> demandSeries,
+            @JsonProperty(value = "materialGlobalAssetIdAnonymized") String materialGlobalAssetIdAnonymized) {
+        this.demandSeries = demandSeries;
+        this.materialGlobalAssetIdAnonymized = materialGlobalAssetIdAnonymized;
+    }
+ 
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+ 
+        final ShortTermMaterialDemandAnonymized that = (ShortTermMaterialDemandAnonymized) o;
+        return Objects.equals(demandSeries, that.demandSeries)
+                && Objects.equals(materialGlobalAssetIdAnonymized, that.materialGlobalAssetIdAnonymized);
+    }
+ 
+    @Override
+    public int hashCode() {
+        return Objects.hash(demandSeries, materialGlobalAssetIdAnonymized);
+    }
+}

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/demand/logic/services/DemandRequestApiService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/demand/logic/services/DemandRequestApiService.java
@@ -24,7 +24,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.tractusx.puris.backend.common.edc.domain.model.AssetType;
 import org.eclipse.tractusx.puris.backend.common.edc.logic.service.EdcAdapterService;
+import org.eclipse.tractusx.puris.backend.demand.domain.model.OwnDemand;
 import org.eclipse.tractusx.puris.backend.demand.logic.adapter.ShortTermMaterialDemandSammMapper;
+import org.eclipse.tractusx.puris.backend.demand.logic.dto.anonymizeddamandsamm.ShortTermMaterialDemandAnonymized;
 import org.eclipse.tractusx.puris.backend.demand.logic.dto.demandsamm.ShortTermMaterialDemand;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
@@ -65,14 +67,32 @@ public class DemandRequestApiService {
     private ObjectMapper objectMapper;
 
     public ShortTermMaterialDemand handleDemandSubmodelRequest(String bpnl, String materialNumberCx) {
+        DemandRequestData data = getDemandRequestData(bpnl, materialNumberCx);
+        if (data == null) {
+            return null;
+        }
+        return sammMapper.ownDemandToSamm(data.demands(), data.partner(), data.material());
+    }
+ 
+    public ShortTermMaterialDemandAnonymized handleDemandAnonymizedSubmodelRequest(String bpnl, String materialNumberCx, String contractAgreementId) {
+        DemandRequestData data = getDemandRequestData(bpnl, materialNumberCx);
+        if (data == null) {
+            return null;
+        }
+        // the contract agreement id serves as the salt for the anonymization
+        return sammMapper.ownDemandToAnonymizedSamm(data.demands(), data.partner(), data.material(), contractAgreementId);
+    }
+ 
+    private DemandRequestData getDemandRequestData(String bpnl, String materialNumberCx) {
         Partner partner = partnerService.findByBpnl(bpnl);
         if (partner == null) {
             log.error("Unknown Partner BPNL");
             return null;
         }
-        Material material = mprService.findByPartnerAndPartnerCXNumber(partner, materialNumberCx).getMaterial();
 
-        if (material == null) {
+        var mpr = mprService.findByPartnerAndPartnerCXNumber(partner, materialNumberCx);
+ 
+        if (mpr == null) {
             // Could not identify partner cx number. I.e. we do not have that partner's
             // CX id in one of our MaterialPartnerRelation entities. Try to fix this by
             // looking for MPR's, where that partner is a supplier and where we don't have
@@ -80,23 +100,27 @@ public class DemandRequestApiService {
             // created, but for some unforeseen reason, the initial PartTypeRetrieval didn't succeed.
             log.warn("Could not find " + materialNumberCx + " from partner " + partner.getBpnl());
             mprService.triggerPartTypeRetrievalTask(partner);
-            material = mprService.findByPartnerAndPartnerCXNumber(partner, materialNumberCx).getMaterial();
+            mpr = mprService.findByPartnerAndPartnerCXNumber(partner, materialNumberCx);
         }
-
-        if (material == null) {
+ 
+        if (mpr == null || mpr.getMaterial() == null) {
             log.error("Unknown Material");
             return null;
         }
-        var mpr = mprService.find(material,partner);
-        if (mpr == null || !mpr.isPartnerSuppliesMaterial()) {
+ 
+        if (!mpr.isPartnerSuppliesMaterial()) {
             // only send an answer if partner is registered as supplier
+            log.error("Partner with BPNL {} is not registered as supplier for material {}", bpnl, materialNumberCx);
             return null;
         }
-
+ 
+        Material material = mpr.getMaterial();
         var currentDemands = ownDemandService.findAllByFilters(Optional.of(material.getOwnMaterialNumber()), Optional.of(partner.getBpnl()), Optional.empty());
-        return sammMapper.ownDemandToSamm(currentDemands, partner, material);
+        return new DemandRequestData(partner, material, currentDemands);
     }
-
+ 
+    private record DemandRequestData(Partner partner, Material material, List<OwnDemand> demands) {}
+ 
     public RefreshResult doReportedDemandRequest(Partner partner, Material material) {
         List<RefreshError> errors = new ArrayList<>();
         try {
@@ -108,7 +132,7 @@ public class DemandRequestApiService {
             var data = edcAdapterService.doSubmodelRequest(AssetType.DEMAND_SUBMODEL, mpr, DirectionEnum.INBOUND, 1);
             var samm = objectMapper.treeToValue(data, ShortTermMaterialDemand.class);
             var demands = sammMapper.sammToReportedDemand(samm, partner);
-            
+ 
             for (var demand : demands) {
                 var demandPartner = demand.getPartner();
                 var demandMaterial = demand.getMaterial();
@@ -121,19 +145,19 @@ public class DemandRequestApiService {
                     ))));
                     continue;
                 }
-
+ 
                 List<String> validationErrors = reportedDemandService.validateWithDetails(demand);
                 if (!validationErrors.isEmpty()) {
                     errors.add(new RefreshError(validationErrors));
                 }
             }
-
+ 
             if (!errors.isEmpty()) {
                 log.warn("Validation errors found for ReportedDemand request from partner {} for material {}: {}", 
                         partner.getBpnl(), material.getOwnMaterialNumber(), errors);
                 return new RefreshResult("Validation failed for reported demands", errors);
             }
-
+ 
             // delete older data:
             var oldDemands = reportedDemandService.findAllByFilters(Optional.of(material.getOwnMaterialNumber()), Optional.of(partner.getBpnl()), Optional.empty());
             for (var oldDemand : oldDemands) {
@@ -144,7 +168,7 @@ public class DemandRequestApiService {
             }
             log.info("Successfully updated ReportedDemand for {} and partner {}", 
                 material.getOwnMaterialNumber(), partner.getBpnl());
-                materialService.updateTimestamp(material.getOwnMaterialNumber());
+            materialService.updateTimestamp(material.getOwnMaterialNumber());
             return new RefreshResult("Successfully processed all reported demands", errors);
         } catch (Exception e) {
             log.error("Error in ReportedDemandRequest for " + material.getOwnMaterialNumber() + " and partner " + partner.getBpnl(), e);

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -12,6 +12,7 @@ puris.itemstocksubmodel.apiassetid=${PURIS_ITEMSTOCKSUBMODEL_APIASSETID:itemstoc
 puris.itemstockanonymizedsubmodel.apiassetid=${PURIS_ITEMSTOCKANONYMIZEDSUBMODEL_APIASSETID:itemstockanonymizedsubmodel-api-asset}
 puris.productionsubmodel.apiassetid=${PURIS_PRODUCTIONSUBMODEL_APIASSETID:productionsubmodel-api-asset}
 puris.demandsubmodel.apiassetid=${PURIS_DEMANDSUBMODEL_APIASSETID:demandsubmodel-api-asset}
+puris.demandanonymizedsubmodel.apiassetid=${PURIS_DEMANDANONYMIZEDSUBMODEL_APIASSETID:demandanonymizedsubmodel-api-asset}
 puris.deliverysubmodel.apiassetid=${PURIS_DELIVERYSUBMODEL_APIASSETID:deliverysubmodel-api-asset}
 puris.daysofsupplysubmodel.apiassetid=${PURIS_DAYSOFSUPPLYSUBMODEL_APIASSETID:daysofsupplysubmodel-api-asset}
 puris.deliveryanonymizedsubmodel.apiassetid=${PURIS_DELIVERYANONYMIZEDSUBMODEL_APIASSETID:deliveryanonymizedsubmodel-api-asset}

--- a/backend/src/main/resources/db/changelog/changelog-6.x/changelog-6.2.0.yaml
+++ b/backend/src/main/resources/db/changelog/changelog-6.x/changelog-6.2.0.yaml
@@ -346,3 +346,17 @@ databaseChangeLog:
             baseColumnNames: notification_uuid
             referencedTableName: own_demand_and_capacity_notification
             referencedColumnNames: uuid
+  - changeSet:
+        id: "8"
+        author: OlgaIvkovic
+        changes:
+          - createTable:
+              columns:
+                - column:
+                    constraints:
+                      nullable: false
+                      primaryKey: true
+                      primaryKeyName: demand_anonymized_contract_mapping_pkey
+                    name: partner_bpnl
+                    type: VARCHAR(255)
+              tableName: demand_anonymized_contract_mapping

--- a/backend/src/test/java/org/eclipse/tractusx/puris/backend/demand/logic/adapter/ShortTermMaterialDemandSammMapperTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/puris/backend/demand/logic/adapter/ShortTermMaterialDemandSammMapperTest.java
@@ -1,0 +1,220 @@
+/*
+Copyright (c) 2026 Volkswagen AG
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Apache License, Version 2.0 which is available at
+https://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+package org.eclipse.tractusx.puris.backend.demand.logic.adapter;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import org.eclipse.tractusx.puris.backend.common.domain.model.measurement.ItemUnitEnumeration;
+import org.eclipse.tractusx.puris.backend.common.security.logic.AnonymizationService;
+import org.eclipse.tractusx.puris.backend.demand.domain.model.DemandCategoryEnumeration;
+import org.eclipse.tractusx.puris.backend.demand.domain.model.OwnDemand;
+import org.eclipse.tractusx.puris.backend.demand.logic.dto.anonymizeddamandsamm.DemandSeriesAnonymized;
+import org.eclipse.tractusx.puris.backend.demand.logic.dto.anonymizeddamandsamm.ShortTermMaterialDemandAnonymized;
+import org.eclipse.tractusx.puris.backend.demand.logic.dto.demandsamm.Demand;
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.MaterialPartnerRelation;
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.PolicyProfileVersionEnumeration;
+import org.eclipse.tractusx.puris.backend.masterdata.logic.service.MaterialPartnerRelationService;
+import org.eclipse.tractusx.puris.backend.masterdata.logic.service.MaterialService;
+import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class ShortTermMaterialDemandSammMapperTest {
+    final static String CUSTOMER_MAT_NUMBER = "MNR-7307-AU340474.002";
+    final static String SUPPLIER_MAT_NUMBER = "MNR-8101-ID146955.001";
+    final static String CX_MAT_NUMBER = UUID.randomUUID().toString();
+    final static String OWN_BPNS = "BPNS4444444444SS";
+    final static String SUPPLIER_BPNL = "BPNL1111111111LE";
+    final static String SUPPLIER_BPNS = "BPNS1111111111SI";
+    final static String SUPPLIER_BPNA = "BPNA1111111111AD";
+    final static String OTHER_SUPPLIER_BPNS = "BPNS2222222222SI";
+ 
+    final static Partner supplierPartner = new Partner(
+        "Scenario Supplier",
+        "http://supplier-control-plane:9184/api/v1/dsp",
+        SUPPLIER_BPNL,
+        SUPPLIER_BPNS,
+        "Konzernzentrale Dudelsdorf",
+        SUPPLIER_BPNA,
+        "Heinrich-Supplier-Straße 1",
+        "77785 Dudelsdorf",
+        "Germany",
+        PolicyProfileVersionEnumeration.POLICY_PROFILE_2509
+    );
+ 
+    @Mock
+    private MaterialPartnerRelationService mprService;
+ 
+    @Mock
+    private MaterialService materialService;
+ 
+    @Mock
+    private AnonymizationService anonymizationService;
+ 
+    @InjectMocks
+    private ShortTermMaterialDemandSammMapper demandSammMapper;
+ 
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+ 
+    @Test
+    @Order(1)
+    void map_WhenSingleOwnDemand_ReturnsShortTermMaterialDemandAnonymized() {
+        // Given
+        Material semiconductorMaterial = createSemiconductorMaterial();
+        MaterialPartnerRelation mpr = createMpr(semiconductorMaterial);
+ 
+        Date day = new Date();
+        Date lastUpdated = new Date();
+ 
+        OwnDemand ownDemand = createOwnDemand(semiconductorMaterial, 20, day, OWN_BPNS, SUPPLIER_BPNS, DemandCategoryEnumeration.DEMAND_DEFAULT, lastUpdated);
+ 
+        // When
+        when(mprService.find(semiconductorMaterial, supplierPartner)).thenReturn(mpr);
+        when(anonymizationService.anonymize(anyString(), anyString())).thenAnswer(invocation -> "enc:" + invocation.getArgument(0));
+ 
+        ShortTermMaterialDemandAnonymized samm = demandSammMapper.ownDemandToAnonymizedSamm(List.of(ownDemand), supplierPartner, semiconductorMaterial, "SALT");
+ 
+        // Then
+        assertNotNull(samm);
+        assertTrue(samm.getMaterialGlobalAssetIdAnonymized().startsWith("enc:"));
+        assertEquals("enc:" + CX_MAT_NUMBER, samm.getMaterialGlobalAssetIdAnonymized());
+        assertNotNull(samm.getDemandSeries());
+        assertEquals(1, samm.getDemandSeries().size());
+ 
+        DemandSeriesAnonymized demandSeries = samm.getDemandSeries().stream().toList().get(0);
+        assertEquals("enc:" + OWN_BPNS, demandSeries.getCustomerLocationBpnsAnonymized());
+        assertEquals("enc:" + SUPPLIER_BPNS, demandSeries.getExpectedSupplierLocationBpnsAnonymized());
+        assertEquals(lastUpdated, demandSeries.getLastUpdatedOnDateTime());
+        assertNotNull(demandSeries.getDemands());
+        assertEquals(1, demandSeries.getDemands().size());
+ 
+        Demand mappedDemand = demandSeries.getDemands().stream().toList().get(0);
+        assertEquals(ItemUnitEnumeration.UNIT_PIECE, mappedDemand.getDemand().getUnit());
+        assertEquals(ownDemand.getQuantity(), mappedDemand.getDemand().getValue());
+        assertEquals(day, mappedDemand.getDay());
+    }
+ 
+    @Test
+    @Order(2)
+    void map_WhenMultipleOwnDemands_GroupsByLocationAndOmitsCategory() {
+        // Given
+        Material semiconductorMaterial = createSemiconductorMaterial();
+        MaterialPartnerRelation mpr = createMpr(semiconductorMaterial);
+ 
+        Date day1 = new Date(System.currentTimeMillis() - 2 * 86400000L);
+        Date day2 = new Date(System.currentTimeMillis() - 86400000L);
+        Date day3 = new Date();
+        Date olderUpdate = new Date(System.currentTimeMillis() - 3600000L);
+        Date newerUpdate = new Date();
+ 
+        OwnDemand demand1 = createOwnDemand(semiconductorMaterial, 20, day1, OWN_BPNS, SUPPLIER_BPNS, DemandCategoryEnumeration.DEMAND_DEFAULT, olderUpdate);
+        OwnDemand demand2 = createOwnDemand(semiconductorMaterial, 40, day2, OWN_BPNS, SUPPLIER_BPNS, DemandCategoryEnumeration.DEMAND_SERIES, newerUpdate);
+        OwnDemand demand3 = createOwnDemand(semiconductorMaterial, 10, day3, OWN_BPNS, OTHER_SUPPLIER_BPNS, DemandCategoryEnumeration.DEMAND_DEFAULT, olderUpdate);
+ 
+        // When
+        when(mprService.find(semiconductorMaterial, supplierPartner)).thenReturn(mpr);
+        when(anonymizationService.anonymize(anyString(), anyString())).thenAnswer(invocation -> "enc:" + invocation.getArgument(0));
+ 
+        ShortTermMaterialDemandAnonymized samm = demandSammMapper.ownDemandToAnonymizedSamm(List.of(demand1, demand2, demand3), supplierPartner, semiconductorMaterial, "SALT");
+ 
+        // Then
+        assertNotNull(samm);
+        assertEquals(2, samm.getDemandSeries().size());
+ 
+        DemandSeriesAnonymized firstSeries = samm.getDemandSeries().stream().filter(series -> ("enc:" + SUPPLIER_BPNS).equals(series.getExpectedSupplierLocationBpnsAnonymized())).findFirst().orElseThrow();
+        assertEquals("enc:" + OWN_BPNS, firstSeries.getCustomerLocationBpnsAnonymized());
+        assertEquals(2, firstSeries.getDemands().size());
+        assertEquals(newerUpdate, firstSeries.getLastUpdatedOnDateTime());
+ 
+        DemandSeriesAnonymized secondSeries = samm.getDemandSeries().stream().filter(series -> ("enc:" + OTHER_SUPPLIER_BPNS).equals(series.getExpectedSupplierLocationBpnsAnonymized())).findFirst().orElseThrow();
+        assertEquals("enc:" + OWN_BPNS, secondSeries.getCustomerLocationBpnsAnonymized());
+        assertEquals(1, secondSeries.getDemands().size());
+        assertEquals(olderUpdate, secondSeries.getLastUpdatedOnDateTime());
+    }
+ 
+    @Test
+    @Order(3)
+    void map_WhenNoMaterialPartnerRelationExists_ReturnsNull() {
+        // Given
+        Material semiconductorMaterial = createSemiconductorMaterial();
+        OwnDemand ownDemand = createOwnDemand(semiconductorMaterial, 20, new Date(), OWN_BPNS, SUPPLIER_BPNS, DemandCategoryEnumeration.DEMAND_DEFAULT, new Date());
+ 
+        // When
+        when(mprService.find(semiconductorMaterial, supplierPartner)).thenReturn(null);
+ 
+        ShortTermMaterialDemandAnonymized samm = demandSammMapper.ownDemandToAnonymizedSamm(List.of(ownDemand), supplierPartner, semiconductorMaterial, "SALT");
+ 
+        // Then
+        assertNull(samm);
+    }
+ 
+    private Material createSemiconductorMaterial() {
+        return Material.builder()
+            .ownMaterialNumber(CUSTOMER_MAT_NUMBER)
+            .materialFlag(true)
+            .productFlag(false)
+            .name("Semiconductor")
+            .build();
+    }
+ 
+    private MaterialPartnerRelation createMpr(Material material) {
+        MaterialPartnerRelation mpr = new MaterialPartnerRelation();
+        mpr.setPartner(supplierPartner);
+        mpr.setMaterial(material);
+        mpr.setPartnerBuysMaterial(false);
+        mpr.setPartnerSuppliesMaterial(true);
+        mpr.setPartnerMaterialNumber(SUPPLIER_MAT_NUMBER);
+        mpr.setPartnerCXNumber(CX_MAT_NUMBER);
+        return mpr;
+    }
+ 
+    private OwnDemand createOwnDemand(Material material, double quantity, Date day, String demandLocationBpns, String supplierLocationBpns, DemandCategoryEnumeration category, Date lastUpdatedOnDateTime) {
+        return OwnDemand.builder()
+            .partner(supplierPartner)
+            .material(material)
+            .quantity(quantity)
+            .measurementUnit(ItemUnitEnumeration.UNIT_PIECE)
+            .day(day)
+            .demandLocationBpns(demandLocationBpns)
+            .supplierLocationBpns(supplierLocationBpns)
+            .demandCategoryCode(category)
+            .lastUpdatedOnDateTime(lastUpdatedOnDateTime)
+            .build();
+    }
+}

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -11,6 +11,7 @@ puris.itemstocksubmodel.apiassetid=${PURIS_ITEMSTOCKSUBMODEL_APIASSETID:itemstoc
 puris.itemstockanonymizedsubmodel.apiassetid=${PURIS_ITEMSTOCKANONYMIZEDSUBMODEL_APIASSETID:itemstockanonymizedsubmodel-api-asset}
 puris.productionsubmodel.apiassetid=${PURIS_PRODUCTIONSUBMODEL_APIASSETID:productionsubmodel-api-asset}
 puris.demandsubmodel.apiassetid=${PURIS_DEMANDSUBMODEL_APIASSETID:demandsubmodel-api-asset}
+puris.demandanonymizedsubmodel.apiassetid=${PURIS_DEMANDANONYMIZEDSUBMODEL_APIASSETID:demandanonymizedsubmodel-api-asset}
 puris.deliverysubmodel.apiassetid=${PURIS_DELIVERYSUBMODEL_APIASSETID:deliverysubmodel-api-asset}
 puris.daysofsupplysubmodel.apiassetid=${PURIS_DAYSOFSUPPLYSUBMODEL_APIASSETID:daysofsupplysubmodel-api-asset}
 puris.deliveryanonymizedsubmodel.apiassetid=${PURIS_DELIVERYANONYMIZEDSUBMODEL_APIASSETID:deliveryanonymizedsubmodel-api-asset}

--- a/charts/puris/templates/backend-deployment.yaml
+++ b/charts/puris/templates/backend-deployment.yaml
@@ -169,6 +169,8 @@ spec:
               value: "{{ .Values.backend.puris.productionsubmodel.apiassetid }}"
             - name: PURIS_DEMANDSUBMODEL_APIASSETID
               value: "{{ .Values.backend.puris.demandsubmodel.apiassetid }}"
+            -name: PURIS_DEMANDANONYMIZEDSUBMODEL_APIASSETID
+              value: "{{ .Values.backend.puris.demandanonymizedsubmodel.apiassetid }}"
             - name: PURIS_DELIVERYSUBMODEL_APIASSETID
               value: "{{ .Values.backend.puris.deliverysubmodel.apiassetid }}"
             - name: PURIS_DAYSOFSUPPLYSUBMODEL_APIASSETID

--- a/charts/puris/values.yaml
+++ b/charts/puris/values.yaml
@@ -481,6 +481,9 @@ backend:
     demandsubmodel:
       # -- Asset ID for DemandSubmodel API
       apiassetid: demandsubmodel-api-asset
+    demandanonymizedsubmodel:
+      # -- Asset ID for DemandAnonymizedSubmodel API
+      apiassetid: demandanonymizedsubmodel-api-asset
     deliverysubmodel:
       # -- Asset ID for DeliverySubmodel API
       apiassetid: deliverysubmodel-api-asset

--- a/docs/api/openAPI.yaml
+++ b/docs/api/openAPI.yaml
@@ -749,6 +749,30 @@ components:
       - demands
       - lastUpdatedOnDateTime
       type: object
+    DemandSeriesAnonymized:
+      additionalProperties: false
+      properties:
+        customerLocationBpnsAnonymized:
+          maxItems: 50
+          type: string
+        demands:
+          items:
+            $ref: '#/components/schemas/Demand'
+          maxItems: 50
+          type: array
+          uniqueItems: true
+        expectedSupplierLocationBpnsAnonymized:
+          maxItems: 50
+          type: string
+        lastUpdatedOnDateTime:
+          format: date-time
+          maxItems: 50
+          type: string
+      required:
+      - customerLocationBpnsAnonymized
+      - demands
+      - lastUpdatedOnDateTime
+      type: object
     FrontendMaterialDto:
       additionalProperties: false
       properties:
@@ -1846,6 +1870,22 @@ components:
         materialGlobalAssetId:
           maxItems: 50
           pattern: (^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)|(^urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)
+          type: string
+      required:
+      - demandSeries
+      type: object
+    ShortTermMaterialDemandAnonymized:
+      additionalProperties: false
+      properties:
+        demandSeries:
+          items:
+            $ref: '#/components/schemas/DemandSeriesAnonymized'
+          maxItems: 50
+          type: array
+          uniqueItems: true
+        materialGlobalAssetIdAnonymized:
+          maxItems: 50
+          pattern: ^[^\n\x0B\f\r\x85\u2028\u2029]+$
           type: string
       required:
       - demandSeries
@@ -3434,6 +3474,7 @@ paths:
           - ITEM_STOCK_ANONYMIZED_SUBMODEL
           - DELIVERY_ANONYMIZED_SUBMODEL
           - PRODUCTION_ANONYMIZED_SUBMODEL
+          - DEMAND_ANONYMIZED_SUBMODEL
           - SINGLE_LEVEL_BOM_AS_PLANNED_SUBMODEL
           maxItems: 50
           type: string
@@ -3649,6 +3690,65 @@ paths:
         endpoint is meant to be accessed by partners via EDC only. '
       tags:
       - item-stock-request-api-controller
+  /material-demand/anonymized/request/{materialnumbercx}/{partnerBpnl}/submodel/{representation}:
+    get:
+      operationId: getAnonymizedDemandMapping
+      parameters:
+      - in: header
+        name: edc-bpn
+        required: true
+        schema:
+          additionalProperties: false
+          maxItems: 50
+          type: string
+      - in: header
+        name: edc-contract-agreement-id
+        required: true
+        schema:
+          additionalProperties: false
+          maxItems: 50
+          type: string
+      - in: path
+        name: materialnumbercx
+        required: true
+        schema:
+          additionalProperties: false
+          maxItems: 50
+          type: string
+      - in: path
+        name: partnerBpnl
+        required: true
+        schema:
+          additionalProperties: false
+          maxItems: 50
+          type: string
+      - in: path
+        name: representation
+        required: true
+        schema:
+          additionalProperties: false
+          maxItems: 50
+          type: string
+      responses:
+        '200':
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/ShortTermMaterialDemandAnonymized'
+                additionalProperties: false
+          description: Ok
+        '400':
+          description: Bad Request
+        '403':
+          description: Access forbidden - self-access only
+        '500':
+          description: Internal Server Error
+        '501':
+          description: Unsupported representation
+      summary: 'This endpoint receives the ShortTermMaterialDemandAnonymized Submodel
+        1.0.0 requests. This endpoint is meant to be accessed by our own EDC only. '
+      tags:
+      - demand-request-api-controller
   /material-demand/request/{materialnumbercx}/submodel/{representation}:
     get:
       operationId: getDemandMapping

--- a/local/tractus-x-edc/config/customer/puris-backend.properties
+++ b/local/tractus-x-edc/config/customer/puris-backend.properties
@@ -10,6 +10,7 @@ puris.itemstocksubmodel.apiassetid=itemstocksubmodel-api-asset
 puris.itemstockanonymizedsubmodel.apiassetid=itemstockanonymizedsubmodel-api-asset
 puris.productionsubmodel.apiassetid=productionsubmodel-api-asset
 puris.demandsubmodel.apiassetid=demandsubmodel-api-asset
+puris.demandanonymizedsubmodel.apiassetid=demandanonymizedsubmodel-api-asset
 puris.deliverysubmodel.apiassetid=deliverysubmodel-api-asset
 puris.daysofsupplysubmodel.apiassetid=daysofsupplysubmodel-api-asset
 puris.deliveryanonymizedsubmodel.apiassetid=deliveryanonymizedsubmodel-api-asset

--- a/local/tractus-x-edc/config/supplier/puris-backend.properties
+++ b/local/tractus-x-edc/config/supplier/puris-backend.properties
@@ -10,6 +10,7 @@ puris.itemstocksubmodel.apiassetid=itemstocksubmodel-api-asset
 puris.itemstockanonymizedsubmodel.apiassetid=itemstockanonymizedsubmodel-api-asset
 puris.productionsubmodel.apiassetid=productionsubmodel-api-asset
 puris.demandsubmodel.apiassetid=demandsubmodel-api-asset
+puris.demandanonymizedsubmodel.apiassetid=demandanonymizedsubmodel-api-asset
 puris.deliverysubmodel.apiassetid=deliverysubmodel-api-asset
 puris.daysofsupplysubmodel.apiassetid=daysofsupplysubmodel-api-asset
 puris.deliveryanonymizedsubmodel.apiassetid=deliveryanonymizedsubmodel-api-asset


### PR DESCRIPTION


## Description
- Implemented anonymized version of the demand request submodel 
- updated the ShortTermMaterialDemandSammMapper to support mapping to the new model
- added new submodel endpoint to DemandRequestApiController
- added basic unit test for ShortTermMaterialDemandSammMapperTest


Updates #1238 
## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files ([TRG 7.02](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02))
- [x] Documentation Notice are present on all affected files ([TRG 7.07](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07))
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
- [x] **Changelog** updated (`changelog.md`) with PR reference and brief summary.
- [x] **Frontend** version bumped, if needed (`frontend/package.json`, `frontend/package-lock.json`)
- [x] **Backend** version bumped, if needed (`backend/pom.xml`)
- [x] **Open API** specification updated, if controllers have been changed (use python script `scripts/generate_openapi_yaml.py` with running customer backend)
