### PR TITLE
fix(partTypeInformationController): allow requests with own bpnl in part type controller for irs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The **need for configuration updates** is **marked bold**.
 - Fix the new part type information controller that was causing an issue with the DTR tests ([#1204](https://github.com/eclipse-tractusx/puris/pull/1204))
 - Create self-contracts for all supported profile versions, and extend self-contracting to the anonymized submodels and PartTypeInformation ([#1216](https://github.com/eclipse-tractusx/puris/pull/1216))
 - improved check for existing policies ([#1220](https://github.com/eclipse-tractusx/puris/pull/1220), [#1221](https://github.com/eclipse-tractusx/puris/pull/1221))
+- allow requests with own bpnl in part type controller for irs ([#1222](https://github.com/eclipse-tractusx/puris/pull/1222))
 
 ### Version Bumps
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartTypeInformationController.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartTypeInformationController.java
@@ -159,10 +159,15 @@ public class PartTypeInformationController {
         if (material == null || !material.isProductFlag()) {
             return ProductLookup.error(HttpStatus.NOT_FOUND);
         }
-        var mpr = mprService.find(material, partner);
-        if (mpr == null || !mpr.isPartnerBuysMaterial()) {
-            return ProductLookup.error(HttpStatus.NOT_FOUND);
+
+        // #1222: don't evaluate the MPR, if it is a self-lookup from IRS
+        if (!bpnl.equals(partnerService.getOwnPartnerEntity().getBpnl())){
+            var mpr = mprService.find(material, partner);
+            if (mpr == null || !mpr.isPartnerBuysMaterial()) {
+                return ProductLookup.error(HttpStatus.NOT_FOUND);
+            }
         }
+
         return ProductLookup.found(material);
     }
 

--- a/backend/src/test/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartTypeInformationControllerTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/puris/backend/masterdata/controller/PartTypeInformationControllerTest.java
@@ -26,6 +26,9 @@ import org.eclipse.tractusx.puris.backend.common.security.SecurityConfig;
 import org.eclipse.tractusx.puris.backend.common.security.annotation.WithMockApiKey;
 import org.eclipse.tractusx.puris.backend.common.security.logic.ApiKeyAuthenticationProvider;
 import org.eclipse.tractusx.puris.backend.common.util.VariablesService;
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.MaterialPartnerRelation;
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.adapter.PartTypeInformationSammMapper;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.MaterialPartnerRelationService;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.MaterialService;
@@ -37,8 +40,13 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Base64;
 
 @WebMvcTest(PartTypeInformationController.class)
 @Import({SecurityConfig.class, ApiKeyAuthenticationProvider.class, DtrSecurityConfiguration.class, VariablesService.class, TestConfig.class})
@@ -59,6 +67,41 @@ class PartTypeInformationControllerTest {
     @MockitoBean
     PartTypeInformationSammMapper sammMapper;
 
+    String MATERIAL_OWN_MATERIAL_NUMBER = "some-number-4711";
+    String MATERIAL_PARTNER_MATERIAL_NUMBER = "some-number-4711";
+    String OWN_PARTNER_BPNL = "BPNL1234567890LE";
+    String OTHER_PARTNER_BPNL = "BPNL0987654321LE";
+
+    Material product;
+    Partner ownPartner;
+    Partner otherPartner;
+    MaterialPartnerRelation mpr;
+
+    Base64.Encoder encoder = Base64.getEncoder();
+    
+    
+    void setup() {
+        product = Material.builder()
+            .ownMaterialNumber(MATERIAL_OWN_MATERIAL_NUMBER)
+            .productFlag(true)
+            .build();
+
+        ownPartner = new Partner();
+        ownPartner.setBpnl(OWN_PARTNER_BPNL);
+
+        otherPartner = new Partner();
+        otherPartner.setBpnl(OTHER_PARTNER_BPNL);
+
+        mpr = new MaterialPartnerRelation(
+            product,
+            otherPartner,
+            MATERIAL_PARTNER_MATERIAL_NUMBER,
+            false,
+            true
+        );
+    }
+    
+
     @Test
     @WithMockApiKey
     void getPartTypeInformationSamm_GivenPathNotImplemented_Returns501() throws Exception {
@@ -66,5 +109,44 @@ class PartTypeInformationControllerTest {
         this.mockMvc.perform(
             get("/parttypeinformation/request/material-number/description")
         ).andExpect(status().isNotImplemented());
+    }
+
+    @Test
+    @WithMockApiKey
+    void resolveProduct_GivenSelfRequest_ResolvesProduct() throws Exception {
+
+        String encodedMaterialNumber = encoder.encodeToString(MATERIAL_OWN_MATERIAL_NUMBER.getBytes());
+
+        setup();
+
+        when(partnerService.findByBpnl(OWN_PARTNER_BPNL)).thenReturn(ownPartner);
+        when(materialService.findByOwnMaterialNumber(MATERIAL_OWN_MATERIAL_NUMBER)).thenReturn(product);
+        when(partnerService.getOwnPartnerEntity()).thenReturn(ownPartner);
+
+        this.mockMvc.perform(
+            get("/parttypeinformation/"+ PartTypeInformationController.VERSION_1_0_0 +"/" +encodedMaterialNumber+"/submodel/$value" )
+            .header("edc-bpn", OWN_PARTNER_BPNL)
+        ).andExpect(status().isOk());
+
+    }
+
+    @Test
+    @WithMockApiKey
+    void resolveProduct_GivenPartnerRequest_ResolvesProduct() throws Exception {
+
+        String encodedMaterialNumber = encoder.encodeToString(MATERIAL_OWN_MATERIAL_NUMBER.getBytes());
+
+        setup();
+
+        when(partnerService.findByBpnl(OTHER_PARTNER_BPNL)).thenReturn(otherPartner);
+        when(materialService.findByOwnMaterialNumber(MATERIAL_OWN_MATERIAL_NUMBER)).thenReturn(product);
+        when(partnerService.getOwnPartnerEntity()).thenReturn(ownPartner);        
+        when(materialPartnerRelationService.find(any(Material.class), any(Partner.class))).thenReturn(mpr);
+
+        this.mockMvc.perform(
+            get("/parttypeinformation/"+ PartTypeInformationController.VERSION_2_0_0 +"/" +encodedMaterialNumber+"/submodel/$value" )
+            .header("edc-bpn", OTHER_PARTNER_BPNL)
+        ).andExpect(status().isOk());
+
     }
 }


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

solves #1222 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files ([TRG 7.02](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02))
- [x] Documentation Notice are present on all affected files ([TRG 7.07](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07))
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
- [x] **Changelog** updated (`changelog.md`) with PR reference and brief summary.
- [x] **Frontend** version bumped, if needed (`frontend/package.json`, `frontend/package-lock.json`)
- [x] **Backend** version bumped, if needed (`backend/pom.xml`)
- [x] **Open API** specification updated, if controllers have been changed (use python script `scripts/generate_openapi_yaml.py` with running customer backend)
