### PR TITLE
feat: create missing partner contracts during migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The **need for configuration updates** is **marked bold**.
   - Added logic to map and save received irs job data ([#1184](https://github.com/eclipse-tractusx/puris/pull/1184))
   - Added frontend for Aggregated Supply Chain Data ([#1201](https://github.com/eclipse-tractusx/puris/pull/1201))
 - Added link to affected outgoing material on the material details header, showing open demand/capacity notifications affecting a material via its descendant (child) materials ([#1202](https://github.com/eclipse-tractusx/puris/pull/1202))
+- Added logic to create missing partner contract definitions and policies during migrations ([#1225](https://github.com/eclipse-tractusx/puris/pull/1225))
 
 ### Changed
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/MigrationTaskCommandLineRunner.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/MigrationTaskCommandLineRunner.java
@@ -18,14 +18,18 @@
  */
 package org.eclipse.tractusx.puris.backend;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.tractusx.puris.backend.common.ddtr.logic.DtrAdapterService;
+import org.eclipse.tractusx.puris.backend.common.edc.logic.service.EdcAdapterService;
 import org.eclipse.tractusx.puris.backend.common.migration.MigrationTaskService;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Material;
 import org.eclipse.tractusx.puris.backend.masterdata.domain.model.MaterialPartnerRelation;
+import org.eclipse.tractusx.puris.backend.masterdata.domain.model.Partner;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.MaterialPartnerRelationService;
 import org.eclipse.tractusx.puris.backend.masterdata.logic.service.MaterialService;
+import org.eclipse.tractusx.puris.backend.masterdata.logic.service.PartnerService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.core.annotation.Order;
@@ -47,9 +51,14 @@ public class MigrationTaskCommandLineRunner implements CommandLineRunner {
     private MaterialPartnerRelationService materialPartnerRelationService;
     @Autowired
     private MigrationTaskService migrationTaskService;
+    @Autowired
+    private PartnerService partnerService;
+    @Autowired
+    private EdcAdapterService edcAdapterService;
  
     @Override
     public void run(String... args) throws Exception {
+        migrationTaskService.resetStuckInProgressTasks();
         var latestTask = migrationTaskService.getLatestPendingMigrationTask();
         if (latestTask == null) {
             log.info("No pending migration task found, skipping migration");
@@ -59,7 +68,7 @@ public class MigrationTaskCommandLineRunner implements CommandLineRunner {
         migrationTaskService.markTaskInProgress(latestTask);
 
         List<String> errors = updateDigitalTwins();
-
+        errors.addAll(createMissingPartnerContractDefinitions());
         if (errors.isEmpty()) {
             migrationTaskService.markTaskCompleted(latestTask);
             log.info("Migration task for target version {} completed successfully", latestTask.getTargetVersion());
@@ -69,8 +78,16 @@ public class MigrationTaskCommandLineRunner implements CommandLineRunner {
         }
     }
 
+    /**
+     * Updates the digital twins at the DTR for all materials in the database.
+     * For each material, it attempts to update the corresponding material twin at the DTR.
+     * Any errors encountered during this process are collected and returned.
+     *
+     * @return A list of error messages encountered during the update of digital twins.
+     * If no errors occurred, the list will be empty.
+     */
     private List<String> updateDigitalTwins() {
-        List<String> errors = List.of();
+        List<String> errors = new ArrayList<>();
         List<Material> materials = materialService.findAll();
         if (materials.isEmpty()) {
             log.info("No materials found in database, skipping digital twin update at DTR");
@@ -121,6 +138,29 @@ public class MigrationTaskCommandLineRunner implements CommandLineRunner {
             } catch (Exception e) {
                 String error = String.format("Error while updating digital twins at dDTR for material %s: %s", material.getOwnMaterialNumber(), e.getMessage());
                 log.error(error);
+                errors.add(error);
+            }
+        }
+        return errors;
+    }
+
+    /**
+     * Creates missing policies and contract definitions for all partners except the own partner.
+     * This method iterates over all partners except the own partner and ensures that each has the necessary
+     * policies and contract definitions in place. Existing policies and contract definitions are not modified.
+     * Any errors encountered during this process are collected and returned.
+     * 
+     * @return A list of error messages encountered during the creation of missing policies and contract definitions.
+     * If no errors occurred, the list will be empty.
+     */
+    private List<String> createMissingPartnerContractDefinitions() {
+        List<String> errors = new ArrayList<>();
+        List<Partner> partners = partnerService.findAll().stream().filter(partner -> !partnerService.getOwnPartnerEntity().equals(partner)).toList();
+        for (Partner partner : partners) {
+            boolean result = edcAdapterService.createPolicyAndContractDefForPartner(partner);
+            if (!result) {
+                String error = String.format("Failed to create policy and contract definition for partner %s.", partner.getBpnl());
+                log.warn(error);
                 errors.add(error);
             }
         }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/service/EdcAdapterService.java
@@ -346,6 +346,10 @@ public class EdcAdapterService {
         var body = edcRequestBodyBuilder.buildSubmodelContractDefinitionWithBpnRestrictedPolicy(assetId, partner);
         try (var response = sendPostRequest(body, List.of("v3", "contractdefinitions"))) {
             if (!response.isSuccessful()) {
+                if (response.code() == 409) {
+                    log.info("Contract definition already exists for partner " + partner.getBpnl() + " and {} Submodel", semanticId);
+                    return true;
+                }
                 log.warn("Contract definition registration failed for partner " + partner.getBpnl() + " and {} Submodel", semanticId);
                 if (response.body() != null) {
                     log.warn("Response: \n" + response.body().string());
@@ -363,6 +367,10 @@ public class EdcAdapterService {
         var body = edcRequestBodyBuilder.buildDtrContractDefinitionForPartner(partner);
         try (var response = sendPostRequest(body, List.of("v3", "contractdefinitions"))) {
             if (!response.isSuccessful()) {
+                if (response.code() == 409) {
+                    log.info("Contract definition already exists for partner " + partner.getBpnl() + " and DTR");
+                    return true;
+                }
                 log.warn("Contract definition registration failed for partner " + partner.getBpnl() + " and DTR");
                 return false;
             }
@@ -385,6 +393,10 @@ public class EdcAdapterService {
         var body = edcRequestBodyBuilder.buildBpnAndMembershipRestrictedPolicy(partner);
         try (var response = sendPostRequest(body, List.of("v3", "policydefinitions"))) {
             if (!response.isSuccessful()) {
+                if (response.code() == 409 || isPolicyExisting(edcRequestBodyBuilder.getBpnPolicyId(partner))) {
+                    log.info("Policy definition already exists for partner " + partner.getBpnl());
+                    return true;
+                }
                 log.warn("Policy Registration failed");
                 if (response.body() != null) {
                     log.warn("Response: \n" + response.body().string());
@@ -407,18 +419,13 @@ public class EdcAdapterService {
         var body = edcRequestBodyBuilder.buildPurisFrameworkPolicy(profileVersion);
         try (var response = sendPostRequest(body, List.of("v3", "policydefinitions"))) {
             if (!response.isSuccessful()) {
-                try (Response policyExists = sendGetRequest(List.of("v3", "policydefinitions", profileVersion.CONTRACT_POLICY_ID))) {
-                    if (policyExists.isSuccessful()) {
+                if (response.code() == 409 || isPolicyExisting(profileVersion.CONTRACT_POLICY_ID)) {
                         log.info("PURIS Framework agreement policy definition already existed");
-                    } else {
-                        log.warn("Framework Policy Registration failed");
-                        if (response.body() != null) {
-                            log.warn("Response: \n" + response.body().string());
-                        }
-                        return false;
+                } else {
+                    log.warn("Framework Policy Registration failed");
+                    if (response.body() != null) {
+                        log.warn("Response: \n" + response.body().string());
                     }
-                } catch(Exception e) {
-                    log.error("Failed to check if puris framework agreement policy definition already exists", e);
                     return false;
                 }
             }
@@ -445,18 +452,13 @@ public class EdcAdapterService {
         var body = edcRequestBodyBuilder.buildDtrFrameworkPolicy(profileVersion);
         try (var response = sendPostRequest(body, List.of("v3", "policydefinitions"))) {
             if (!response.isSuccessful()) {
-                try (Response policyExists = sendGetRequest(List.of("v3", "policydefinitions", profileVersion.DTR_CONTRACT_POLICY_ID))) {
-                    if (policyExists.isSuccessful()) {
+                if (response.code() == 409 || isPolicyExisting(profileVersion.DTR_CONTRACT_POLICY_ID)) {
                         log.info("DTR Framework agreement policy definition already existed");
-                    } else {
-                        log.warn("Framework Policy Registration failed");
-                        if (response.body() != null) {
-                            log.warn("Response: \n" + response.body().string());
-                        }
-                        return false;
+                } else {
+                    log.warn("DTR Framework Policy Registration failed");
+                    if (response.body() != null) {
+                        log.warn("Response: \n" + response.body().string());
                     }
-                } catch(Exception e) {
-                    log.error("Failed to check if dtr framework agreement policy definition already exists", e);
                     return false;
                 }
             }
@@ -1634,5 +1636,24 @@ public class EdcAdapterService {
         log.info("Contract Offer constraints can be fulfilled by PURIS FOSS application (passed).");
 
         return true;
+    }
+
+    /**
+     * This method checks if a policy with the given ID already exists in the EDC.
+     * It sends a GET request to the EDC to verify the existence of the policy.
+     * If the request is successful, it returns true, indicating that the policy exists.
+     * If the request fails or an exception occurs, it returns false.
+     * 
+     * NOTE: This method only checks for the existence of the policy and does not validate its contents.
+     * @param policyId  The ID of the policy to check for existence.
+     * @return true if the policy exists, false otherwise.
+     */
+    private boolean isPolicyExisting(String policyId) {
+        try (Response policyExists = sendGetRequest(List.of("v3", "policydefinitions", policyId))) {
+            return policyExists.isSuccessful();
+        } catch(Exception e) {
+            log.error("Failed to check if policy definition already exists", e);
+            return false;
+        }
     }
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/util/EdcRequestBodyBuilder.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/edc/logic/util/EdcRequestBodyBuilder.java
@@ -321,7 +321,7 @@ public class EdcRequestBodyBuilder {
      * @param partner the partner
      * @return the policy-id
      */
-    private String getBpnPolicyId(Partner partner) {
+    public String getBpnPolicyId(Partner partner) {
         return partner.getBpnl() + "_policy";
     }
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/migration/MigrationTaskService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/common/migration/MigrationTaskService.java
@@ -33,6 +33,18 @@ public class MigrationTaskService {
     private final MigrationTaskRepository migrationTaskRepository;
 
     /**
+     * Finds all migration tasks that are currently in progress and resets their status to pending.
+     * This is useful for handling tasks that may have been left in an inconsistent state due to unexpected interruptions.
+     */
+    public void resetStuckInProgressTasks() {
+        List<MigrationTask> inProgressTasks = migrationTaskRepository.findByStatus(MigrationTaskStatusEnumeration.IN_PROGRESS);
+        for (MigrationTask task : inProgressTasks) {
+            task.setStatus(MigrationTaskStatusEnumeration.PENDING);
+            saveMigrationTask(task);
+        }
+    }
+
+    /**
      * Finds the pending migration task with the highest target version.
      * If multiple tasks have the same target version, the one that was created first is returned.
      * @return the latest pending migration task, or null if there are no pending tasks


### PR DESCRIPTION
## Description

- added logic to the migration runner to automatically create any missing policies and contract definitions for existing partners
- automatically reset migration tasks that got stuck on `IN_PROGRESS`

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files ([TRG 7.02](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02))
- [x] Documentation Notice are present on all affected files ([TRG 7.07](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07))
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
- [x] **Changelog** updated (`changelog.md`) with PR reference and brief summary.
- [x] **Frontend** version bumped, if needed (`frontend/package.json`, `frontend/package-lock.json`)
- [x] **Backend** version bumped, if needed (`backend/pom.xml`)
- [x] **Open API** specification updated, if controllers have been changed (use python script `scripts/generate_openapi_yaml.py` with running customer backend)
