### PR TITLE
feat: updated aggregated material data node to allow mapping of job data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The **need for configuration updates** is **marked bold**.
 - improved check for existing policies ([#1220](https://github.com/eclipse-tractusx/puris/pull/1220), [#1221](https://github.com/eclipse-tractusx/puris/pull/1221))
 - allow requests with own bpnl in part type controller for irs ([#1222](https://github.com/eclipse-tractusx/puris/pull/1222))
 - Fixed validity dates and renamed allowedBpnls property to allowedBpnlSet for Chain Opening Grants ([#1224](https://github.com/eclipse-tractusx/puris/pull/1224))
+- Updated AggregatedMaterialDataNode and its children to allow for proper mapping of job data ([#1227](https://github.com/eclipse-tractusx/puris/pull/1227))
 
 ### Version Bumps
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/aggregateddata/domain/model/AggregatedMaterialDataNode.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/aggregateddata/domain/model/AggregatedMaterialDataNode.java
@@ -18,8 +18,6 @@ SPDX-License-Identifier: Apache-2.0
 */
 package org.eclipse.tractusx.puris.backend.aggregateddata.domain.model;
 
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -71,7 +69,7 @@ public class AggregatedMaterialDataNode {
 
     @OneToMany(mappedBy = "parentNode", cascade = CascadeType.ALL)
     @ToString.Exclude
-    protected List<AggregatedMaterialDataNode> childMaterialData = new ArrayList<>();
+    protected List<AggregatedMaterialDataNode> childMaterialData;
 
     @NotNull
     protected double quantity;
@@ -87,18 +85,15 @@ public class AggregatedMaterialDataNode {
     @Pattern(regexp = PatternStore.NON_EMPTY_NON_VERTICAL_WHITESPACE_STRING)
     protected String externalMaterialName;
 
-    @OneToMany(cascade = CascadeType.ALL)
-    @JoinColumn(name = "aggregated_material_data_node_id")
+    @OneToMany(mappedBy = "aggregatedMaterialDataNode", cascade = CascadeType.ALL)
     @Valid
-    protected Set<ReportedAnonymizedProduction> productions = new HashSet<>();
+    protected Set<ReportedAnonymizedProduction> productions;
 
-    @OneToMany(cascade = CascadeType.ALL)
-    @JoinColumn(name = "aggregated_material_data_node_id")
+    @OneToMany(mappedBy = "aggregatedMaterialDataNode", cascade = CascadeType.ALL)
     @Valid
-    protected Set<ReportedAnonymizedDelivery> deliveries = new HashSet<>();
+    protected Set<ReportedAnonymizedDelivery> deliveries;
 
-    @OneToMany(cascade = CascadeType.ALL)
-    @JoinColumn(name = "aggregated_material_data_node_id")
+    @OneToMany(mappedBy = "aggregatedMaterialDataNode", cascade = CascadeType.ALL)
     @Valid
-    protected Set<ReportedAnonymizedStock> stocks = new HashSet<>();
+    protected Set<ReportedAnonymizedStock> stocks;
 }

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/aggregateddata/logic/adapter/AggregatedMaterialDataNodeMapper.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/aggregateddata/logic/adapter/AggregatedMaterialDataNodeMapper.java
@@ -115,11 +115,11 @@ public class AggregatedMaterialDataNodeMapper {
             try {
                 switch (AssetType.fromUrn(aspect)) {
                     case DELIVERY_ANONYMIZED_SUBMODEL -> target.getDeliveries().addAll(
-                        mapDeliveries(objectMapper.treeToValue(payload, DeliveryInformationAnonymized.class)));
+                        mapDeliveries(objectMapper.treeToValue(payload, DeliveryInformationAnonymized.class), target));
                     case ITEM_STOCK_ANONYMIZED_SUBMODEL -> target.getStocks().addAll(
-                        mapStocks(objectMapper.treeToValue(payload, ItemStockAnonymizedSamm.class)));
+                        mapStocks(objectMapper.treeToValue(payload, ItemStockAnonymizedSamm.class), target));
                     case PRODUCTION_ANONYMIZED_SUBMODEL -> target.getProductions().addAll(
-                        mapProductions(objectMapper.treeToValue(payload, PlannedProductionOutputAnonymized.class)));
+                        mapProductions(objectMapper.treeToValue(payload, PlannedProductionOutputAnonymized.class), target));
                     default -> throw new IllegalArgumentException("Unexpected aspect: " + aspect);
                 }
             } catch (JsonProcessingException e) {
@@ -128,7 +128,7 @@ public class AggregatedMaterialDataNodeMapper {
         }
     }
 
-    private Set<ReportedAnonymizedDelivery> mapDeliveries(DeliveryInformationAnonymized samm) {
+    private Set<ReportedAnonymizedDelivery> mapDeliveries(DeliveryInformationAnonymized samm, AggregatedMaterialDataNode target) {
         var deliveries = new HashSet<ReportedAnonymizedDelivery>();
         for (var deliveryAnonymized : samm.getDeliveries()) {
             var departureEvent = deliveryAnonymized.getTransitEvents().stream()
@@ -144,14 +144,15 @@ public class AggregatedMaterialDataNodeMapper {
                 .dateOfDeparture(departureEvent.getDateTimeOfEvent())
                 .departureType(departureEvent.getEventType())
                 .originBpnsAnonymized(deliveryAnonymized.getOriginBpnsAnonymized())
-                .destinationBpnsAnonymized(deliveryAnonymized.getDestinationBpnsAnonymized());
+                .destinationBpnsAnonymized(deliveryAnonymized.getDestinationBpnsAnonymized())
+                .aggregatedMaterialDataNode(target);
             arrivalEvent.ifPresent(event -> builder.dateOfArrival(event.getDateTimeOfEvent()).arrivalType(event.getEventType()));
             deliveries.add(builder.build());
         }
         return deliveries;
     }
 
-    private Set<ReportedAnonymizedStock> mapStocks(ItemStockAnonymizedSamm samm) {
+    private Set<ReportedAnonymizedStock> mapStocks(ItemStockAnonymizedSamm samm, AggregatedMaterialDataNode target) {
         var stocks = new HashSet<ReportedAnonymizedStock>();
         for (var allocatedStock : samm.getAllocatedStocksAnonymized()) {
             stocks.add(ReportedAnonymizedStock.builder()
@@ -160,12 +161,13 @@ public class AggregatedMaterialDataNodeMapper {
                 .stockLocationBpnsAnonymized(allocatedStock.getStockLocationBPNSAnonymized())
                 .isBlocked(allocatedStock.getIsBlocked())
                 .lastUpdatedOnDateTime(allocatedStock.getLastUpdatedOnDateTime())
+                .aggregatedMaterialDataNode(target)
                 .build());
         }
         return stocks;
     }
 
-    private Set<ReportedAnonymizedProduction> mapProductions(PlannedProductionOutputAnonymized samm) {
+    private Set<ReportedAnonymizedProduction> mapProductions(PlannedProductionOutputAnonymized samm, AggregatedMaterialDataNode target) {
         var productions = new HashSet<ReportedAnonymizedProduction>();
         for (var output : samm.getAllocatedPlannedProductionOutputs()) {
             productions.add(ReportedAnonymizedProduction.builder()
@@ -175,6 +177,7 @@ public class AggregatedMaterialDataNodeMapper {
                 .estimatedTimeOfCompletion(output.getEstimatedTimeOfCompletion())
                 .lastUpdatedOnDateTime(output.getLastUpdatedOnDateTime())
                 .materialGlobalAssetIdAnonymized(samm.getMaterialGlobalAssetIdAnonymized())
+                .aggregatedMaterialDataNode(target)
                 .build());
         }
         return productions;

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/delivery/domain/model/ReportedAnonymizedDelivery.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/delivery/domain/model/ReportedAnonymizedDelivery.java
@@ -23,17 +23,22 @@ import java.util.Date;
 import java.util.Objects;
 import java.util.UUID;
 
+import org.eclipse.tractusx.puris.backend.aggregateddata.domain.model.AggregatedMaterialDataNode;
 import org.eclipse.tractusx.puris.backend.common.domain.model.measurement.ItemUnitEnumeration;
 import org.eclipse.tractusx.puris.backend.common.util.PatternStore;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -54,8 +59,11 @@ public class ReportedAnonymizedDelivery {
     @GeneratedValue
     protected UUID uuid;
 
-    @Column(name = "aggregated_material_data_node_id", insertable = false, updatable = false)
-    protected UUID aggregatedMaterialDataNodeId;
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "aggregated_material_data_node_id")
+    @ToString.Exclude
+    @JsonIgnore
+    protected AggregatedMaterialDataNode aggregatedMaterialDataNode;
 
     private double quantity;
     private ItemUnitEnumeration measurementUnit;

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/production/domain/model/ReportedAnonymizedProduction.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/production/domain/model/ReportedAnonymizedProduction.java
@@ -24,15 +24,20 @@ import java.util.Date;
 import java.util.Objects;
 import java.util.UUID;
 
+import org.eclipse.tractusx.puris.backend.aggregateddata.domain.model.AggregatedMaterialDataNode;
 import org.eclipse.tractusx.puris.backend.common.domain.model.measurement.ItemUnitEnumeration;
 import org.eclipse.tractusx.puris.backend.common.util.PatternStore;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -50,8 +55,11 @@ public class ReportedAnonymizedProduction {
     @GeneratedValue
     protected UUID uuid;
 
-    @Column(name = "aggregated_material_data_node_id", insertable = false, updatable = false)
-    protected UUID aggregatedMaterialDataNodeId;
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "aggregated_material_data_node_id")
+    @ToString.Exclude
+    @JsonIgnore
+    protected AggregatedMaterialDataNode aggregatedMaterialDataNode;
 
     protected double quantity;
     protected ItemUnitEnumeration measurementUnit;

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/ReportedAnonymizedStock.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/stock/domain/model/ReportedAnonymizedStock.java
@@ -21,15 +21,20 @@ import java.util.Date;
 import java.util.Objects;
 import java.util.UUID;
 
+import org.eclipse.tractusx.puris.backend.aggregateddata.domain.model.AggregatedMaterialDataNode;
 import org.eclipse.tractusx.puris.backend.common.domain.model.measurement.ItemUnitEnumeration;
 import org.eclipse.tractusx.puris.backend.common.util.PatternStore;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -47,8 +52,11 @@ public class ReportedAnonymizedStock {
     @GeneratedValue
     protected UUID uuid;
 
-    @Column(name = "aggregated_material_data_node_id", insertable = false, updatable = false)
-    protected UUID aggregatedMaterialDataNodeId;
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "aggregated_material_data_node_id")
+    @ToString.Exclude
+    @JsonIgnore
+    protected AggregatedMaterialDataNode aggregatedMaterialDataNode;
     
     protected double quantity;
 

--- a/backend/src/main/resources/db/changelog/changelog-6.x/changelog-6.2.0.yaml
+++ b/backend/src/main/resources/db/changelog/changelog-6.x/changelog-6.2.0.yaml
@@ -896,3 +896,25 @@ databaseChangeLog:
                   name: target_version
                   value: "6.2.0"
             tableName: migration_task
+  - changeSet:
+      id: "14"
+      author: ReneSchroederLJ
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: reported_anonymized_delivery
+            baseColumnNames: aggregated_material_data_node_id
+            referencedTableName: aggregated_material_data_node
+            referencedColumnNames: uuid
+            constraintName: fk_reported_anonymized_delivery_node
+        - addForeignKeyConstraint:
+            baseTableName: reported_anonymized_stock
+            baseColumnNames: aggregated_material_data_node_id
+            referencedTableName: aggregated_material_data_node
+            referencedColumnNames: uuid
+            constraintName: fk_reported_anonymized_stock_node
+        - addForeignKeyConstraint:
+            baseTableName: reported_anonymized_production
+            baseColumnNames: aggregated_material_data_node_id
+            referencedTableName: aggregated_material_data_node
+            referencedColumnNames: uuid
+            constraintName: fk_reported_anonymized_production_node

--- a/docs/api/openAPI.yaml
+++ b/docs/api/openAPI.yaml
@@ -1766,10 +1766,6 @@ components:
     ReportedAnonymizedDelivery:
       additionalProperties: false
       properties:
-        aggregatedMaterialDataNodeId:
-          format: uuid
-          maxItems: 50
-          type: string
         arrivalType:
           enum:
           - estimated-departure
@@ -1860,10 +1856,6 @@ components:
     ReportedAnonymizedProduction:
       additionalProperties: false
       properties:
-        aggregatedMaterialDataNodeId:
-          format: uuid
-          maxItems: 50
-          type: string
         estimatedTimeOfCompletion:
           format: date-time
           maxItems: 50
@@ -1933,10 +1925,6 @@ components:
     ReportedAnonymizedStock:
       additionalProperties: false
       properties:
-        aggregatedMaterialDataNodeId:
-          format: uuid
-          maxItems: 50
-          type: string
         blocked:
           type: boolean
         lastUpdatedOnDateTime:


### PR DESCRIPTION
## Description

- updated `AggregatedMaterialDataNode` and its child models to allow successfully inserting mapped job results

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files ([TRG 7.02](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02))
- [x] Documentation Notice are present on all affected files ([TRG 7.07](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07))
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
- [x] **Changelog** updated (`changelog.md`) with PR reference and brief summary.
- [x] **Frontend** version bumped, if needed (`frontend/package.json`, `frontend/package-lock.json`)
- [x] **Backend** version bumped, if needed (`backend/pom.xml`)
- [x] **Open API** specification updated, if controllers have been changed (use python script `scripts/generate_openapi_yaml.py` with running customer backend)
