### PR TITLE
fix: handle partial IRS job results gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The **need for configuration updates** is **marked bold**.
 - Renamed "validUntil" to "validTo" in chain opening grants ([#1226](https://github.com/eclipse-tractusx/puris/pull/1226))
 - Updated AggregatedMaterialDataNode and its children to allow for proper mapping of job data ([#1227](https://github.com/eclipse-tractusx/puris/pull/1227))
 - Ignore parent object when converting aggregated data nodes to json ([#1228](https://github.com/eclipse-tractusx/puris/pull/1228))
+- Handle partial IRS job failures gracefully ([#1234](https://github.com/eclipse-tractusx/puris/pull/1234))
 
 ### Version Bumps
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/aggregateddata/domain/model/AggregatedMaterialDataNode.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/aggregateddata/domain/model/AggregatedMaterialDataNode.java
@@ -36,7 +36,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -76,17 +75,13 @@ public class AggregatedMaterialDataNode {
     @ToString.Exclude
     protected List<AggregatedMaterialDataNode> childMaterialData;
 
-    @NotNull
-    protected double quantity;
+    protected Double quantity;
 
-    @NotNull
     protected ItemUnitEnumeration measurementUnit;
 
-    @NotNull
     @Pattern(regexp = PatternStore.NON_EMPTY_NON_VERTICAL_WHITESPACE_STRING)
     protected String externalMaterialNumber;
 
-    @NotNull
     @Pattern(regexp = PatternStore.NON_EMPTY_NON_VERTICAL_WHITESPACE_STRING)
     protected String externalMaterialName;
 

--- a/backend/src/main/java/org/eclipse/tractusx/puris/backend/aggregateddata/logic/adapter/AggregatedMaterialDataNodeMapper.java
+++ b/backend/src/main/java/org/eclipse/tractusx/puris/backend/aggregateddata/logic/adapter/AggregatedMaterialDataNodeMapper.java
@@ -48,6 +48,8 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @Slf4j
 public class AggregatedMaterialDataNodeMapper {
+    private static final String CHAIN_OPENING_REJECTED = "CHAIN_OPENING_REJECTED";
+
     @Autowired
     private MaterialService materialService;
 
@@ -72,24 +74,33 @@ public class AggregatedMaterialDataNodeMapper {
             .build();
 
         for (JsonNode childNode : elements(json.path("result").get("childItems"))) {
-            aggregatedData.getChildMaterialData().add(mapNode(childNode, aggregatedData, null));
+            var node = mapNode(childNode, aggregatedData, null);
+            if (node != null) {
+                aggregatedData.getChildMaterialData().add(node);
+            }
         }
 
         return aggregatedData;
     }
 
+    /**
+     * Maps a childItems entry to a node, or returns {@code null} if the branch was rejected
+     * by the partner (tombstone reason {@code CHAIN_OPENING_REJECTED}) and must be fully
+     * dismissed. Any other missing data is mapped as-is; the frontend is responsible for displaying gaps.
+     */
     private AggregatedMaterialDataNode mapNode(JsonNode json, AggregatedMaterialData root, AggregatedMaterialDataNode parent) {
-        var quantity = readQuantity(json);
-        if (quantity == null) {
-            throw new IllegalArgumentException("Missing quantity for node " + getText(json, "materialNumber"));
+        if (isChainOpeningRejected(json)) {
+            log.warn("Skipping node with rejected chain opening grant: {}", json);
+            return null;
         }
+        var quantity = readQuantity(json);
         var node = AggregatedMaterialDataNode.builder()
             .aggregatedMaterialData(root)
             .parentNode(parent)
             .externalMaterialNumber(getText(json, "materialNumber"))
             .externalMaterialName(getText(json, "materialName"))
-            .quantity(quantity.getValue())
-            .measurementUnit(quantity.getUnit())
+            .quantity(quantity != null ? quantity.getValue() : null)
+            .measurementUnit(quantity != null ? quantity.getUnit() : null)
             .productions(new HashSet<>())
             .deliveries(new HashSet<>())
             .stocks(new HashSet<>())
@@ -99,7 +110,10 @@ public class AggregatedMaterialDataNodeMapper {
         mapAspectItems(json.get("items"), node);
 
         for (JsonNode childNode : elements(json.get("childItems"))) {
-            node.getChildMaterialData().add(mapNode(childNode, root, node));
+            var childMaterialNode = mapNode(childNode, root, node);
+            if (childMaterialNode != null) {
+                node.getChildMaterialData().add(childMaterialNode);
+            }
         }
 
         return node;
@@ -181,6 +195,15 @@ public class AggregatedMaterialDataNodeMapper {
                 .build());
         }
         return productions;
+    }
+
+    private static boolean isChainOpeningRejected(JsonNode json) {
+        for (JsonNode tombstone : elements(json.get("tombstones"))) {
+            if (CHAIN_OPENING_REJECTED.equals(getText(tombstone, "reason"))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private ItemQuantityEntity readQuantity(JsonNode json) {

--- a/backend/src/main/resources/db/changelog/changelog-6.x/changelog-6.2.0.yaml
+++ b/backend/src/main/resources/db/changelog/changelog-6.x/changelog-6.2.0.yaml
@@ -930,3 +930,23 @@ databaseChangeLog:
             referencedTableName: aggregated_material_data_node
             referencedColumnNames: uuid
             constraintName: fk_reported_anonymized_production_node
+  - changeSet:
+      id: "16"
+      author: ReneSchroederLJ
+      changes:
+        - dropNotNullConstraint:
+            tableName: aggregated_material_data_node
+            columnName: external_material_number
+            columnDataType: VARCHAR(255)
+        - dropNotNullConstraint:
+            tableName: aggregated_material_data_node
+            columnName: external_material_name
+            columnDataType: VARCHAR(255)
+        - dropNotNullConstraint:
+            tableName: aggregated_material_data_node
+            columnName: quantity
+            columnDataType: FLOAT8
+        - dropNotNullConstraint:
+            tableName: aggregated_material_data_node
+            columnName: measurement_unit
+            columnDataType: SMALLINT

--- a/backend/src/test/java/org/eclipse/tractusx/puris/backend/aggregateddata/logic/adapter/AggregatedMaterialDataNodeMapperTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/puris/backend/aggregateddata/logic/adapter/AggregatedMaterialDataNodeMapperTest.java
@@ -329,6 +329,85 @@ public class AggregatedMaterialDataNodeMapperTest {
     }
 
     @Test
+    void jsonToAggregatedMaterialData_timeoutTombstoneChildItem_isMappedWithMissingMaterialInfo() throws Exception {
+        JsonNode json = objectMapper.readTree("""
+            {
+              "job": { "globalAssetId": "%s" },
+              "result": {
+                "childItems": [
+                  {
+                    "materialNumber": "PARTNER-MNR",
+                    "materialName": "Central Control Unit",
+                    "quantity": { "value": 1.0, "unit": "unit:piece" },
+                    "items": [],
+                    "childItems": [
+                      {
+                        "materialNumber": null,
+                        "materialName": null,
+                        "quantity": null,
+                        "items": [],
+                        "tombstones": [ { "type": "RECURSIVE_TOMBSTONE", "reason": "CHILD_RESPONSE_TIMEOUT" } ],
+                        "childItems": []
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+            """.formatted(GLOBAL_ASSET_ID));
+        when(materialService.findByMaterialNumberCx(GLOBAL_ASSET_ID)).thenReturn(MATERIAL);
+
+        AggregatedMaterialData result = mapper.jsonToAggregatedMaterialData(json);
+
+        assertNotNull(result);
+        assertEquals(1, result.getChildMaterialData().size());
+        var rootNode = result.getChildMaterialData().get(0);
+        assertEquals("PARTNER-MNR", rootNode.getExternalMaterialNumber());
+        assertEquals(1, rootNode.getChildMaterialData().size());
+        var timedOutChild = rootNode.getChildMaterialData().get(0);
+        assertNull(timedOutChild.getExternalMaterialNumber());
+        assertNull(timedOutChild.getExternalMaterialName());
+        assertNull(timedOutChild.getQuantity());
+        assertNull(timedOutChild.getMeasurementUnit());
+    }
+
+    @Test
+    void jsonToAggregatedMaterialData_chainOpeningRejectedTombstone_isSkipped() throws Exception {
+        JsonNode json = objectMapper.readTree("""
+            {
+              "job": { "globalAssetId": "%s" },
+              "result": {
+                "childItems": [
+                  {
+                    "materialNumber": "PARTNER-MNR",
+                    "materialName": "Central Control Unit",
+                    "quantity": { "value": 1.0, "unit": "unit:piece" },
+                    "items": [],
+                    "childItems": []
+                  },
+                  {
+                    "materialNumber": null,
+                    "materialName": null,
+                    "quantity": { "value": 1.0, "unit": "unit:piece" },
+                    "items": [],
+                    "tombstones": [ { "type": "RECURSIVE_TOMBSTONE", "reason": "CHAIN_OPENING_REJECTED" } ],
+                    "childItems": []
+                  }
+                ]
+              }
+            }
+            """.formatted(GLOBAL_ASSET_ID));
+        when(materialService.findByMaterialNumberCx(GLOBAL_ASSET_ID)).thenReturn(MATERIAL);
+
+        AggregatedMaterialData result = mapper.jsonToAggregatedMaterialData(json);
+
+        assertNotNull(result);
+        assertEquals(1, result.getChildMaterialData().size());
+        var rootNode = result.getChildMaterialData().get(0);
+        assertEquals("PARTNER-MNR", rootNode.getExternalMaterialNumber());
+    }
+
+    @Test
     void jsonToAggregatedMaterialData_missingChildItems_returnsEmptyChildren() throws Exception {
         JsonNode json = objectMapper.readTree("""
             {


### PR DESCRIPTION
## Description

- improve handling of IRS job results
  - partial failures no longer result in exceptions
  - child data is skipped if the grant was rejected
  - partial child data from other errors is saved and should be handled by the frontend

resolves #1230 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files ([TRG 7.02](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02))
- [x] Documentation Notice are present on all affected files ([TRG 7.07](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07))
- [x] If helm chart has been changed, the chart version has been bumped to either next major, minor or patch level (compared to released chart).
- [x] **Changelog** updated (`changelog.md`) with PR reference and brief summary.
- [x] **Frontend** version bumped, if needed (`frontend/package.json`, `frontend/package-lock.json`)
- [x] **Backend** version bumped, if needed (`backend/pom.xml`)
- [x] **Open API** specification updated, if controllers have been changed (use python script `scripts/generate_openapi_yaml.py` with running customer backend)
