### PR TITLE
fix: update chain opening grant structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,8 @@ The **need for configuration updates** is **marked bold**.
 
 - Fix the new part type information controller that was causing an issue with the DTR tests ([#1204](https://github.com/eclipse-tractusx/puris/pull/1204))
 - Create self-contracts for all supported profile versions, and extend self-contracting to the anonymized submodels and PartTypeInformation ([#1216](https://github.com/eclipse-tractusx/puris/pull/1216))
-- improved check for existing policies ([#1220](https://github.com/eclipse-tractusx/puris/pull/1220), [#1221](https://github.com/eclipse-tractusx/puris/pull/1221))
+- Improved check for existing policies ([#1220](https://github.com/eclipse-tractusx/puris/pull/1220), [#1221](https://github.com/eclipse-tractusx/puris/pull/1221))
+- Fixed validity dates and renamed allowedBpnls property to allowedBpnlSet for Chain Opening Grants ([#1221](https://github.com/eclipse-tractusx/puris/pull/1221))
 
 ### Version Bumps
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ The **need for configuration updates** is **marked bold**.
 - Fix the new part type information controller that was causing an issue with the DTR tests ([#1204](https://github.com/eclipse-tractusx/puris/pull/1204))
 - Create self-contracts for all supported profile versions, and extend self-contracting to the anonymized submodels and PartTypeInformation ([#1216](https://github.com/eclipse-tractusx/puris/pull/1216))
 - Improved check for existing policies ([#1220](https://github.com/eclipse-tractusx/puris/pull/1220), [#1221](https://github.com/eclipse-tractusx/puris/pull/1221))
-- Fixed validity dates and renamed allowedBpnls property to allowedBpnlSet for Chain Opening Grants ([#1221](https://github.com/eclipse-tractusx/puris/pull/1221))
+- Fixed validity dates and renamed allowedBpnls property to allowedBpnlSet for Chain Opening Grants ([#1224](https://github.com/eclipse-tractusx/puris/pull/1224))
 
 ### Version Bumps
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/irs/domain/model/IrsChainOpeningGrant.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/irs/domain/model/IrsChainOpeningGrant.java
@@ -26,9 +26,11 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.eclipse.tractusx.puris.backend.common.util.PatternStore;
+import org.eclipse.tractusx.puris.backend.common.util.VariablesService;
 import org.eclipse.tractusx.puris.backend.demandandcapacitynotification.domain.model.ReportedDemandAndCapacityNotification;
 import org.eclipse.tractusx.puris.backend.irs.IrsAdapterConfiguration;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -110,7 +112,7 @@ public abstract class IrsChainOpeningGrant {
 	 * of {@link #getReportedNotifications()}. This is the wire shape expected by the IRS
 	 * grant-creation request.
 	 */
-	@JsonProperty("allowedBpnls")
+	@JsonIgnore
 	public Set<String> getAllowedBpnls() {
 		return getReportedNotifications().stream()
 			.map(ReportedDemandAndCapacityNotification::getPartner)

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/irs/logic/service/IrsChainOpeningRootGrantService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/irs/logic/service/IrsChainOpeningRootGrantService.java
@@ -199,11 +199,8 @@ public class IrsChainOpeningRootGrantService {
 		Instant notificationEnd = notification.getExpectedEndDateOfEffect() != null
 			? notification.getExpectedEndDateOfEffect().toInstant() : null;
 
-		Instant newValidFrom = grant.getValidFrom() == null || notificationStart.isBefore(grant.getValidFrom())
-			? notificationStart : grant.getValidFrom();
-		Instant newValidUntil = grant.getValidUntil() == null || notificationEnd == null
-			? null
-			: (notificationEnd.isAfter(grant.getValidUntil()) ? notificationEnd : grant.getValidUntil());
+		Instant newValidFrom = notificationStart;
+		Instant newValidUntil = notificationEnd;
 
 		if (!Objects.equals(grant.getValidFrom(), newValidFrom) || !Objects.equals(grant.getValidUntil(), newValidUntil)) {
 			changed = true;

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/irs/logic/service/IrsChainOpeningRootGrantService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/irs/logic/service/IrsChainOpeningRootGrantService.java
@@ -199,8 +199,17 @@ public class IrsChainOpeningRootGrantService {
 		Instant notificationEnd = notification.getExpectedEndDateOfEffect() != null
 			? notification.getExpectedEndDateOfEffect().toInstant() : null;
 
-		Instant newValidFrom = notificationStart;
-		Instant newValidUntil = notificationEnd;
+		Instant newValidFrom = grant.getValidFrom() == null
+			? notificationStart : (notificationStart.isBefore(grant.getValidFrom()) ? notificationStart : grant.getValidFrom());
+		Instant newValidUntil = null;
+		if (grant.getValidUntil() == null || (notificationEnd != null && notificationEnd.isAfter(grant.getValidUntil()))) {
+			newValidUntil = notificationEnd;
+		} else {
+			newValidUntil = grant.getValidUntil();
+		}
+		if (newValidUntil == null) {
+			newValidUntil = newValidFrom.plusSeconds(60 * 60 * 24 * 7);
+		}
 
 		if (!Objects.equals(grant.getValidFrom(), newValidFrom) || !Objects.equals(grant.getValidUntil(), newValidUntil)) {
 			changed = true;

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/irs/logic/service/IrsRequestBodybuilder.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/irs/logic/service/IrsRequestBodybuilder.java
@@ -64,7 +64,12 @@ public class IrsRequestBodybuilder {
      * @return the grant creation request body
      */
     public JsonNode buildGrantCreationRequestBody(IrsChainOpeningGrant grant) {
-        return objectMapper.valueToTree(grant);
+        ObjectNode grantNode = objectMapper.valueToTree(grant);
+        ArrayNode allowedBpnlsNode = objectMapper.createArrayNode();
+        grantNode.set("allowedBpnlSet", allowedBpnlsNode);
+        grant.getAllowedBpnls().forEach(allowedBpnlsNode::add);
+        allowedBpnlsNode.add(variablesService.getOwnBpnl());
+        return grantNode;
     }
 
     /**


### PR DESCRIPTION
## Description

- updated "allowedBpnls" property to "allowedBpnlSet"
- simplified validTo and validFrom calculation

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files ([TRG 7.02](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02))
- [x] Documentation Notice are present on all affected files ([TRG 7.07](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07))
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
- [x] **Changelog** updated (`changelog.md`) with PR reference and brief summary.
- [x] **Frontend** version bumped, if needed (`frontend/package.json`, `frontend/package-lock.json`)
- [x] **Backend** version bumped, if needed (`backend/pom.xml`)
- [x] **Open API** specification updated, if controllers have been changed (use python script `scripts/generate_openapi_yaml.py` with running customer backend)
