### PR TITLE
feat: rename validUntil to validTo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The **need for configuration updates** is **marked bold**.
 - improved check for existing policies ([#1220](https://github.com/eclipse-tractusx/puris/pull/1220), [#1221](https://github.com/eclipse-tractusx/puris/pull/1221))
 - allow requests with own bpnl in part type controller for irs ([#1222](https://github.com/eclipse-tractusx/puris/pull/1222))
 - Fixed validity dates and renamed allowedBpnls property to allowedBpnlSet for Chain Opening Grants ([#1224](https://github.com/eclipse-tractusx/puris/pull/1224))
+- Renamed "validUntil" to "validTo" in chain opening grants ([#1226](https://github.com/eclipse-tractusx/puris/pull/1226))
 
 ### Version Bumps
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/irs/domain/model/IrsChainOpeningGrant.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/irs/domain/model/IrsChainOpeningGrant.java
@@ -57,7 +57,7 @@ import lombok.experimental.SuperBuilder;
  * <p>
  * A grant allows {@link #requesterBpn} to recursively query the set of {@link #getAllowedBpnls()}
  * for the material identified by {@link #globalAssetId}, for the duration of the
- * [{@link #validFrom}, {@link #validUntil}] window. A grant is uniquely identified by the
+ * [{@link #validFrom}, {@link #validTo}] window. A grant is uniquely identified by the
  * combination of {@link #requesterBpn}, {@link #globalAssetId} and {@link #sourceDisruptionId}.
  * <p>
  * {@link #getReportedNotifications()} is declared abstract rather than mapped here: a real
@@ -96,7 +96,7 @@ public abstract class IrsChainOpeningGrant {
 
 	protected Instant validFrom;
 
-	protected Instant validUntil;
+	protected Instant validTo;
 
 	@Builder.Default
 	protected String useCase = IrsAdapterConfiguration.PURIS_USE_CASE;

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/irs/domain/model/IrsChainOpeningPartnerGrant.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/irs/domain/model/IrsChainOpeningPartnerGrant.java
@@ -48,7 +48,7 @@ import lombok.experimental.SuperBuilder;
  * {@link #getAllowedBpnls()} for child materials of the material identified by
  * {@link #globalAssetId} (a material directly affected by one of our own disruption
  * notifications that we approved data exchange for), for the duration of the
- * [{@link #validFrom}, {@link #validUntil}] window. The allowed BPNLs are derived from the
+ * [{@link #validFrom}, {@link #validTo}] window. The allowed BPNLs are derived from the
  * partners of {@link #reportedNotifications}, the set of reported notifications currently
  * backing this grant.
  */

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/irs/domain/model/IrsChainOpeningRootGrant.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/irs/domain/model/IrsChainOpeningRootGrant.java
@@ -47,7 +47,7 @@ import lombok.experimental.SuperBuilder;
  * A root grant's {@link #requesterBpn} is always our own company BPNL. It allows us to
  * recursively query the set of {@link #getAllowedBpnls()} for child materials of the material
  * identified by {@link #globalAssetId} (a parent of a material affected by a reported disruption
- * notification), for the duration of the [{@link #validFrom}, {@link #validUntil}] window. The
+ * notification), for the duration of the [{@link #validFrom}, {@link #validTo}] window. The
  * allowed BPNLs are derived from the partners of {@link #reportedNotifications}, the set of
  * reported notifications currently backing this grant.
  */

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/irs/logic/service/IrsChainOpeningPartnerGrantService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/irs/logic/service/IrsChainOpeningPartnerGrantService.java
@@ -286,7 +286,7 @@ public class IrsChainOpeningPartnerGrantService {
 				.sourceDisruptionId(sourceDisruptionId)
 				.useCase(IrsAdapterConfiguration.PURIS_USE_CASE)
 				.validFrom(ownNotification.getStartDateOfEffect().toInstant())
-				.validUntil(ownNotification.getExpectedEndDateOfEffect() == null
+				.validTo(ownNotification.getExpectedEndDateOfEffect() == null
 					? null : ownNotification.getExpectedEndDateOfEffect().toInstant())
 				.syncStatus(IrsGrantSyncStatusEnumeration.NOT_SYNCED)
 				.build();
@@ -369,7 +369,7 @@ public class IrsChainOpeningPartnerGrantService {
 		OwnDemandAndCapacityNotification matchingNotification = ownNotificationRepository
 			.findBySourceDisruptionIdAndPartnerBpnl(sourceDisruptionId, grant.getRequesterBpn()).stream()
 			.filter(notification -> DemandAndCapacityNotificationService.isNotificationActiveNow(notification, now))
-			.filter(notification -> DemandAndCapacityNotificationService.isWithinNotificationBounds(notification, grant.getValidFrom(), grant.getValidUntil()))
+			.filter(notification -> DemandAndCapacityNotificationService.isWithinNotificationBounds(notification, grant.getValidFrom(), grant.getValidTo()))
 			.filter(notification -> DemandAndCapacityNotificationService.affectsMaterialWithMaterialNumberCx(notification, grant.getGlobalAssetId()))
 			.findFirst()
 			.orElse(null);

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/irs/logic/service/IrsChainOpeningRootGrantService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/irs/logic/service/IrsChainOpeningRootGrantService.java
@@ -201,21 +201,21 @@ public class IrsChainOpeningRootGrantService {
 
 		Instant newValidFrom = grant.getValidFrom() == null
 			? notificationStart : (notificationStart.isBefore(grant.getValidFrom()) ? notificationStart : grant.getValidFrom());
-		Instant newValidUntil = null;
-		if (grant.getValidUntil() == null || (notificationEnd != null && notificationEnd.isAfter(grant.getValidUntil()))) {
-			newValidUntil = notificationEnd;
+		Instant newValidTo = null;
+		if (grant.getValidTo() == null || (notificationEnd != null && notificationEnd.isAfter(grant.getValidTo()))) {
+			newValidTo = notificationEnd;
 		} else {
-			newValidUntil = grant.getValidUntil();
+			newValidTo = grant.getValidTo();
 		}
-		if (newValidUntil == null) {
-			newValidUntil = newValidFrom.plusSeconds(60 * 60 * 24 * 7);
+		if (newValidTo == null) {
+			newValidTo = newValidFrom.plusSeconds(60 * 60 * 24 * 7);
 		}
 
-		if (!Objects.equals(grant.getValidFrom(), newValidFrom) || !Objects.equals(grant.getValidUntil(), newValidUntil)) {
+		if (!Objects.equals(grant.getValidFrom(), newValidFrom) || !Objects.equals(grant.getValidTo(), newValidTo)) {
 			changed = true;
 		}
 		grant.setValidFrom(newValidFrom);
-		grant.setValidUntil(newValidUntil);
+		grant.setValidTo(newValidTo);
 
 		if (!isNew && changed && grant.getSyncStatus() == IrsGrantSyncStatusEnumeration.SYNCED) {
 			grant.setSyncStatus(IrsGrantSyncStatusEnumeration.OUT_OF_SYNC);

--- a/backend/src/main/resources/db/changelog/changelog-6.x/changelog-6.2.0.yaml
+++ b/backend/src/main/resources/db/changelog/changelog-6.x/changelog-6.2.0.yaml
@@ -896,3 +896,15 @@ databaseChangeLog:
                   name: target_version
                   value: "6.2.0"
             tableName: migration_task
+  - changeSet:
+      id: "14"
+      author: "ReneSchroederLj"
+      changes:
+        - renameColumn:
+            tableName: "chain_opening_root_grant"
+            oldColumnName: "valid_until"
+            newColumnName: "valid_to"
+        - renameColumn:
+            tableName: "chain_opening_grant"
+            oldColumnName: "valid_until"
+            newColumnName: "valid_to"

--- a/backend/src/test/java/org/eclipse/tractusx/puris/backend/irs/logic/service/IrsChainOpeningPartnerGrantServiceTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/puris/backend/irs/logic/service/IrsChainOpeningPartnerGrantServiceTest.java
@@ -81,7 +81,7 @@ class IrsChainOpeningPartnerGrantServiceTest {
     private static final String SUPPLIER_BPNL = "BPNLXXSUPPLIERXX";
     private static final UUID SOURCE_DISRUPTION_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
     private static final Instant VALID_FROM = Instant.now().minusSeconds(7 * 24 * 3600L);
-    private static final Instant VALID_UNTIL = Instant.now().plusSeconds(7 * 24 * 3600L);
+    private static final Instant VALID_TO = Instant.now().plusSeconds(7 * 24 * 3600L);
 
     @Mock
     private IrsRequestService irsRequestService;
@@ -155,11 +155,11 @@ class IrsChainOpeningPartnerGrantServiceTest {
         notification.setSourceDisruptionId(SOURCE_DISRUPTION_ID);
         notification.setPartner(partner(PARTNER_BPNL));
         notification.setStatus(StatusEnumeration.OPEN);
-        // Padded a bit wider than [VALID_FROM, VALID_UNTIL] (the grant's own bounds) so
+        // Padded a bit wider than [VALID_FROM, VALID_TO] (the grant's own bounds) so
         // isWithinNotificationBounds isn't tripped up by Instant<->Date millisecond truncation
         // at an exact boundary.
         notification.setStartDateOfEffect(Date.from(VALID_FROM.minusSeconds(3600)));
-        notification.setExpectedEndDateOfEffect(Date.from(VALID_UNTIL.plusSeconds(3600)));
+        notification.setExpectedEndDateOfEffect(Date.from(VALID_TO.plusSeconds(3600)));
         notification.setMaterials(materials);
         return notification;
     }
@@ -213,7 +213,7 @@ class IrsChainOpeningPartnerGrantServiceTest {
             .requesterBpn(PARTNER_BPNL)
             .reportedNotifications(notifications)
             .validFrom(VALID_FROM)
-            .validUntil(VALID_UNTIL)
+            .validTo(VALID_TO)
             .build();
     }
 

--- a/backend/src/test/java/org/eclipse/tractusx/puris/backend/irs/logic/service/IrsChainOpeningRootGrantServiceTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/puris/backend/irs/logic/service/IrsChainOpeningRootGrantServiceTest.java
@@ -74,7 +74,7 @@ class IrsChainOpeningRootGrantServiceTest {
     private static final String ALLOWED_BPNL = "BPNLXXSUPPLIERXX";
     private static final UUID SOURCE_DISRUPTION_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
     private static final Instant VALID_FROM = Instant.now().minusSeconds(7 * 24 * 3600L);
-    private static final Instant VALID_UNTIL = Instant.now().plusSeconds(7 * 24 * 3600L);
+    private static final Instant VALID_TO = Instant.now().plusSeconds(7 * 24 * 3600L);
     private static final String PARENT_MATERIAL_NUMBER = "MNR-001";
     private static final String CHILD_MATERIAL_NUMBER = "MNR-002";
     private static final String OWN_BPNL = "BPNLXXOWNCOMPANYX";
@@ -125,7 +125,7 @@ class IrsChainOpeningRootGrantServiceTest {
             .requesterBpn(OWN_BPNL)
             .reportedNotifications(notificationsFor(allowedBpnls))
             .validFrom(VALID_FROM)
-            .validUntil(VALID_UNTIL)
+            .validTo(VALID_TO)
             .build();
     }
 
@@ -205,7 +205,7 @@ class IrsChainOpeningRootGrantServiceTest {
         notification.setPartner(partner);
         notification.setStatus(StatusEnumeration.OPEN);
         notification.setStartDateOfEffect(Date.from(VALID_FROM));
-        notification.setExpectedEndDateOfEffect(Date.from(VALID_UNTIL));
+        notification.setExpectedEndDateOfEffect(Date.from(VALID_TO));
         notification.setMaterials(materials);
         return notification;
     }
@@ -415,7 +415,7 @@ class IrsChainOpeningRootGrantServiceTest {
         notification.setPartner(partner);
         notification.setStatus(StatusEnumeration.OPEN);
         notification.setStartDateOfEffect(Date.from(VALID_FROM));
-        notification.setExpectedEndDateOfEffect(Date.from(VALID_UNTIL));
+        notification.setExpectedEndDateOfEffect(Date.from(VALID_TO));
         notification.setMaterials(List.of(childMaterial));
         return notification;
     }
@@ -454,7 +454,7 @@ class IrsChainOpeningRootGrantServiceTest {
             .sourceDisruptionId(SOURCE_DISRUPTION_ID.toString())
             .reportedNotifications(notificationsFor(new HashSet<>(Set.of("BPNLXXOTHERSUPPLIER"))))
             .validFrom(VALID_FROM)
-            .validUntil(VALID_UNTIL)
+            .validTo(VALID_TO)
             .syncStatus(IrsGrantSyncStatusEnumeration.SYNCED)
             .build();
 


### PR DESCRIPTION
## Description

- renamed `validUntil` to `validTo` in chain opening grants to ensure compatibility with the IRS API

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files ([TRG 7.02](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02))
- [x] Documentation Notice are present on all affected files ([TRG 7.07](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07))
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
- [x] **Changelog** updated (`changelog.md`) with PR reference and brief summary.
- [x] **Frontend** version bumped, if needed (`frontend/package.json`, `frontend/package-lock.json`)
- [x] **Backend** version bumped, if needed (`backend/pom.xml`)
- [x] **Open API** specification updated, if controllers have been changed (use python script `scripts/generate_openapi_yaml.py` with running customer backend)
