### PR TITLE
fix: improve handling of existing dtr policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ The **need for configuration updates** is **marked bold**.
 
 - Fix the new part type information controller that was causing an issue with the DTR tests ([#1204](https://github.com/eclipse-tractusx/puris/pull/1204))
 - Create self-contracts for all supported profile versions, and extend self-contracting to the anonymized submodels and PartTypeInformation ([#1216](https://github.com/eclipse-tractusx/puris/pull/1216))
-- improved check for existing policies ([#1220](https://github.com/eclipse-tractusx/puris/pull/1220))
+- improved check for existing policies ([#1220](https://github.com/eclipse-tractusx/puris/pull/1220), [#1221](https://github.com/eclipse-tractusx/puris/pull/1221))
 
 ### Version Bumps
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
@@ -407,14 +407,18 @@ public class EdcAdapterService {
         var body = edcRequestBodyBuilder.buildPurisFrameworkPolicy(profileVersion);
         try (var response = sendPostRequest(body, List.of("v3", "policydefinitions"))) {
             if (!response.isSuccessful()) {
-                Response policyExists = sendGetRequest(List.of("v3", "policydefinitions", profileVersion.CONTRACT_POLICY_ID));
-                if (policyExists.isSuccessful()) {
-                    log.info("Framework agreement policy definition already existed");
-                } else {
-                    log.warn("Framework Policy Registration failed");
-                    if (response.body() != null) {
-                        log.warn("Response: \n" + response.body().string());
+                try (Response policyExists = sendGetRequest(List.of("v3", "policydefinitions", profileVersion.CONTRACT_POLICY_ID))) {
+                    if (policyExists.isSuccessful()) {
+                        log.info("PURIS Framework agreement policy definition already existed");
+                    } else {
+                        log.warn("Framework Policy Registration failed");
+                        if (response.body() != null) {
+                            log.warn("Response: \n" + response.body().string());
+                        }
+                        return false;
                     }
+                } catch(Exception e) {
+                    log.error("Failed to check if puris framework agreement policy definition already exists", e);
                     return false;
                 }
             }
@@ -441,15 +445,20 @@ public class EdcAdapterService {
         var body = edcRequestBodyBuilder.buildDtrFrameworkPolicy(profileVersion);
         try (var response = sendPostRequest(body, List.of("v3", "policydefinitions"))) {
             if (!response.isSuccessful()) {
-                if (response.code() == 409) {
-                    log.info("Framework agreement policy definition already existed");
-                    return true;
+                try (Response policyExists = sendGetRequest(List.of("v3", "policydefinitions", profileVersion.DTR_CONTRACT_POLICY_ID))) {
+                    if (policyExists.isSuccessful()) {
+                        log.info("DTR Framework agreement policy definition already existed");
+                    } else {
+                        log.warn("Framework Policy Registration failed");
+                        if (response.body() != null) {
+                            log.warn("Response: \n" + response.body().string());
+                        }
+                        return false;
+                    }
+                } catch(Exception e) {
+                    log.error("Failed to check if dtr framework agreement policy definition already exists", e);
+                    return false;
                 }
-                log.warn("Framework Policy Registration failed");
-                if (response.body() != null) {
-                    log.warn("Response: \n" + response.body().string());
-                }
-                return false;
             }
             /** 
              * if the IRS adapter is enabled the DTR framework policy for 24.05 should be registered in the policy store


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files ([TRG 7.02](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02))
- [x] Documentation Notice are present on all affected files ([TRG 7.07](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07))
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
- [x] **Changelog** updated (`changelog.md`) with PR reference and brief summary.
- [x] **Frontend** version bumped, if needed (`frontend/package.json`, `frontend/package-lock.json`)
- [x] **Backend** version bumped, if needed (`backend/pom.xml`)
- [x] **Open API** specification updated, if controllers have been changed (use python script `scripts/generate_openapi_yaml.py` with running customer backend)
