### PR TITLE
fix: ignore parent nodes when converting aggregated data to json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The **need for configuration updates** is **marked bold**.
 - Fixed validity dates and renamed allowedBpnls property to allowedBpnlSet for Chain Opening Grants ([#1224](https://github.com/eclipse-tractusx/puris/pull/1224))
 - Renamed "validUntil" to "validTo" in chain opening grants ([#1226](https://github.com/eclipse-tractusx/puris/pull/1226))
 - Updated AggregatedMaterialDataNode and its children to allow for proper mapping of job data ([#1227](https://github.com/eclipse-tractusx/puris/pull/1227))
+- Ignore parent object when converting aggregated data nodes to json ([#1228](https://github.com/eclipse-tractusx/puris/pull/1228))
 
 ### Version Bumps
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/aggregateddata/domain/model/AggregatedMaterialDataNode.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/aggregateddata/domain/model/AggregatedMaterialDataNode.java
@@ -38,6 +38,9 @@ import jakarta.persistence.OneToMany;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -60,11 +63,13 @@ public class AggregatedMaterialDataNode {
     @ManyToOne(optional = false)
     @JoinColumn(name = "aggregated_material_data_id")
     @ToString.Exclude
+    @JsonIgnore
     protected AggregatedMaterialData aggregatedMaterialData;
 
     @ManyToOne
     @JoinColumn(name = "parent_node_id")
     @ToString.Exclude
+    @JsonIgnore
     protected AggregatedMaterialDataNode parentNode;
 
     @OneToMany(mappedBy = "parentNode", cascade = CascadeType.ALL)


### PR DESCRIPTION
## Description

- Fixed a circular dependency causing a stack overflow during JSON conversion

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files ([TRG 7.02](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02))
- [x] Documentation Notice are present on all affected files ([TRG 7.07](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07))
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
- [x] **Changelog** updated (`changelog.md`) with PR reference and brief summary.
- [x] **Frontend** version bumped, if needed (`frontend/package.json`, `frontend/package-lock.json`)
- [x] **Backend** version bumped, if needed (`backend/pom.xml`)
- [x] **Open API** specification updated, if controllers have been changed (use python script `scripts/generate_openapi_yaml.py` with running customer backend)
